### PR TITLE
Add schema-validated frontmatter for batch-safe artifacts

### DIFF
--- a/.ambient/ambient.json
+++ b/.ambient/ambient.json
@@ -1,15 +1,14 @@
 {
   "name": "RFE Creator",
   "description": "Create, review, and submit RFEs to RHAIRFE. Refine approved RFEs into strategies in RHAISTRAT.",
-  "systemPrompt": "You are an RFE and strategy creation assistant. Help users create well-formed RFEs (WHAT/WHY) and refine approved RFEs into strategies (HOW).\n\nUse the available skills:\n- /rfe.create — Create RFEs from a problem statement\n- /rfe.review — Validate RFEs (rubric + technical feasibility)\n- /rfe.submit — Submit to Jira as RHAIRFEs\n- /rfe.speedrun — Run the full RFE pipeline\n- /strat.create — Clone approved RFEs to RHAISTRAT\n- /strat.refine — Feature refinement (HOW, dependencies, components)\n- /strat.review — Adversarial review of strategies\n- /strat.prioritize — [Not yet implemented]\n\nAll artifacts are written to the artifacts/ directory.",
+  "systemPrompt": "You are an RFE and strategy creation assistant. Help users create well-formed RFEs (WHAT/WHY) and refine approved RFEs into strategies (HOW).\n\nUse the available skills:\n- /rfe.create — Create RFEs from a problem statement\n- /rfe.review — Validate RFEs (rubric + technical feasibility)\n- /rfe.submit — Submit to Jira as RHAIRFEs\n- /rfe.speedrun — Run the full RFE pipeline\n- /strat.create — Clone approved RFEs to RHAISTRAT\n- /strat.refine — Feature refinement (HOW, dependencies, components)\n- /strat.review — Adversarial review of strategies\n- /strat.prioritize — [Not yet implemented]\n\nAll artifacts are written to the artifacts/ directory. Structured metadata is stored in YAML frontmatter — use scripts/frontmatter.py to read and write it.",
   "startupPrompt": "Greet the user and introduce yourself as their RFE & Strategy assistant. List the available skills. Inform them to run /rfe.create to start, or /rfe.speedrun for the full pipeline with minimal interaction.",
   "greeting": "Welcome to RFE Creator! I help you turn ideas into well-formed RFEs and refine them into implementation-ready strategies.\n\nRFE Pipeline:\n• /rfe.create — Create RFEs from a problem statement\n• /rfe.review — Validate (rubric + technical feasibility)\n• /rfe.submit — Submit to Jira as RHAIRFEs\n• /rfe.speedrun — Full pipeline, minimal interaction\n\nStrategy Pipeline (after RFE approval):\n• /strat.create — Clone approved RFEs to RHAISTRAT\n• /strat.refine — Add the HOW (dependencies, components, NFRs)\n• /strat.review — Adversarial review (4 independent reviewers)\n\nType /rfe.create to get started.",
   "results": {
-    "RFE List": "artifacts/rfes.md",
+    "RFE Index": "artifacts/rfes.md",
     "RFE Tasks": "artifacts/rfe-tasks/*.md",
-    "RFE Review Report": "artifacts/rfe-review-report.md",
-    "Jira Tickets": "artifacts/jira-tickets.md",
+    "RFE Reviews": "artifacts/rfe-reviews/*.md",
     "Strategy Tasks": "artifacts/strat-tasks/*.md",
-    "Strategy Review Report": "artifacts/strat-review-report.md"
+    "Strategy Reviews": "artifacts/strat-reviews/*.md"
   }
 }

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -13,7 +13,7 @@ You are a platform architect reviewing refined strategy features. Your job is to
 
 Read the strategy artifacts in `artifacts/strat-tasks/`. Cross-reference against the source RFEs in `artifacts/rfe-tasks/`.
 
-If `artifacts/strat-review-report.md` exists, read it — this is a re-review.
+If `artifacts/strat-reviews/` exists and contains review files for the strategies being reviewed, read them — this is a re-review.
 
 ## Architecture Context
 

--- a/.claude/skills/feasibility-review/SKILL.md
+++ b/.claude/skills/feasibility-review/SKILL.md
@@ -13,7 +13,7 @@ You are a staff engineer reviewing refined strategy features. Your job is to fin
 
 Read the strategy artifacts in `artifacts/strat-tasks/`. Cross-reference against the source RFEs in `artifacts/rfe-tasks/` to verify the strategy actually delivers the stated business need.
 
-If `artifacts/strat-review-report.md` exists, read it — this is a re-review.
+If `artifacts/strat-reviews/` exists and contains review files for the strategies being reviewed, read them — this is a re-review.
 
 ## Architecture Context
 

--- a/.claude/skills/rfe.create/SKILL.md
+++ b/.claude/skills/rfe.create/SKILL.md
@@ -52,15 +52,19 @@ Key rules:
 
 ## Step 4: Write Artifacts
 
-For each RFE, first write the markdown body to `artifacts/rfe-tasks/RFE-NNN-<slug>.md`, then set frontmatter using the CLI tool:
+For each RFE, first write the markdown body to `artifacts/rfe-tasks/RFE-NNN-<slug>.md`, then set frontmatter using the CLI tool.
+
+First, read the schema to know exact field names and allowed values:
 
 ```bash
-# Get the schema to know exact field names and allowed values
 python3 scripts/frontmatter.py schema rfe-task
+```
 
-# Set frontmatter on each RFE file
-python3 scripts/frontmatter.py set artifacts/rfe-tasks/RFE-001-<slug>.md \
-    rfe_id=RFE-001 \
+Then set frontmatter on each RFE file, using the actual values for this RFE:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/rfe-tasks/<filename>.md \
+    rfe_id=<rfe_id> \
     title="<title>" \
     priority=<priority> \
     size=<size> \

--- a/.claude/skills/rfe.create/SKILL.md
+++ b/.claude/skills/rfe.create/SKILL.md
@@ -52,11 +52,28 @@ Key rules:
 
 ## Step 4: Write Artifacts
 
-Write the following files:
-- `artifacts/rfes.md` — Summary table of all RFEs (number, title, priority, size, one-line summary)
-- `artifacts/rfe-tasks/RFE-001-<slug>.md` — Individual RFE file for each RFE
+For each RFE, first write the markdown body to `artifacts/rfe-tasks/RFE-NNN-<slug>.md`, then set frontmatter using the CLI tool:
 
-Create the `artifacts/` and `artifacts/rfe-tasks/` directories if they don't exist.
+```bash
+# Get the schema to know exact field names and allowed values
+python3 scripts/frontmatter.py schema rfe-task
+
+# Set frontmatter on each RFE file
+python3 scripts/frontmatter.py set artifacts/rfe-tasks/RFE-001-<slug>.md \
+    rfe_id=RFE-001 \
+    title="<title>" \
+    priority=<priority> \
+    size=<size> \
+    status=Draft
+```
+
+After all RFE files are written, rebuild the index:
+
+```bash
+python3 scripts/frontmatter.py rebuild-index
+```
+
+Create the `artifacts/`, `artifacts/rfe-tasks/`, and `artifacts/rfe-reviews/` directories if they don't exist.
 
 Tell the PM they can:
 - Edit any artifact file directly before proceeding

--- a/.claude/skills/rfe.create/rfe-template.md
+++ b/.claude/skills/rfe.create/rfe-template.md
@@ -16,9 +16,6 @@ Scale the output to match the size of the RFE. Use the appropriate section set b
 ```markdown
 # RFE-NNN: <Title>
 
-**Priority**: <Blocker|Critical|Major|Normal|Minor>
-**Size**: S
-
 ## Summary
 <2-3 sentences: what the user needs and why>
 
@@ -39,9 +36,6 @@ Scale the output to match the size of the RFE. Use the appropriate section set b
 
 ```markdown
 # RFE-NNN: <Title>
-
-**Priority**: <Blocker|Critical|Major|Normal|Minor>
-**Size**: M
 
 ## Summary
 <What the user needs and why, in enough detail to be unambiguous>
@@ -70,9 +64,6 @@ Scale the output to match the size of the RFE. Use the appropriate section set b
 
 ```markdown
 # RFE-NNN: <Title>
-
-**Priority**: <Blocker|Critical|Major|Normal|Minor>
-**Size**: <L|XL>
 
 ## Summary
 <Comprehensive description of the business need>

--- a/.claude/skills/rfe.create/rfe-template.md
+++ b/.claude/skills/rfe.create/rfe-template.md
@@ -14,8 +14,6 @@ Scale the output to match the size of the RFE. Use the appropriate section set b
 ## Concise Format (S)
 
 ```markdown
-# RFE-NNN: <Title>
-
 ## Summary
 <2-3 sentences: what the user needs and why>
 
@@ -35,8 +33,6 @@ Scale the output to match the size of the RFE. Use the appropriate section set b
 ## Standard Format (M)
 
 ```markdown
-# RFE-NNN: <Title>
-
 ## Summary
 <What the user needs and why, in enough detail to be unambiguous>
 
@@ -63,8 +59,6 @@ Scale the output to match the size of the RFE. Use the appropriate section set b
 ## Full Format (L/XL)
 
 ```markdown
-# RFE-NNN: <Title>
-
 ## Summary
 <Comprehensive description of the business need>
 

--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -40,7 +40,7 @@ python3 scripts/frontmatter.py set artifacts/rfe-tasks/<jira_key>.md \
     status=Ready
 ```
 
-**Save an original snapshot** by copying the file (after frontmatter is set) to `artifacts/rfe-originals/<jira_key>.md`. This snapshot captures the RFE as it existed in Jira before any local review or revision. It serves two purposes: (1) before/after data analysis of what remediation changed, and (2) optimistic conflict detection at submit time. Create the `artifacts/rfe-originals/` directory if it doesn't exist. This file is never modified by review or revision — it is only overwritten by a fresh Jira fetch.
+**Save an original snapshot** of the raw Jira description to `artifacts/rfe-originals/<jira_key>.md`. Write the `fields.description` value as-is (the raw markdown from Jira, not the templated version). This snapshot is used for (1) before/after data analysis of what remediation changed, and (2) optimistic conflict detection at submit time — the submit skill re-fetches the description from Jira and compares it against this file to detect concurrent modifications. Create the `artifacts/rfe-originals/` directory if it doesn't exist. This file is never modified by review or revision — it is only overwritten by a fresh Jira fetch.
 
 **Also write a separate comments file** to `artifacts/rfe-tasks/<jira_key>-comments.md` with the Jira comment history. Format each comment as:
 

--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -19,19 +19,24 @@ python3 scripts/fetch_issue.py RHAIRFE-1234 --fields summary,description,priorit
 
 The script outputs JSON to stdout with description and comment bodies already converted to markdown. Parse `fields.description`, `fields.summary`, `fields.priority.name`, and `comments` array.
 
-Write the RFE to `artifacts/rfe-tasks/RHAIRFE-1234.md` (using the Jira key as the filename) using the RFE template format (read `${CLAUDE_SKILL_DIR}/../rfe.create/rfe-template.md` for the format). Then set frontmatter:
+Write the RFE to `artifacts/rfe-tasks/<jira_key>.md` (using the Jira key as the filename) using the RFE template format (read `${CLAUDE_SKILL_DIR}/../rfe.create/rfe-template.md` for the format).
+
+First, read the schema to know exact field names and allowed values:
 
 ```bash
 python3 scripts/frontmatter.py schema rfe-task
-python3 scripts/frontmatter.py set artifacts/rfe-tasks/RHAIRFE-1234.md \
-    rfe_id=RHAIRFE-1234 \
+```
+
+Then set frontmatter, using the Jira key as the `rfe_id`:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/rfe-tasks/<jira_key>.md \
+    rfe_id=<jira_key> \
     title="<title from Jira>" \
-    priority=<priority> \
+    priority=<priority from Jira> \
     size=<inferred size> \
     status=Ready
 ```
-
-Use the Jira key as the `rfe_id` for issues fetched from Jira.
 
 **Also write a separate comments file** to `artifacts/rfe-tasks/RHAIRFE-1234-comments.md` with the Jira comment history. Format each comment as:
 
@@ -105,31 +110,31 @@ Invoke the `rfe-feasibility-review` skill on the RFE artifacts. This runs in a f
 
 ## Step 3: Write Per-Issue Review Files
 
-For each reviewed RFE, write a review file to `artifacts/rfe-reviews/`. First get the schema:
+For each reviewed RFE, write a review file to `artifacts/rfe-reviews/`. First, read the schema to know exact field names and allowed values:
 
 ```bash
 python3 scripts/frontmatter.py schema rfe-review
 ```
 
-Then for each RFE, write the review body (assessor feedback, feasibility details, strategy considerations, revision history) to `artifacts/rfe-reviews/{id}-review.md`, then set frontmatter:
+Then for each RFE, write the review body (assessor feedback, feasibility details, strategy considerations, revision history) to `artifacts/rfe-reviews/{id}-review.md`, then set frontmatter using the actual review results:
 
 ```bash
-python3 scripts/frontmatter.py set artifacts/rfe-reviews/RHAIRFE-1234-review.md \
-    rfe_id=RHAIRFE-1234 \
-    score=9 \
-    pass=true \
-    recommendation=submit \
-    feasibility=feasible \
-    revised=false \
-    needs_attention=false \
-    scores.what=2 \
-    scores.why=1 \
-    scores.open_to_how=2 \
-    scores.not_a_task=2 \
-    scores.right_sized=2
+python3 scripts/frontmatter.py set artifacts/rfe-reviews/<id>-review.md \
+    rfe_id=<rfe_id> \
+    score=<total_score> \
+    pass=<true_or_false> \
+    recommendation=<recommendation> \
+    feasibility=<feasibility> \
+    revised=<true_or_false> \
+    needs_attention=<true_or_false> \
+    scores.what=<what_score> \
+    scores.why=<why_score> \
+    scores.open_to_how=<open_to_how_score> \
+    scores.not_a_task=<not_a_task_score> \
+    scores.right_sized=<right_sized_score>
 ```
 
-For local RFEs (no Jira key), use the RFE-NNN-based filename: `artifacts/rfe-reviews/RFE-001-slug-review.md`.
+Use the RFE's `rfe_id` for the filename prefix (e.g., `RHAIRFE-1234-review.md` for Jira-fetched RFEs, `RFE-001-slug-review.md` for local RFEs).
 
 The review file body should contain:
 

--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -11,7 +11,9 @@ You are an RFE review orchestrator. Your job is to review RFEs for quality and t
 
 Check if `$ARGUMENTS` contains a Jira key (e.g., `RHAIRFE-1234`).
 
-**If a Jira key is provided**: Fetch the RFE from Jira. Try `mcp__atlassian__getJiraIssue` first. If the MCP tool is unavailable, fall back to the REST API script:
+**If a Jira key is provided**: First check if `artifacts/rfe-tasks/<jira_key>.md` already exists locally. If it does, use the local copy — do not re-fetch from Jira. This preserves any local edits from prior review cycles.
+
+**If the local file does not exist**, fetch the RFE from Jira. Try `mcp__atlassian__getJiraIssue` first. If the MCP tool is unavailable, fall back to the REST API script:
 
 ```bash
 python3 scripts/fetch_issue.py RHAIRFE-1234 --fields summary,description,priority,labels,status,comment --markdown
@@ -38,7 +40,9 @@ python3 scripts/frontmatter.py set artifacts/rfe-tasks/<jira_key>.md \
     status=Ready
 ```
 
-**Also write a separate comments file** to `artifacts/rfe-tasks/RHAIRFE-1234-comments.md` with the Jira comment history. Format each comment as:
+**Save an original snapshot** by copying the file (after frontmatter is set) to `artifacts/rfe-originals/<jira_key>.md`. This snapshot captures the RFE as it existed in Jira before any local review or revision. It serves two purposes: (1) before/after data analysis of what remediation changed, and (2) optimistic conflict detection at submit time. Create the `artifacts/rfe-originals/` directory if it doesn't exist. This file is never modified by review or revision — it is only overwritten by a fresh Jira fetch.
+
+**Also write a separate comments file** to `artifacts/rfe-tasks/<jira_key>-comments.md` with the Jira comment history. Format each comment as:
 
 ```markdown
 # Comments: RHAIRFE-1234

--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -164,7 +164,7 @@ python3 scripts/frontmatter.py rebuild-index
 
 ## Step 4: Auto-Revise
 
-Always attempt at least one auto-revision cycle when any criterion scores below full marks. Improve what you can with available information. If a revision requires information you don't have (e.g., named customer accounts), make the best improvement possible and note the gap in Revision Notes for the user. Only skip auto-revision entirely if the RFE is technically infeasible or the problem statement needs to be rethought from scratch.
+Always attempt at least one auto-revision cycle when any criterion scores below full marks. Improve what you can with available information. If a revision requires information you don't have (e.g., named customer accounts), make the best improvement possible and note the gap in the review file's Revision History for the user. Only skip auto-revision entirely if the RFE is technically infeasible or the problem statement needs to be rethought from scratch.
 
 ### Revision Principles
 
@@ -184,7 +184,7 @@ This file must NOT be merged back into the RFE description.
 
 **Right-sizing is a recommendation, never auto-applied.** If the rubric scores Right-sized at 0 or 1, report the recommendation to split in the review file. Do NOT remove acceptance criteria, scope items, or capabilities from the artifact to force a different shape. Splitting an RFE is a structural decision that changes what the RFE *is* — only the author can make that call.
 
-**Do not invent missing evidence.** If the rubric flags weak business justification due to missing named customers or revenue data, flag the gap in Revision Notes for the author to fill. Do not fabricate evidence.
+**Do not invent missing evidence.** If the rubric flags weak business justification due to missing named customers or revenue data, flag the gap in the review file's Revision History for the author to fill. Do not fabricate evidence.
 
 ### Revision Steps
 
@@ -195,7 +195,7 @@ This file must NOT be merged back into the RFE description.
    - **WHY**: Strengthen with available evidence (stakeholder comments, strategic alignment references); flag gaps the author must fill (named customers, revenue data)
    - **Right-sized**: Report the recommendation only; do not split or remove scope. Advise the user to run `/rfe.split` if splitting is needed
    - **WHAT / Not a task**: Follow assessor guidance if provided
-4. Add a `### Revision Notes` section at the end of each RFE **only if its content was actually changed** (sections rewritten, reframed, or removed). The Revision Notes should document what changed and why. Do NOT add Revision Notes to artifacts where no content was modified — gaps that require author input (e.g., missing named customers) belong only in the review file, not in the artifact.
+4. Document what changed and why in the review file's `## Revision History` section. Do NOT add revision notes to the RFE artifact itself — keep RFE files clean with only frontmatter and business content. Gaps that require author input (e.g., missing named customers) also belong in the review file, not in the artifact.
 5. Update the review file frontmatter: set `revised=true` if content was modified, set `needs_attention=true` if human review is still needed
 6. Re-run the review (go back to Step 2) on the revised artifacts
 

--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -19,12 +19,24 @@ python3 scripts/fetch_issue.py RHAIRFE-1234 --fields summary,description,priorit
 
 The script outputs JSON to stdout with description and comment bodies already converted to markdown. Parse `fields.description`, `fields.summary`, `fields.priority.name`, and `comments` array.
 
-Write the RFE to `artifacts/rfe-tasks/` as a local artifact using the RFE template format (read `${CLAUDE_SKILL_DIR}/../rfe.create/rfe-template.md` for the format). Update `artifacts/rfes.md` with the RFE summary. Record the Jira key in the artifact metadata so `/rfe.submit` knows to update rather than create.
+Write the RFE to `artifacts/rfe-tasks/RHAIRFE-1234.md` (using the Jira key as the filename) using the RFE template format (read `${CLAUDE_SKILL_DIR}/../rfe.create/rfe-template.md` for the format). Then set frontmatter:
 
-**Also write a separate comments file** to `artifacts/rfe-tasks/RFE-NNN-comments.md` with the Jira comment history. Format each comment as:
+```bash
+python3 scripts/frontmatter.py schema rfe-task
+python3 scripts/frontmatter.py set artifacts/rfe-tasks/RHAIRFE-1234.md \
+    rfe_id=RHAIRFE-1234 \
+    title="<title from Jira>" \
+    priority=<priority> \
+    size=<inferred size> \
+    status=Ready
+```
+
+Use the Jira key as the `rfe_id` for issues fetched from Jira.
+
+**Also write a separate comments file** to `artifacts/rfe-tasks/RHAIRFE-1234-comments.md` with the Jira comment history. Format each comment as:
 
 ```markdown
-# Comments: RHAIRFE-NNNN
+# Comments: RHAIRFE-1234
 
 ## <Author Name> — <date>
 <comment body>
@@ -39,9 +51,9 @@ This file provides stakeholder context to the review forks. It is NOT part of th
 
 ## Step 1: Verify Artifacts Exist
 
-Read `artifacts/rfes.md` and list files in `artifacts/rfe-tasks/`. If no RFE artifacts exist and no Jira key was provided, tell the user to run `/rfe.create` first or provide a Jira key (e.g., `/rfe.review RHAIRFE-1234`) and stop.
+List files in `artifacts/rfe-tasks/`. If no RFE artifacts exist and no Jira key was provided, tell the user to run `/rfe.create` first or provide a Jira key (e.g., `/rfe.review RHAIRFE-1234`) and stop.
 
-Check if a prior review report exists at `artifacts/rfe-review-report.md`. If it does, read it — this is a re-review after revisions.
+Check if prior reviews exist in `artifacts/rfe-reviews/`. If any exist for the RFEs being reviewed, read them — this is a re-review after revisions.
 
 ## Step 1.5: Fetch Architecture Context
 
@@ -51,7 +63,7 @@ bash scripts/fetch-architecture-context.sh
 
 The architecture context path for the feasibility fork is `.context/architecture-context/architecture/$LATEST`.
 
-If the fetch fails (network issue, repo unavailable, API rate limit), proceed without architecture context. Note it in the review report.
+If the fetch fails (network issue, repo unavailable, API rate limit), proceed without architecture context. Note it in the review output.
 
 ## Step 2: Run Reviews
 
@@ -76,7 +88,7 @@ When any assess-rfe skill resolves its `{PLUGIN_ROOT}`, it should use the absolu
 
 **If the bootstrap succeeded**: Invoke `/assess-rfe` to score each RFE against the rubric. The plugin owns the scoring logic, criteria, and calibration. Do not reimplement or second-guess its scores.
 
-**If the bootstrap failed** (network issue, git unavailable): Skip rubric validation. Note in the review report that rubric validation was skipped because assess-rfe could not be fetched. Perform a basic quality check instead:
+**If the bootstrap failed** (network issue, git unavailable): Skip rubric validation. Note in the review that rubric validation was skipped because assess-rfe could not be fetched. Perform a basic quality check instead:
 - Does each RFE describe a business need (WHAT/WHY), not a task or technical activity?
 - Does each RFE avoid prescribing architecture, technology, or implementation?
 - Does each RFE name specific affected customers?
@@ -85,51 +97,60 @@ When any assess-rfe skill resolves its `{PLUGIN_ROOT}`, it should use the absolu
 
 ### Stakeholder Context
 
-Both review forks should read any `artifacts/rfe-tasks/RFE-NNN-comments.md` files that exist. Comments from stakeholders provide context about what is intentional in the RFE, what has already been discussed, and what related work exists. This context should inform the review — e.g., if a stakeholder has already confirmed a technology choice is deliberate, the rubric should not penalize it.
+Both review forks should read any `artifacts/rfe-tasks/*-comments.md` files that exist for the RFEs being reviewed. Comments from stakeholders provide context about what is intentional in the RFE, what has already been discussed, and what related work exists. This context should inform the review — e.g., if a stakeholder has already confirmed a technology choice is deliberate, the rubric should not penalize it.
 
 ### Review 2: Technical Feasibility (Forked)
 
 Invoke the `rfe-feasibility-review` skill on the RFE artifacts. This runs in a forked context with architecture context (if available) to assess whether each RFE is technically feasible without the business context influencing the assessment. If comments files exist in `artifacts/rfe-tasks/`, include them in the feasibility reviewer's context.
 
-## Step 3: Combine Results
+## Step 3: Write Per-Issue Review Files
 
-Write `artifacts/rfe-review-report.md` with the following structure:
+For each reviewed RFE, write a review file to `artifacts/rfe-reviews/`. First get the schema:
+
+```bash
+python3 scripts/frontmatter.py schema rfe-review
+```
+
+Then for each RFE, write the review body (assessor feedback, feasibility details, strategy considerations, revision history) to `artifacts/rfe-reviews/{id}-review.md`, then set frontmatter:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/rfe-reviews/RHAIRFE-1234-review.md \
+    rfe_id=RHAIRFE-1234 \
+    score=9 \
+    pass=true \
+    recommendation=submit \
+    feasibility=feasible \
+    revised=false \
+    needs_attention=false \
+    scores.what=2 \
+    scores.why=1 \
+    scores.open_to_how=2 \
+    scores.not_a_task=2 \
+    scores.right_sized=2
+```
+
+For local RFEs (no Jira key), use the RFE-NNN-based filename: `artifacts/rfe-reviews/RFE-001-slug-review.md`.
+
+The review file body should contain:
 
 ```markdown
-# RFE Review Report
+## Assessor Feedback
+<Full rubric feedback verbatim — scores, notes, verdict, and actionable suggestions.>
 
-**Date**: <date>
-**RFEs reviewed**: <count>
-**Rubric validation**: <pass/fail/skipped>
-**Technical feasibility**: <pass/conditional/fail>
+## Technical Feasibility
+<feasible / infeasible — with details>
 
-## Summary
-<Overall assessment: are these RFEs ready for submission?>
-
-## Per-RFE Results
-
-### RFE-001: <title>
-
-**Rubric score**: <score>/10 <PASS/FAIL> (or "skipped — plugin not installed")
-<Include the FULL rubric feedback verbatim — scores, notes, verdict, and actionable suggestions. Do not summarize or paraphrase the assessor's output. The assessor's specific recommendations (e.g., "remove the Technical Approach section") are instructions for the revision step and must not be lost in summarization.>
-
-**Technical feasibility**: <feasible / infeasible / needs RFE revision>
-**Strategy considerations**: <none / list of items flagged for /strat.refine>
-
-**Recommendation**: <submit / revise / split / reject>
-<Specific actionable suggestions if revision needed>
-
-### RFE-002: <title>
-...
-
-## Changes vs. Original
-<For Jira-sourced RFEs only: summarize what was modified compared to the original Jira description. List sections added, removed, or edited so the user can see what will change if they submit.>
+## Strategy Considerations
+<Items flagged for /strat.refine, or "none">
 
 ## Revision History
-<If this is a re-review, note what changed since the prior review:>
-- What concerns from the prior review were addressed
-- What concerns remain
-- What new issues the revisions introduced
+<What changed across auto-revision cycles, or "none">
+```
+
+After writing all review files, rebuild the index:
+
+```bash
+python3 scripts/frontmatter.py rebuild-index
 ```
 
 ## Step 4: Auto-Revise
@@ -142,7 +163,7 @@ Always attempt at least one auto-revision cycle when any criterion scores below 
 
 **Reframe, don't remove.** When the assessor flags sections for HOW violations, the problem may not be the information — it's the framing. Prescriptive architecture and implementation directives can almost always be reframed into non-prescriptive context that preserves useful information while fixing the rubric score. For example, a section that assigns components to architectural roles can be reframed as a flat context list with a disclaimer that engineering should determine the design. Only remove content as a last resort when there is nothing reframeable (pure implementation detail with no business-facing content).
 
-**If content must be removed**, preserve it for Jira-sourced RFEs by writing it to `artifacts/rfe-tasks/RFE-NNN-removed-context.md` so `/rfe.submit` can post it as a comment, prefixed with:
+**If content must be removed**, preserve it for Jira-sourced RFEs by writing it to `artifacts/rfe-tasks/{id}-removed-context.md` (using the same id prefix as the main file — Jira key or RFE-NNN-slug) so `/rfe.submit` can post it as a comment, prefixed with:
 
 ```
 *[RFE Creator]* The following technical implementation details were removed from the RFE description during review. This content is better suited for a RHAISTRAT and is preserved here for reference:
@@ -152,25 +173,26 @@ This file must NOT be merged back into the RFE description.
 
 **When a section mixes WHAT and HOW and the assessor did not flag it**, leave it alone. Do not proactively scan for additional HOW content beyond what the assessor identified.
 
-**Right-sizing is a recommendation, never auto-applied.** If the rubric scores Right-sized at 0 or 1, report the recommendation to split in the review report. Do NOT remove acceptance criteria, scope items, or capabilities from the artifact to force a different shape. Splitting an RFE is a structural decision that changes what the RFE *is* — only the author can make that call.
+**Right-sizing is a recommendation, never auto-applied.** If the rubric scores Right-sized at 0 or 1, report the recommendation to split in the review file. Do NOT remove acceptance criteria, scope items, or capabilities from the artifact to force a different shape. Splitting an RFE is a structural decision that changes what the RFE *is* — only the author can make that call.
 
 **Do not invent missing evidence.** If the rubric flags weak business justification due to missing named customers or revenue data, flag the gap in Revision Notes for the author to fill. Do not fabricate evidence.
 
 ### Revision Steps
 
-1. Read the **full** review feedback for each failing RFE (the verbatim assessor output in the review report)
-2. Read the comments file (`artifacts/rfe-tasks/RFE-NNN-comments.md`) if it exists — stakeholder comments may explain why certain content is intentional
+1. Read the **full** review feedback for each failing RFE (from the review file just written)
+2. Read the comments file (`artifacts/rfe-tasks/{id}-comments.md`) if it exists — stakeholder comments may explain why certain content is intentional
 3. For each criterion the assessor flagged, follow its specific recommendations:
-   - **Open to HOW**: Reframe flagged sections to remove prescriptive framing while preserving useful context. If content cannot be reframed, remove it and write it to `artifacts/rfe-tasks/RFE-NNN-removed-context.md` for preservation as a Jira comment during `/rfe.submit`
+   - **Open to HOW**: Reframe flagged sections to remove prescriptive framing while preserving useful context. If content cannot be reframed, remove it and write it to `artifacts/rfe-tasks/{id}-removed-context.md` for preservation as a Jira comment during `/rfe.submit`
    - **WHY**: Strengthen with available evidence (stakeholder comments, strategic alignment references); flag gaps the author must fill (named customers, revenue data)
    - **Right-sized**: Report the recommendation only; do not split or remove scope. Advise the user to run `/rfe.split` if splitting is needed
    - **WHAT / Not a task**: Follow assessor guidance if provided
-4. Add a `### Revision Notes` section at the end of each RFE **only if its content was actually changed** (sections rewritten, reframed, or removed). The Revision Notes should document what changed and why. Do NOT add Revision Notes to artifacts where no content was modified — gaps that require author input (e.g., missing named customers) belong only in the review report, not in the artifact. This distinction matters because the submit script uses the presence of Revision Notes to apply the `rfe-creator-auto-revised` label.
-5. Re-run the review (go back to Step 2) on the revised artifacts
+4. Add a `### Revision Notes` section at the end of each RFE **only if its content was actually changed** (sections rewritten, reframed, or removed). The Revision Notes should document what changed and why. Do NOT add Revision Notes to artifacts where no content was modified — gaps that require author input (e.g., missing named customers) belong only in the review file, not in the artifact.
+5. Update the review file frontmatter: set `revised=true` if content was modified, set `needs_attention=true` if human review is still needed
+6. Re-run the review (go back to Step 2) on the revised artifacts
 
 **Revision limits**:
 - Maximum 2 auto-revision cycles
-- If RFEs still fail after 2 cycles, stop and present the review report to the user
+- If RFEs still fail after 2 cycles, stop and present the results to the user
 
 ## Step 5: Advise the User
 

--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -44,13 +44,13 @@ Do not run `/rfe.create`. The RFE already exists in Jira.
 
 Run `/rfe.review $ARGUMENTS` — this fetches the RFE from Jira, reviews it, and auto-revises.
 
-**If all RFEs pass** (rubric >= 7/10 with no zeros, feasibility is feasible/conditional): proceed to Phase 3.
+**If all RFEs pass** (rubric >= 7/10 with no zeros, feasibility is feasible): proceed to Phase 3.
 
-**If any RFE fails**: Auto-revise the failing RFEs using the review feedback. Read the review report, identify the specific issues, edit the RFE artifact files to address them, then re-run `/rfe.review`.
+**If any RFE fails**: Auto-revise the failing RFEs using the review feedback. Read the review files in `artifacts/rfe-reviews/`, identify the specific issues, edit the RFE artifact files to address them, then re-run `/rfe.review`.
 
 **Revision limits**:
 - Maximum 2 revision cycles
-- If RFEs still fail after 2 cycles, stop and present the review report to the user
+- If RFEs still fail after 2 cycles, stop and present the review results to the user
 - Tell them: "These RFEs need manual attention. Run `/rfe.review` after editing to continue."
 
 ### Phase 3: Submit
@@ -68,7 +68,7 @@ At the end, summarize what happened:
 - RHAIRFE-NNNN: <title> (Priority: Normal)
 
 Review cycles: N
-Artifacts: artifacts/rfes.md, artifacts/rfe-tasks/, artifacts/rfe-review-report.md, artifacts/jira-tickets.md
+Artifacts: artifacts/rfes.md, artifacts/rfe-tasks/, artifacts/rfe-reviews/
 ```
 
 $ARGUMENTS

--- a/.claude/skills/rfe.split/SKILL.md
+++ b/.claude/skills/rfe.split/SKILL.md
@@ -20,11 +20,19 @@ python3 scripts/fetch_issue.py RHAIRFE-1234 --fields summary,description,priorit
 
 The script outputs JSON to stdout with the description already converted to markdown. Parse `fields.description`, `fields.summary`, and `fields.priority.name`.
 
-Write it to `artifacts/rfe-tasks/RHAIRFE-1234.md` using the RFE template format (read `${CLAUDE_SKILL_DIR}/../rfe.create/rfe-template.md` for the format). Set frontmatter:
+Write it to `artifacts/rfe-tasks/<jira_key>.md` using the RFE template format (read `${CLAUDE_SKILL_DIR}/../rfe.create/rfe-template.md` for the format).
+
+First, read the schema to know exact field names and allowed values:
 
 ```bash
-python3 scripts/frontmatter.py set artifacts/rfe-tasks/RHAIRFE-1234.md \
-    rfe_id=RHAIRFE-1234 \
+python3 scripts/frontmatter.py schema rfe-task
+```
+
+Then set frontmatter, using the Jira key as the `rfe_id`:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/rfe-tasks/<jira_key>.md \
+    rfe_id=<jira_key> \
     title="<title>" \
     priority=<priority> \
     size=<size> \
@@ -147,22 +155,22 @@ Using the recommended decomposition:
    - If the original came from Jira, note the source key (e.g., `**Split from**: RHAIRFE-1234`)
 4. Number new RFEs sequentially after the highest existing RFE number in `artifacts/rfe-tasks/`
 5. Write each to `artifacts/rfe-tasks/RFE-NNN-<slug>.md`
-6. Set frontmatter on each child with `parent_key` pointing to the original's Jira key:
+6. Set frontmatter on each child with `parent_key` pointing to the original's `rfe_id`:
 
 ```bash
-python3 scripts/frontmatter.py set artifacts/rfe-tasks/RFE-003-<slug>.md \
-    rfe_id=RFE-003 \
-    title="<title>" \
+python3 scripts/frontmatter.py set artifacts/rfe-tasks/<child_filename>.md \
+    rfe_id=<child_rfe_id> \
+    title="<child_title>" \
     priority=<priority> \
     size=<size> \
     status=Draft \
-    parent_key=RHAIRFE-1234
+    parent_key=<parent_rfe_id>
 ```
 
 7. Archive the original by updating its frontmatter status:
 
 ```bash
-python3 scripts/frontmatter.py set artifacts/rfe-tasks/<original-file>.md \
+python3 scripts/frontmatter.py set artifacts/rfe-tasks/<original_filename>.md \
     status=Archived
 ```
 

--- a/.claude/skills/rfe.split/SKILL.md
+++ b/.claude/skills/rfe.split/SKILL.md
@@ -41,7 +41,7 @@ python3 scripts/frontmatter.py set artifacts/rfe-tasks/<jira_key>.md \
     status=Ready
 ```
 
-**Save an original snapshot** by copying the file (after frontmatter is set) to `artifacts/rfe-originals/<jira_key>.md`. This snapshot captures the RFE as it existed in Jira before any local splitting or revision. It serves two purposes: (1) before/after data analysis of what remediation changed, and (2) optimistic conflict detection at submit time. Create the `artifacts/rfe-originals/` directory if it doesn't exist. This file is never modified by split or revision — it is only overwritten by a fresh Jira fetch.
+**Save an original snapshot** of the raw Jira description to `artifacts/rfe-originals/<jira_key>.md`. Write the `fields.description` value as-is (the raw markdown from Jira, not the templated version). This snapshot is used for (1) before/after data analysis of what remediation changed, and (2) optimistic conflict detection at submit time — the submit skill re-fetches the description from Jira and compares it against this file to detect concurrent modifications. Create the `artifacts/rfe-originals/` directory if it doesn't exist. This file is never modified by split or revision — it is only overwritten by a fresh Jira fetch.
 
 **If a local artifact reference**: Find and read the matching file in `artifacts/rfe-tasks/`.
 

--- a/.claude/skills/rfe.split/SKILL.md
+++ b/.claude/skills/rfe.split/SKILL.md
@@ -20,13 +20,22 @@ python3 scripts/fetch_issue.py RHAIRFE-1234 --fields summary,description,priorit
 
 The script outputs JSON to stdout with the description already converted to markdown. Parse `fields.description`, `fields.summary`, and `fields.priority.name`.
 
-Write it to `artifacts/rfe-tasks/` as a local artifact using the RFE template format (read `${CLAUDE_SKILL_DIR}/../rfe.create/rfe-template.md` for the format). Record the Jira key in the artifact metadata.
+Write it to `artifacts/rfe-tasks/RHAIRFE-1234.md` using the RFE template format (read `${CLAUDE_SKILL_DIR}/../rfe.create/rfe-template.md` for the format). Set frontmatter:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/rfe-tasks/RHAIRFE-1234.md \
+    rfe_id=RHAIRFE-1234 \
+    title="<title>" \
+    priority=<priority> \
+    size=<size> \
+    status=Ready
+```
 
 **If a local artifact reference**: Find and read the matching file in `artifacts/rfe-tasks/`.
 
 **If no argument provided**: Fail with: "Usage: `/rfe.split <RFE-NNN or RHAIRFE-1234>`. Provide a local artifact reference or a Jira key." Do not proceed.
 
-Also read `artifacts/rfe-review-report.md` if it exists — the right-sizing feedback explains why this RFE needs splitting.
+Also check for a prior review in `artifacts/rfe-reviews/` for this RFE — the right-sizing feedback explains why this RFE needs splitting.
 
 ## Step 1.5: Load Right-sizing Rubric
 
@@ -47,8 +56,8 @@ If the bootstrap fails, proceed with a basic right-sizing heuristic: each child 
 ### Step 2a: Triage Already-Delivered Capabilities
 
 Before decomposing, check for capabilities that are already delivered or in progress. Sources:
-- The review report (`artifacts/rfe-review-report.md`) may flag delivered items
-- Stakeholder comments (`artifacts/rfe-tasks/RFE-NNN-comments.md`) often reveal what has shipped
+- The review file (`artifacts/rfe-reviews/{id}-review.md`) may flag delivered items
+- Stakeholder comments (`artifacts/rfe-tasks/{id}-comments.md`) often reveal what has shipped
 - Related strategy tickets mentioned in the RFE
 
 For each acceptance criterion and scope item, mark it as:
@@ -138,8 +147,30 @@ Using the recommended decomposition:
    - If the original came from Jira, note the source key (e.g., `**Split from**: RHAIRFE-1234`)
 4. Number new RFEs sequentially after the highest existing RFE number in `artifacts/rfe-tasks/`
 5. Write each to `artifacts/rfe-tasks/RFE-NNN-<slug>.md`
-6. Archive the original by renaming it to `RFE-NNN-<slug>.md.split`
-7. Update `artifacts/rfes.md` — remove the original entry, add the new RFEs
+6. Set frontmatter on each child with `parent_key` pointing to the original's Jira key:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/rfe-tasks/RFE-003-<slug>.md \
+    rfe_id=RFE-003 \
+    title="<title>" \
+    priority=<priority> \
+    size=<size> \
+    status=Draft \
+    parent_key=RHAIRFE-1234
+```
+
+7. Archive the original by updating its frontmatter status:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/rfe-tasks/<original-file>.md \
+    status=Archived
+```
+
+8. Rebuild the index:
+
+```bash
+python3 scripts/frontmatter.py rebuild-index
+```
 
 ## Step 4: Review New RFEs
 
@@ -149,11 +180,11 @@ Run `/rfe.review` on the new artifacts. This runs rubric scoring, technical feas
 
 ## Step 4.5: Right-sizing Self-Correction (up to 3 cycles)
 
-**This step is mandatory, not advisory.** After `/rfe.review` completes, check whether any child RFE scored below 2/2 on Right-sized. If so, run up to 3 correction cycles. Do not defer to the user or skip this step — the `/rfe.review` principle "right-sizing is a recommendation, never auto-applied" does not apply here because `/rfe.split` is explicitly authorized to re-decompose children.
+**This step is mandatory, not advisory.** After `/rfe.review` completes, check whether any child RFE scored below 2/2 on Right-sized (read from `artifacts/rfe-reviews/{id}-review.md` frontmatter: `scores.right_sized`). If so, run up to 3 correction cycles. Do not defer to the user or skip this step — the `/rfe.review` principle "right-sizing is a recommendation, never auto-applied" does not apply here because `/rfe.split` is explicitly authorized to re-decompose children.
 
 ### Each cycle:
 
-1. **Diagnose**: For each child scoring below 2/2, read the assessor's Right-sized feedback. Identify the specific grouping mistake:
+1. **Diagnose**: For each child scoring below 2/2, read the assessor's Right-sized feedback from the review file. Identify the specific grouping mistake:
    - **Theme-based grouping**: Capabilities grouped by topic but independently deliverable with different teams, upstream dependencies, or delivery timelines
    - **Mixed delivery paths**: One child spans both internal work and upstream changes in different projects
    - **Multiple user scenarios**: The strategy-feature summary requires "and" connecting different user scenarios
@@ -164,7 +195,7 @@ Run `/rfe.review` on the new artifacts. This runs rubric scoring, technical feas
    - Does one require the other to function at all?
    - Do they serve different customer segments or have different technical maturity?
 
-   Generate new child RFEs for the re-split capabilities. Archive the replaced child (rename to `.resplit`). Update `artifacts/rfes.md`.
+   Generate new child RFEs for the re-split capabilities. Archive the replaced child (set `status=Archived` in frontmatter). Rebuild the index.
 
 3. **Re-review**: Run `/rfe.review` on the new/changed artifacts only.
 
@@ -211,7 +242,7 @@ Present the final state:
 ```
 ## Split Complete
 
-Original: RFE-001 (archived as RFE-001-*.md.split)
+Original: RHAIRFE-1234 (archived)
 New RFEs:
 - RFE-003: <title> (Priority: Normal) — PASS
 - RFE-004: <title> (Priority: Normal) — PASS

--- a/.claude/skills/rfe.split/SKILL.md
+++ b/.claude/skills/rfe.split/SKILL.md
@@ -12,7 +12,9 @@ You are an RFE splitting assistant. Your job is to decompose an oversized RFE in
 
 Check if `$ARGUMENTS` contains a Jira key (e.g., `RHAIRFE-1234`) or a local artifact reference (e.g., `RFE-001`).
 
-**If a Jira key**: Fetch the RFE from Jira. Try `mcp__atlassian__getJiraIssue` first. If the MCP tool is unavailable, fall back to the REST API script:
+**If a Jira key**: First check if `artifacts/rfe-tasks/<jira_key>.md` already exists locally. If it does, use the local copy — do not re-fetch from Jira. This preserves any local edits from prior review or split cycles.
+
+**If the local file does not exist**, fetch the RFE from Jira. Try `mcp__atlassian__getJiraIssue` first. If the MCP tool is unavailable, fall back to the REST API script:
 
 ```bash
 python3 scripts/fetch_issue.py RHAIRFE-1234 --fields summary,description,priority,labels,status --markdown
@@ -38,6 +40,8 @@ python3 scripts/frontmatter.py set artifacts/rfe-tasks/<jira_key>.md \
     size=<size> \
     status=Ready
 ```
+
+**Save an original snapshot** by copying the file (after frontmatter is set) to `artifacts/rfe-originals/<jira_key>.md`. This snapshot captures the RFE as it existed in Jira before any local splitting or revision. It serves two purposes: (1) before/after data analysis of what remediation changed, and (2) optimistic conflict detection at submit time. Create the `artifacts/rfe-originals/` directory if it doesn't exist. This file is never modified by split or revision — it is only overwritten by a fresh Jira fetch.
 
 **If a local artifact reference**: Find and read the matching file in `artifacts/rfe-tasks/`.
 

--- a/.claude/skills/rfe.submit/SKILL.md
+++ b/.claude/skills/rfe.submit/SKILL.md
@@ -37,7 +37,7 @@ For each Jira-sourced RFE being submitted, check if an original snapshot exists 
 python3 scripts/fetch_issue.py <rfe_id> --fields summary,description --markdown
 ```
 
-2. Compare the fetched description against the original snapshot's description (ignoring frontmatter). If they differ, someone modified the RFE in Jira since we last fetched it.
+2. Compare the fetched `fields.description` against the contents of the original snapshot file (which contains the raw Jira description, not the templated version). If they differ, someone modified the RFE in Jira since we last fetched it.
 
 3. **If a conflict is detected**: Stop submission for that RFE. Report the conflict:
 

--- a/.claude/skills/rfe.submit/SKILL.md
+++ b/.claude/skills/rfe.submit/SKILL.md
@@ -27,11 +27,11 @@ Check if `JIRA_SERVER`, `JIRA_USER`, and `JIRA_TOKEN` environment variables are 
 
 ## Step 1: Detect Mode and Run
 
-Read `artifacts/rfes.md`. Determine whether this is a split submission or standard submission.
+Check task file frontmatter to determine whether this is a split submission or standard submission.
 
 ### Split Submission
 
-If any RFE has an "Archived" status containing "split", run:
+If any task file has `status: Archived` and other task files have a matching `parent_key`, this is a split submission. Find the parent's `rfe_id` from its frontmatter and run:
 
 ```bash
 python3 scripts/split_submit.py <PARENT_KEY> [--dry-run] [--artifacts-dir artifacts]
@@ -42,6 +42,8 @@ The split submit script handles:
 - Creating child tickets with proper "Issue split" linking to the parent
 - Closing the parent ticket as Obsolete
 - Idempotent recovery if interrupted
+- Renaming local files from RFE-NNN to RHAIRFE-NNNN after submission
+- Rebuilding the rfes.md index
 
 ### Standard Submission
 
@@ -52,16 +54,17 @@ python3 scripts/submit.py [--dry-run] [--artifacts-dir artifacts]
 ```
 
 The standard submit script handles:
-- Reading the review report and skipping rejected RFEs
-- Creating new RHAIRFE tickets for RFEs without a Jira key
-- Updating existing tickets for RFEs fetched from Jira (by Jira key)
+- Reading review recommendations from `rfe-reviews/` frontmatter and skipping rejected RFEs
+- Creating new RHAIRFE tickets for RFEs with local IDs (RFE-NNN)
+- Updating existing tickets for RFEs with Jira IDs (RHAIRFE-NNNN)
 - Applying labels from the labeling scheme (see below)
 - Posting removed-context comments where applicable
-- Writing the ticket mapping to `artifacts/jira-tickets.md`
+- Renaming local files from RFE-NNN to RHAIRFE-NNNN after submission
+- Rebuilding the rfes.md index
 
 ## Step 2: Report Results
 
-After the script completes, read and report the results from `artifacts/jira-tickets.md`.
+After the script completes, read `artifacts/rfes.md` (rebuilt by the script) and report the results.
 
 If the script fails, report the error and suggest the user check credentials or use `--dry-run` to validate locally.
 
@@ -72,9 +75,9 @@ The scripts automatically apply labels based on what happened during the pipelin
 | Label | When applied |
 |-------|-------------|
 | `rfe-creator-auto-created` | Ticket was created by the pipeline (new RFEs, not updates) |
-| `rfe-creator-auto-revised` | Ticket content was modified by automation (artifact contains Revision Notes) |
+| `rfe-creator-auto-revised` | Ticket content was modified by automation (review frontmatter `revised: true`) |
 | `rfe-creator-split-original` | Parent ticket that was decomposed into smaller RFEs |
 | `rfe-creator-split-result` | Child ticket produced by splitting another RFE |
-| `rfe-creator-needs-attention` | Automation couldn't fully resolve all issues — human review needed |
+| `rfe-creator-needs-attention` | Automation couldn't fully resolve all issues — human review needed (review frontmatter `needs_attention: true`) |
 
 $ARGUMENTS

--- a/.claude/skills/rfe.submit/SKILL.md
+++ b/.claude/skills/rfe.submit/SKILL.md
@@ -25,7 +25,31 @@ Check if `JIRA_SERVER`, `JIRA_USER`, and `JIRA_TOKEN` environment variables are 
 >
 > After environment variables are set, re-run `/rfe.submit`.
 
-## Step 1: Detect Mode and Run
+## Step 1: Conflict Detection
+
+Before submitting, check for concurrent modifications to any Jira-sourced RFEs (those with `rfe_id` starting with `RHAIRFE-`).
+
+For each Jira-sourced RFE being submitted, check if an original snapshot exists at `artifacts/rfe-originals/<rfe_id>.md`. If it does:
+
+1. Re-fetch the current Jira description using the REST API script:
+
+```bash
+python3 scripts/fetch_issue.py <rfe_id> --fields summary,description --markdown
+```
+
+2. Compare the fetched description against the original snapshot's description (ignoring frontmatter). If they differ, someone modified the RFE in Jira since we last fetched it.
+
+3. **If a conflict is detected**: Stop submission for that RFE. Report the conflict:
+
+> **Conflict detected for `<rfe_id>`**: The RFE was modified in Jira since it was last fetched. Submitting would overwrite those changes.
+>
+> To resolve: re-fetch from Jira by running `/rfe.review <rfe_id>`, then re-apply your changes.
+
+4. **If no conflict**: Proceed with submission.
+
+If no original snapshot exists (e.g., for locally-created RFEs with `RFE-NNN` IDs), skip conflict detection — there is no Jira state to conflict with.
+
+## Step 2: Detect Mode and Run
 
 Check task file frontmatter to determine whether this is a split submission or standard submission.
 
@@ -62,7 +86,7 @@ The standard submit script handles:
 - Renaming local files from RFE-NNN to RHAIRFE-NNNN after submission
 - Rebuilding the rfes.md index
 
-## Step 2: Report Results
+## Step 3: Report Results
 
 After the script completes, read `artifacts/rfes.md` (rebuilt by the script) and report the results.
 

--- a/.claude/skills/scope-review/SKILL.md
+++ b/.claude/skills/scope-review/SKILL.md
@@ -13,7 +13,7 @@ You are a product owner reviewing refined strategy features for scope. Your job 
 
 Read the strategy artifacts in `artifacts/strat-tasks/`. Cross-reference against the source RFEs in `artifacts/rfe-tasks/`.
 
-If `artifacts/strat-review-report.md` exists, read it — this is a re-review.
+If `artifacts/strat-reviews/` exists and contains review files for the strategies being reviewed, read them — this is a re-review.
 
 ## What to Assess
 

--- a/.claude/skills/strat.create/SKILL.md
+++ b/.claude/skills/strat.create/SKILL.md
@@ -79,14 +79,12 @@ After cloning, run `/strat.refine` to add the technical strategy.
 
 ## Step 4: Create Local Strategy Stubs
 
-Regardless of whether Jira cloning succeeded, create stub files in `artifacts/strat-tasks/` for each strategy:
+Regardless of whether Jira cloning succeeded, create stub files in `artifacts/strat-tasks/` for each strategy.
+
+Write the markdown body to `artifacts/strat-tasks/STRAT-NNN-<slug>.md`:
 
 ```markdown
 # STRAT-NNN: <title>
-
-**Source RFE**: <RFE-NNN or RHAIRFE-NNNN>
-**Jira Key**: <RHAISTRAT-NNNN if cloned, otherwise "pending — see strat-jira-guide.md">
-**Priority**: <priority from source RFE>
 
 ## Business Need (from RFE)
 <Full content copied from the source RFE — this is fixed input for strategy refinement>
@@ -96,6 +94,26 @@ Regardless of whether Jira cloning succeeded, create stub files in `artifacts/st
 ```
 
 The business need section is copied verbatim from the RFE. It must not be modified during strategy work.
+
+Then set frontmatter on each strategy file. First, read the schema to know exact field names and allowed values:
+
+```bash
+python3 scripts/frontmatter.py schema strat-task
+```
+
+Then set frontmatter using the actual values for this strategy:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/strat-tasks/<filename>.md \
+    strat_id=<strat_id> \
+    title="<title>" \
+    source_rfe=<source_rfe_id> \
+    jira_key=<RHAISTRAT_key_or_null> \
+    priority=<priority> \
+    status=Draft
+```
+
+Use `jira_key=null` if Jira cloning was not done.
 
 ## Step 5: Write Artifacts
 

--- a/.claude/skills/strat.create/SKILL.md
+++ b/.claude/skills/strat.create/SKILL.md
@@ -11,8 +11,13 @@ You are a strategy creation assistant. Your job is to create strategies from app
 
 Check for available RFE sources:
 
-1. **Local artifacts** — check for `artifacts/rfe-tasks/` and `artifacts/rfes.md`
-2. **Jira** — check if Jira MCP is available or if `JIRA_SERVER`/`JIRA_USER`/`JIRA_TOKEN` env vars are set, and if the user has provided RHAIRFE keys or `artifacts/jira-tickets.md` exists
+1. **Local artifacts** — check for `artifacts/rfe-tasks/` files with valid frontmatter. Read Jira keys from task file frontmatter:
+
+```bash
+python3 scripts/frontmatter.py read artifacts/rfe-tasks/<file>.md
+```
+
+2. **Jira** — check if Jira MCP is available or if `JIRA_SERVER`/`JIRA_USER`/`JIRA_TOKEN` env vars are set, and if the user has provided RHAIRFE keys
 
 **If both local artifacts and Jira are available**: Ask the user which source to use. Local artifacts may have been edited after submission; Jira has the canonical version. Let the user decide.
 

--- a/.claude/skills/strat.create/SKILL.md
+++ b/.claude/skills/strat.create/SKILL.md
@@ -84,8 +84,6 @@ Regardless of whether Jira cloning succeeded, create stub files in `artifacts/st
 Write the markdown body to `artifacts/strat-tasks/STRAT-NNN-<slug>.md`:
 
 ```markdown
-# STRAT-NNN: <title>
-
 ## Business Need (from RFE)
 <Full content copied from the source RFE — this is fixed input for strategy refinement>
 

--- a/.claude/skills/strat.refine/SKILL.md
+++ b/.claude/skills/strat.refine/SKILL.md
@@ -10,7 +10,13 @@ You are a senior engineer performing feature refinement. Your job is to take app
 
 ## Inputs
 
-Read the strategy files in `artifacts/strat-tasks/`. Each contains the business need from the source RFE. This business need is **fixed input** — do not modify it, weaken it, or reinterpret it. Your job is to add or revise the HOW, not change the WHAT.
+Read the strategy files in `artifacts/strat-tasks/`. Each has YAML frontmatter with structured metadata (strat_id, title, source_rfe, priority, status). Read frontmatter with:
+
+```bash
+python3 scripts/frontmatter.py read artifacts/strat-tasks/<filename>.md
+```
+
+Each file also contains the business need from the source RFE. This business need is **fixed input** — do not modify it, weaken it, or reinterpret it. Your job is to add or revise the HOW, not change the WHAT.
 
 ## Revision Mode
 
@@ -55,5 +61,12 @@ For each strategy, use the template in `${CLAUDE_SKILL_DIR}/strat-template.md`. 
 ## Output
 
 Update each file in `artifacts/strat-tasks/` with the completed strategy. Preserve the business need section unchanged.
+
+After writing the strategy content, update the frontmatter status:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/strat-tasks/<filename>.md \
+    status=Refined
+```
 
 $ARGUMENTS

--- a/.claude/skills/strat.refine/SKILL.md
+++ b/.claude/skills/strat.refine/SKILL.md
@@ -14,16 +14,16 @@ Read the strategy files in `artifacts/strat-tasks/`. Each contains the business 
 
 ## Revision Mode
 
-Check if `artifacts/strat-review-report.md` exists. If it does, this is a revision — the strategies have already been refined and reviewed. Read the review report carefully.
+Check if prior reviews exist in `artifacts/strat-reviews/` for any of the strategies being refined. If they do, this is a revision — the strategies have already been refined and reviewed. Read each strategy's review file.
 
 In revision mode:
 - **Do not regenerate from scratch.** Read the existing strategy content and the review feedback.
-- **Address each reviewer's concerns specifically.** The report contains findings from up to 4 independent reviewers (feasibility, testability, scope, architecture). Address each concern that has merit.
+- **Address each reviewer's concerns specifically.** The review file contains findings from up to 4 independent reviewers (feasibility, testability, scope, architecture). Address each concern that has merit.
 - **Preserve what's working.** If reviewers approved aspects of the strategy, don't rewrite those sections.
 - **Note what changed.** Add a `### Revision Notes` section at the end of each revised strategy listing what was changed and why, referencing the specific review concerns addressed.
 - **Flag disagreements.** If you believe a reviewer's concern is invalid, keep the current approach and explain why in the revision notes rather than silently ignoring it.
 
-If no review report exists, this is initial refinement — generate the strategy from the stub.
+If no review files exist, this is initial refinement — generate the strategy from the stub.
 
 ## Architecture Context
 

--- a/.claude/skills/strat.refine/SKILL.md
+++ b/.claude/skills/strat.refine/SKILL.md
@@ -26,7 +26,7 @@ In revision mode:
 - **Do not regenerate from scratch.** Read the existing strategy content and the review feedback.
 - **Address each reviewer's concerns specifically.** The review file contains findings from up to 4 independent reviewers (feasibility, testability, scope, architecture). Address each concern that has merit.
 - **Preserve what's working.** If reviewers approved aspects of the strategy, don't rewrite those sections.
-- **Note what changed.** Add a `### Revision Notes` section at the end of each revised strategy listing what was changed and why, referencing the specific review concerns addressed.
+- **Note what changed.** Document what changed and why in the review file's `## Revision History` section (`artifacts/strat-reviews/{id}-review.md`), not in the strategy artifact itself. Keep strategy files clean with only frontmatter and business/strategy content.
 - **Flag disagreements.** If you believe a reviewer's concern is invalid, keep the current approach and explain why in the revision notes rather than silently ignoring it.
 
 If no review files exist, this is initial refinement — generate the strategy from the stub.

--- a/.claude/skills/strat.review/SKILL.md
+++ b/.claude/skills/strat.review/SKILL.md
@@ -35,34 +35,22 @@ Each reviewer receives:
 
 ## Step 4: Write Per-Strategy Review Files
 
-For each reviewed strategy, write a review file to `artifacts/strat-reviews/`. First get the schema:
+For each reviewed strategy, write a review file to `artifacts/strat-reviews/`. First, read the schema to know exact field names and allowed values:
 
 ```bash
 python3 scripts/frontmatter.py schema strat-review
 ```
 
-Then for each strategy, write the review body to `artifacts/strat-reviews/{id}-review.md`, then set frontmatter:
+Then for each strategy, write the review body to `artifacts/strat-reviews/{id}-review.md`, then set frontmatter using the actual review results:
 
 ```bash
-python3 scripts/frontmatter.py set artifacts/strat-reviews/STRAT-001-slug-review.md \
-    strat_id=STRAT-001 \
-    recommendation=revise \
-    reviewers.feasibility=approve \
-    reviewers.testability=revise \
-    reviewers.scope=approve \
-    reviewers.architecture=approve
-```
-
-If the strategy has a Jira key, use it as the `strat_id`:
-
-```bash
-python3 scripts/frontmatter.py set artifacts/strat-reviews/RHAISTRAT-400-review.md \
-    strat_id=RHAISTRAT-400 \
-    recommendation=approve \
-    reviewers.feasibility=approve \
-    reviewers.testability=approve \
-    reviewers.scope=approve \
-    reviewers.architecture=approve
+python3 scripts/frontmatter.py set artifacts/strat-reviews/<id>-review.md \
+    strat_id=<strat_id> \
+    recommendation=<recommendation> \
+    reviewers.feasibility=<verdict> \
+    reviewers.testability=<verdict> \
+    reviewers.scope=<verdict> \
+    reviewers.architecture=<verdict>
 ```
 
 The review file body should contain:

--- a/.claude/skills/strat.review/SKILL.md
+++ b/.claude/skills/strat.review/SKILL.md
@@ -5,13 +5,13 @@ user-invocable: true
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Skill
 ---
 
-You are a strategy review orchestrator. Your job is to run independent adversarial reviews of the strategies in `artifacts/strat-tasks/` and combine the results into a single review report.
+You are a strategy review orchestrator. Your job is to run independent adversarial reviews of the strategies in `artifacts/strat-tasks/` and write per-strategy review files.
 
 ## Step 1: Verify Artifacts Exist
 
 Read files in `artifacts/strat-tasks/`. If no strategy artifacts exist or they haven't been refined yet (no "Strategy" section), tell the user to run `/strat.refine` first and stop.
 
-Check if a prior review report exists at `artifacts/strat-review-report.md`. If it does, read it — this is a re-review after revisions.
+Check if prior reviews exist in `artifacts/strat-reviews/`. If any exist for the strategies being reviewed, read them — this is a re-review after revisions.
 
 ## Step 2: Fetch Architecture Context
 
@@ -31,44 +31,60 @@ Invoke these forked reviewer skills in parallel. Each runs in its own isolated c
 Each reviewer receives:
 - The strategy artifacts (`artifacts/strat-tasks/`)
 - The source RFEs (`artifacts/rfes.md`, `artifacts/rfe-tasks/`)
-- The prior review report (if this is a re-review)
+- Prior review files from `artifacts/strat-reviews/` (if this is a re-review)
 
-## Step 4: Combine Results
+## Step 4: Write Per-Strategy Review Files
 
-Write `artifacts/strat-review-report.md`:
+For each reviewed strategy, write a review file to `artifacts/strat-reviews/`. First get the schema:
+
+```bash
+python3 scripts/frontmatter.py schema strat-review
+```
+
+Then for each strategy, write the review body to `artifacts/strat-reviews/{id}-review.md`, then set frontmatter:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/strat-reviews/STRAT-001-slug-review.md \
+    strat_id=STRAT-001 \
+    recommendation=revise \
+    reviewers.feasibility=approve \
+    reviewers.testability=revise \
+    reviewers.scope=approve \
+    reviewers.architecture=approve
+```
+
+If the strategy has a Jira key, use it as the `strat_id`:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/strat-reviews/RHAISTRAT-400-review.md \
+    strat_id=RHAISTRAT-400 \
+    recommendation=approve \
+    reviewers.feasibility=approve \
+    reviewers.testability=approve \
+    reviewers.scope=approve \
+    reviewers.architecture=approve
+```
+
+The review file body should contain:
 
 ```markdown
-# Strategy Review Report
+## Feasibility
+<assessment from feasibility reviewer>
 
-**Date**: <date>
-**Strategies reviewed**: <count>
-**Architecture context**: <version or "not available">
+## Testability
+<assessment from testability reviewer>
 
-## Summary
-<Overall assessment: are these strategies ready for prioritization?>
+## Scope
+<assessment from scope reviewer>
 
-## Per-Strategy Results
+## Architecture
+<assessment from architecture reviewer, or "skipped — no context">
 
-### STRAT-001: <title>
+## Agreements
+<where reviewers aligned>
 
-**Feasibility**: <assessment>
-**Testability**: <assessment>
-**Scope**: <assessment>
-**Architecture**: <assessment or "skipped — no context">
-
-**Consensus recommendation**: <approve / revise / split / reject>
-**Key concerns**:
-- <concern from reviewer>
-- <concern from reviewer>
-
-**Agreements across reviewers**: <where reviewers aligned>
-**Disagreements**: <where reviewers diverged — preserve both views>
-
-### STRAT-002: <title>
-...
-
-## Revision History
-<If re-review: what changed, what's resolved, what's new>
+## Disagreements
+<where reviewers diverged — preserve both views>
 ```
 
 Important: **Preserve disagreements.** If the feasibility reviewer says "this is fine" but the scope reviewer says "this is too big," report both views. Do not average or harmonize.

--- a/.claude/skills/testability-review/SKILL.md
+++ b/.claude/skills/testability-review/SKILL.md
@@ -13,7 +13,7 @@ You are a test engineer reviewing refined strategy features. Your job is to dete
 
 Read the strategy artifacts in `artifacts/strat-tasks/`. Cross-reference against the source RFEs in `artifacts/rfe-tasks/` for the original acceptance criteria.
 
-If `artifacts/strat-review-report.md` exists, read it — this is a re-review.
+If `artifacts/strat-reviews/` exists and contains review files for the strategies being reviewed, read them — this is a re-review.
 
 ## What to Assess
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 artifacts/
 .claude/skills/assess-rfe/
 .claude/skills/export-rubric/
+__pycache__/
 .mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ artifacts/
     RHAIRFE-1595-review.md
     RFE-001-slug-review.md
 
-  strat-tasks/              # Individual strategy files, linked to source RFEs
+  strat-tasks/              # Individual strategy files with YAML frontmatter
     RHAISTRAT-400.md
   strat-reviews/            # Per-strategy review files with YAML frontmatter
     RHAISTRAT-400-review.md
@@ -41,6 +41,7 @@ All task and review files use YAML frontmatter for structured metadata. Skills m
 # Get schema for a file type
 python3 scripts/frontmatter.py schema rfe-task
 python3 scripts/frontmatter.py schema rfe-review
+python3 scripts/frontmatter.py schema strat-task
 python3 scripts/frontmatter.py schema strat-review
 
 # Set/update frontmatter on a file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ artifacts/
     RHAIRFE-1595-removed-context.md  # Companion: content removed during revision
     RFE-001-slug.md          # New RFE (pre-submission, renamed on submit)
 
-  rfe-originals/            # Snapshots of Jira-fetched RFEs before local modification
+  rfe-originals/            # Raw Jira descriptions at time of fetch (not templated)
     RHAIRFE-1595.md          # Baseline for before/after analysis and submit-time conflict detection
 
   rfe-reviews/              # Per-issue review files with YAML frontmatter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,19 +9,54 @@ All skills read from and write to the `artifacts/` directory in the working dire
 ```
 artifacts/
   rfe-rubric.md             # Written by assess-rfe plugin (if installed) — rubric reference
-  rfes.md                   # RFE master list — summary of all RFEs
-  rfe-tasks/                # Individual RFE files
-    RFE-001-*.md
-    RFE-002-*.md
-  rfe-review-report.md      # Review results (rubric scores + feasibility)
-  jira-tickets.md           # Jira ticket mapping after submission
-  strat-tickets.md          # RHAISTRAT ticket mapping after cloning
+  rfes.md                   # Generated index — rebuilt from frontmatter, not a source of truth
+
+  rfe-tasks/                # Individual RFE files with YAML frontmatter
+    RHAIRFE-1595.md          # Existing Jira issue (keyed by Jira key)
+    RHAIRFE-1595-comments.md # Companion: stakeholder comment history
+    RHAIRFE-1595-removed-context.md  # Companion: content removed during revision
+    RFE-001-slug.md          # New RFE (pre-submission, renamed on submit)
+
+  rfe-reviews/              # Per-issue review files with YAML frontmatter
+    RHAIRFE-1595-review.md
+    RFE-001-slug-review.md
+
   strat-tasks/              # Individual strategy files, linked to source RFEs
-    STRAT-001-*.md
-    STRAT-002-*.md
-  strat-review-report.md    # Strategy review results (4 forked reviewers)
+    RHAISTRAT-400.md
+  strat-reviews/            # Per-strategy review files with YAML frontmatter
+    RHAISTRAT-400-review.md
+
+  strat-tickets.md          # RHAISTRAT ticket mapping after cloning
   strat-prioritization.md   # Prioritization decisions and rationale
 ```
+
+### Frontmatter
+
+All task and review files use YAML frontmatter for structured metadata. Skills must use `scripts/frontmatter.py` to read schemas, set fields, and read validated data — never write YAML by hand.
+
+```bash
+# Get schema for a file type
+python3 scripts/frontmatter.py schema rfe-task
+python3 scripts/frontmatter.py schema rfe-review
+python3 scripts/frontmatter.py schema strat-review
+
+# Set/update frontmatter on a file
+python3 scripts/frontmatter.py set <path> field=value field=value ...
+
+# Read validated frontmatter as JSON
+python3 scripts/frontmatter.py read <path>
+
+# Rebuild rfes.md index from all frontmatter
+python3 scripts/frontmatter.py rebuild-index
+```
+
+### File Naming
+
+- **Existing Jira issues**: Use Jira key as filename and `rfe_id` (e.g., `RHAIRFE-1595.md` with `rfe_id: RHAIRFE-1595`)
+- **New RFEs (pre-submission)**: Use `RFE-NNN-slug.md` naming with `rfe_id: RFE-NNN`
+- **On submit**: `RFE-NNN-slug.md` files are renamed to `RHAIRFE-NNNN.md`, and `rfe_id` is updated to the Jira key
+- **Companion files**: Same prefix as main file with `-comments.md` or `-removed-context.md` suffix
+- **Archived RFEs**: Set `status: Archived` in frontmatter (no filename changes)
 
 ## Jira Integration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,9 @@ artifacts/
     RHAIRFE-1595-removed-context.md  # Companion: content removed during revision
     RFE-001-slug.md          # New RFE (pre-submission, renamed on submit)
 
+  rfe-originals/            # Snapshots of Jira-fetched RFEs before local modification
+    RHAIRFE-1595.md          # Baseline for before/after analysis and submit-time conflict detection
+
   rfe-reviews/              # Per-issue review files with YAML frontmatter
     RHAIRFE-1595-review.md
     RFE-001-slug-review.md

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -105,6 +105,39 @@ SCHEMAS = {
             },
         },
     },
+    "strat-task": {
+        "strat_id": {
+            "type": "string",
+            "required": True,
+            "pattern": r"^(STRAT-\d+|RHAISTRAT-\d+)$",
+        },
+        "title": {
+            "type": "string",
+            "required": True,
+        },
+        "source_rfe": {
+            "type": "string",
+            "required": True,
+            "pattern": r"^(RFE-\d+|RHAIRFE-\d+)$",
+        },
+        "jira_key": {
+            "type": "string",
+            "required": False,
+            "pattern": r"^RHAISTRAT-\d+$",
+            "default": None,
+        },
+        "priority": {
+            "type": "string",
+            "required": True,
+            "enum": ["Blocker", "Critical", "Major", "Normal", "Minor",
+                     "Undefined"],
+        },
+        "status": {
+            "type": "string",
+            "required": True,
+            "enum": ["Draft", "Ready", "Refined", "Reviewed"],
+        },
+    },
     "strat-review": {
         "strat_id": {
             "type": "string",

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -1,0 +1,762 @@
+"""Artifact schema definitions, frontmatter read/write/validate, and index rebuilding.
+
+Owns all structured metadata for RFE and strategy artifacts. Scripts and skills
+use this module instead of regex-parsing markdown prose.
+
+Frontmatter is stored as YAML between --- delimiters at the top of markdown files.
+"""
+
+import os
+import re
+import sys
+
+import yaml
+
+
+# ─── Schema Definitions ────────────────────────────────────────────────────────
+
+# Each schema is a dict of field_name -> field_spec.
+# field_spec keys:
+#   type:     "string" | "int" | "bool" | "dict"
+#   required: bool (default False)
+#   enum:     list of allowed values (optional)
+#   pattern:  regex pattern the value must match (optional, strings only)
+#   default:  default value when not provided (optional)
+#   fields:   nested schema for type="dict" (optional)
+
+SCHEMAS = {
+    "rfe-task": {
+        "rfe_id": {
+            "type": "string",
+            "required": True,
+            "pattern": r"^(RFE-\d+|RHAIRFE-\d+)$",
+        },
+        "title": {
+            "type": "string",
+            "required": True,
+        },
+        "priority": {
+            "type": "string",
+            "required": True,
+            "enum": ["Blocker", "Critical", "Major", "Normal", "Minor",
+                     "Undefined"],
+        },
+        "size": {
+            "type": "string",
+            "required": False,
+            "enum": ["S", "M", "L", "XL"],
+            "default": None,
+        },
+        "status": {
+            "type": "string",
+            "required": True,
+            "enum": ["Draft", "Ready", "Submitted", "Archived"],
+        },
+        "parent_key": {
+            "type": "string",
+            "required": False,
+            "pattern": r"^(RFE-\d+|RHAIRFE-\d+)$",
+            "default": None,
+        },
+    },
+    "rfe-review": {
+        "rfe_id": {
+            "type": "string",
+            "required": True,
+            "pattern": r"^(RFE-\d+|RHAIRFE-\d+)$",
+        },
+        "score": {
+            "type": "int",
+            "required": True,
+        },
+        "pass": {
+            "type": "bool",
+            "required": True,
+        },
+        "recommendation": {
+            "type": "string",
+            "required": True,
+            "enum": ["submit", "revise", "split", "reject"],
+        },
+        "feasibility": {
+            "type": "string",
+            "required": True,
+            "enum": ["feasible", "infeasible"],
+        },
+        "revised": {
+            "type": "bool",
+            "required": True,
+            "default": False,
+        },
+        "needs_attention": {
+            "type": "bool",
+            "required": True,
+            "default": False,
+        },
+        "scores": {
+            "type": "dict",
+            "required": True,
+            "fields": {
+                "what": {"type": "int", "required": True},
+                "why": {"type": "int", "required": True},
+                "open_to_how": {"type": "int", "required": True},
+                "not_a_task": {"type": "int", "required": True},
+                "right_sized": {"type": "int", "required": True},
+            },
+        },
+    },
+    "strat-review": {
+        "strat_id": {
+            "type": "string",
+            "required": True,
+            "pattern": r"^(STRAT-\d+|RHAISTRAT-\d+)$",
+        },
+        "recommendation": {
+            "type": "string",
+            "required": True,
+            "enum": ["approve", "revise", "split", "reject"],
+        },
+        "reviewers": {
+            "type": "dict",
+            "required": True,
+            "fields": {
+                "feasibility": {
+                    "type": "string",
+                    "required": True,
+                    "enum": ["approve", "revise", "reject"],
+                },
+                "testability": {
+                    "type": "string",
+                    "required": True,
+                    "enum": ["approve", "revise", "reject"],
+                },
+                "scope": {
+                    "type": "string",
+                    "required": True,
+                    "enum": ["approve", "revise", "reject"],
+                },
+                "architecture": {
+                    "type": "string",
+                    "required": True,
+                    "enum": ["approve", "revise", "reject"],
+                },
+            },
+        },
+    },
+}
+
+
+# ─── Validation ─────────────────────────────────────────────────────────────────
+
+class ValidationError(Exception):
+    """Raised when frontmatter fails schema validation."""
+    pass
+
+
+def _validate_field(name, value, spec, path=""):
+    """Validate a single field against its spec. Returns list of errors."""
+    errors = []
+    full_name = f"{path}.{name}" if path else name
+
+    if value is None:
+        if spec.get("required", False) and "default" not in spec:
+            errors.append(f"Missing required field: {full_name}")
+        return errors
+
+    expected_type = spec.get("type", "string")
+
+    if expected_type == "string":
+        if not isinstance(value, str):
+            errors.append(
+                f"{full_name}: expected string, got {type(value).__name__}")
+            return errors
+        if "enum" in spec and value not in spec["enum"]:
+            errors.append(
+                f"{full_name}: '{value}' not in {spec['enum']}")
+        if "pattern" in spec and not re.match(spec["pattern"], value):
+            errors.append(
+                f"{full_name}: '{value}' does not match {spec['pattern']}")
+
+    elif expected_type == "int":
+        if not isinstance(value, int) or isinstance(value, bool):
+            errors.append(
+                f"{full_name}: expected int, got {type(value).__name__}")
+
+    elif expected_type == "bool":
+        if not isinstance(value, bool):
+            errors.append(
+                f"{full_name}: expected bool, got {type(value).__name__}")
+
+    elif expected_type == "dict":
+        if not isinstance(value, dict):
+            errors.append(
+                f"{full_name}: expected dict, got {type(value).__name__}")
+            return errors
+        nested_schema = spec.get("fields", {})
+        # Check for unknown fields in nested dict
+        for key in value:
+            if key not in nested_schema:
+                errors.append(f"{full_name}: unknown field '{key}'")
+        # Validate nested fields
+        for field_name, field_spec in nested_schema.items():
+            errors.extend(_validate_field(
+                field_name, value.get(field_name), field_spec, full_name))
+
+    return errors
+
+
+def validate(data, schema_type):
+    """Validate frontmatter data against a schema.
+
+    Args:
+        data: dict of frontmatter fields
+        schema_type: one of "rfe-task", "rfe-review", "strat-review"
+
+    Returns:
+        list of error strings (empty if valid)
+
+    Raises:
+        ValueError: if schema_type is unknown
+    """
+    if schema_type not in SCHEMAS:
+        raise ValueError(
+            f"Unknown schema type: {schema_type}. "
+            f"Valid types: {list(SCHEMAS.keys())}")
+
+    schema = SCHEMAS[schema_type]
+    errors = []
+
+    # Check for unknown top-level fields
+    for key in data:
+        if key not in schema:
+            errors.append(f"Unknown field: {key}")
+
+    # Validate each defined field
+    for field_name, field_spec in schema.items():
+        errors.extend(_validate_field(
+            field_name, data.get(field_name), field_spec))
+
+    return errors
+
+
+def apply_defaults(data, schema_type):
+    """Apply default values for missing optional fields.
+
+    Modifies data in-place and returns it.
+    """
+    schema = SCHEMAS[schema_type]
+    for field_name, field_spec in schema.items():
+        if field_name not in data and "default" in field_spec:
+            data[field_name] = field_spec["default"]
+        if field_spec.get("type") == "dict" and field_name in data:
+            nested = data[field_name]
+            if isinstance(nested, dict):
+                for nested_name, nested_spec in \
+                        field_spec.get("fields", {}).items():
+                    if nested_name not in nested and \
+                            "default" in nested_spec:
+                        nested[nested_name] = nested_spec["default"]
+    return data
+
+
+def get_schema_yaml(schema_type):
+    """Return the schema definition as a YAML string for display."""
+    if schema_type not in SCHEMAS:
+        raise ValueError(
+            f"Unknown schema type: {schema_type}. "
+            f"Valid types: {list(SCHEMAS.keys())}")
+
+    schema = SCHEMAS[schema_type]
+    output = {"required": {}, "optional": {}}
+
+    for name, spec in schema.items():
+        entry = {"type": spec["type"]}
+        if "enum" in spec:
+            entry["enum"] = spec["enum"]
+        if "pattern" in spec:
+            entry["pattern"] = spec["pattern"]
+        if "default" in spec:
+            entry["default"] = spec["default"]
+        if spec.get("type") == "dict" and "fields" in spec:
+            entry["fields"] = {}
+            for fname, fspec in spec["fields"].items():
+                fentry = {"type": fspec["type"]}
+                if "enum" in fspec:
+                    fentry["enum"] = fspec["enum"]
+                entry["fields"][fname] = fentry
+
+        if spec.get("required", False):
+            output["required"][name] = entry
+        else:
+            output["optional"][name] = entry
+
+    return yaml.dump(output, default_flow_style=False, sort_keys=False)
+
+
+# ─── Frontmatter Read/Write ────────────────────────────────────────────────────
+
+_FRONTMATTER_RE = re.compile(
+    r'^---\s*\n(.*?\n)---\s*\n', re.DOTALL)
+
+
+def read_frontmatter(path):
+    """Read and parse YAML frontmatter from a markdown file.
+
+    Returns:
+        (data_dict, body_string) — frontmatter as dict, remainder as string.
+        Returns ({}, full_content) if no frontmatter found.
+    """
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
+        return {}, content
+
+    yaml_str = match.group(1)
+    body = content[match.end():]
+
+    data = yaml.safe_load(yaml_str)
+    if not isinstance(data, dict):
+        return {}, content
+
+    return data, body
+
+
+def read_frontmatter_validated(path, schema_type):
+    """Read frontmatter and validate against schema.
+
+    Returns:
+        (data_dict, body_string)
+
+    Raises:
+        ValidationError: if frontmatter fails validation
+        FileNotFoundError: if file doesn't exist
+    """
+    data, body = read_frontmatter(path)
+    if not data:
+        raise ValidationError(f"No frontmatter found in {path}")
+
+    apply_defaults(data, schema_type)
+    errors = validate(data, schema_type)
+    if errors:
+        raise ValidationError(
+            f"Frontmatter validation failed in {path}:\n"
+            + "\n".join(f"  - {e}" for e in errors))
+
+    return data, body
+
+
+def write_frontmatter(path, data, schema_type):
+    """Write/update YAML frontmatter on a markdown file.
+
+    Validates data against the schema before writing. Preserves the
+    markdown body below the frontmatter. Creates the file if it doesn't
+    exist (with empty body).
+
+    Args:
+        path: file path
+        data: dict of frontmatter fields
+        schema_type: one of "rfe-task", "rfe-review", "strat-review"
+
+    Raises:
+        ValidationError: if data fails schema validation
+    """
+    apply_defaults(data, schema_type)
+    errors = validate(data, schema_type)
+    if errors:
+        raise ValidationError(
+            f"Frontmatter validation failed:\n"
+            + "\n".join(f"  - {e}" for e in errors))
+
+    # Read existing body if file exists
+    body = ""
+    if os.path.exists(path):
+        _, body = read_frontmatter(path)
+
+    yaml_str = yaml.dump(data, default_flow_style=False, sort_keys=False,
+                         allow_unicode=True)
+    content = f"---\n{yaml_str}---\n{body}"
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def update_frontmatter(path, updates, schema_type):
+    """Merge updates into existing frontmatter and rewrite.
+
+    Reads existing frontmatter, merges updates (overwriting on conflict),
+    validates, and writes back.
+
+    Args:
+        path: file path (must exist)
+        updates: dict of fields to add/update
+        schema_type: schema to validate against
+
+    Raises:
+        ValidationError: if merged data fails validation
+        FileNotFoundError: if file doesn't exist
+    """
+    data, body = read_frontmatter(path)
+    for key, value in updates.items():
+        if isinstance(value, dict) and isinstance(data.get(key), dict):
+            data[key].update(value)
+        else:
+            data[key] = value
+
+    apply_defaults(data, schema_type)
+    errors = validate(data, schema_type)
+    if errors:
+        raise ValidationError(
+            f"Frontmatter validation failed after update in {path}:\n"
+            + "\n".join(f"  - {e}" for e in errors))
+
+    yaml_str = yaml.dump(data, default_flow_style=False, sort_keys=False,
+                         allow_unicode=True)
+    content = f"---\n{yaml_str}---\n{body}"
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+# ─── Artifact File Discovery ───────────────────────────────────────────────────
+
+def _is_companion_file(filename):
+    """Check if a filename is a companion file (comments, removed-context)."""
+    return filename.endswith(("-comments.md", "-removed-context.md"))
+
+
+def find_artifact_file(artifacts_dir, identifier):
+    """Find the main artifact file for a given RFE ID or Jira key.
+
+    Matches:
+    - RFE-NNN-*.md (local pre-submission)
+    - RHAIRFE-NNNN.md (Jira-keyed)
+
+    Excludes companion files (-comments.md, -removed-context.md).
+    Excludes archived artifacts (status: Archived in frontmatter).
+
+    Args:
+        artifacts_dir: path to artifacts directory
+        identifier: RFE-NNN or RHAIRFE-NNNN
+
+    Returns:
+        Full path to artifact file, or None if not found.
+    """
+    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
+    if not os.path.isdir(tasks_dir):
+        return None
+
+    for filename in sorted(os.listdir(tasks_dir)):
+        if not filename.endswith(".md"):
+            continue
+        if _is_companion_file(filename):
+            continue
+
+        # Match by Jira key (exact: RHAIRFE-1595.md)
+        if identifier.startswith("RHAIRFE-"):
+            if filename == f"{identifier}.md":
+                path = os.path.join(tasks_dir, filename)
+                # Check if archived
+                data, _ = read_frontmatter(path)
+                if data.get("status") == "Archived":
+                    continue
+                return path
+
+        # Match by local RFE ID (prefix: RFE-001-*.md)
+        if identifier.startswith("RFE-"):
+            if filename.startswith(identifier + "-"):
+                path = os.path.join(tasks_dir, filename)
+                data, _ = read_frontmatter(path)
+                if data.get("status") == "Archived":
+                    continue
+                return path
+
+    return None
+
+
+def find_artifact_file_including_archived(artifacts_dir, identifier):
+    """Like find_artifact_file but includes archived artifacts."""
+    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
+    if not os.path.isdir(tasks_dir):
+        return None
+
+    for filename in sorted(os.listdir(tasks_dir)):
+        if not filename.endswith(".md"):
+            continue
+        if _is_companion_file(filename):
+            continue
+
+        if identifier.startswith("RHAIRFE-"):
+            if filename == f"{identifier}.md":
+                return os.path.join(tasks_dir, filename)
+
+        if identifier.startswith("RFE-"):
+            if filename.startswith(identifier + "-"):
+                return os.path.join(tasks_dir, filename)
+
+    return None
+
+
+def find_removed_context_file(artifacts_dir, identifier):
+    """Find the removed-context file for a given RFE ID or Jira key."""
+    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
+    if not os.path.isdir(tasks_dir):
+        return None
+
+    for filename in sorted(os.listdir(tasks_dir)):
+        if not filename.endswith("-removed-context.md"):
+            continue
+
+        if identifier.startswith("RHAIRFE-"):
+            if filename == f"{identifier}-removed-context.md":
+                return os.path.join(tasks_dir, filename)
+
+        if identifier.startswith("RFE-"):
+            if filename.startswith(identifier + "-") and \
+                    filename.endswith("-removed-context.md"):
+                return os.path.join(tasks_dir, filename)
+
+    return None
+
+
+def find_review_file(artifacts_dir, identifier):
+    """Find the review file for a given RFE ID or Jira key.
+
+    Looks in rfe-reviews/ for {identifier}-review.md or
+    {identifier}-*-review.md (for RFE-NNN slugged names).
+    """
+    reviews_dir = os.path.join(artifacts_dir, "rfe-reviews")
+    if not os.path.isdir(reviews_dir):
+        return None
+
+    for filename in sorted(os.listdir(reviews_dir)):
+        if not filename.endswith("-review.md"):
+            continue
+
+        if identifier.startswith("RHAIRFE-"):
+            if filename == f"{identifier}-review.md":
+                return os.path.join(reviews_dir, filename)
+
+        if identifier.startswith("RFE-"):
+            if filename.startswith(identifier + "-"):
+                return os.path.join(reviews_dir, filename)
+
+    return None
+
+
+def scan_task_files(artifacts_dir):
+    """Scan all RFE task files and return their frontmatter.
+
+    Returns:
+        list of (path, frontmatter_dict) tuples, sorted by rfe_id.
+        Files without valid frontmatter are skipped with a warning.
+    """
+    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
+    if not os.path.isdir(tasks_dir):
+        return []
+
+    results = []
+    for filename in sorted(os.listdir(tasks_dir)):
+        if not filename.endswith(".md"):
+            continue
+        if _is_companion_file(filename):
+            continue
+
+        path = os.path.join(tasks_dir, filename)
+        try:
+            data, _ = read_frontmatter_validated(path, "rfe-task")
+            results.append((path, data))
+        except (ValidationError, Exception) as e:
+            print(f"Warning: skipping {filename}: {e}", file=sys.stderr)
+
+    return sorted(results, key=lambda x: x[1].get("rfe_id", ""))
+
+
+def scan_review_files(artifacts_dir):
+    """Scan all RFE review files and return their frontmatter.
+
+    Returns:
+        list of (path, frontmatter_dict) tuples.
+        Files without valid frontmatter are skipped with a warning.
+    """
+    reviews_dir = os.path.join(artifacts_dir, "rfe-reviews")
+    if not os.path.isdir(reviews_dir):
+        return []
+
+    results = []
+    for filename in sorted(os.listdir(reviews_dir)):
+        if not filename.endswith("-review.md"):
+            continue
+
+        path = os.path.join(reviews_dir, filename)
+        try:
+            data, _ = read_frontmatter_validated(path, "rfe-review")
+            results.append((path, data))
+        except (ValidationError, Exception) as e:
+            print(f"Warning: skipping {filename}: {e}", file=sys.stderr)
+
+    return results
+
+
+# ─── File Renaming (post-submit) ───────────────────────────────────────────────
+
+def rename_to_jira_key(artifacts_dir, rfe_id, jira_key):
+    """Rename RFE-NNN-*.md files to RHAIRFE-NNNN.md after submission.
+
+    Renames the task file, companion files, and review file.
+    Updates rfe_id in frontmatter to the new Jira key.
+
+    Args:
+        artifacts_dir: path to artifacts directory
+        rfe_id: e.g. "RFE-001"
+        jira_key: e.g. "RHAIRFE-1600"
+    """
+    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
+    reviews_dir = os.path.join(artifacts_dir, "rfe-reviews")
+
+    # Rename task file and companions
+    if os.path.isdir(tasks_dir):
+        for filename in list(os.listdir(tasks_dir)):
+            if not filename.startswith(rfe_id + "-"):
+                continue
+            if not filename.endswith(".md"):
+                continue
+
+            old_path = os.path.join(tasks_dir, filename)
+
+            if filename.endswith("-comments.md"):
+                new_name = f"{jira_key}-comments.md"
+            elif filename.endswith("-removed-context.md"):
+                new_name = f"{jira_key}-removed-context.md"
+            else:
+                new_name = f"{jira_key}.md"
+
+            new_path = os.path.join(tasks_dir, new_name)
+            os.rename(old_path, new_path)
+
+            # Update frontmatter on main task file
+            if new_name == f"{jira_key}.md":
+                update_frontmatter(new_path,
+                                   {"rfe_id": jira_key,
+                                    "status": "Submitted"},
+                                   "rfe-task")
+
+    # Rename review file
+    if os.path.isdir(reviews_dir):
+        for filename in list(os.listdir(reviews_dir)):
+            if filename.startswith(rfe_id + "-") and \
+                    filename.endswith("-review.md"):
+                old_path = os.path.join(reviews_dir, filename)
+                new_path = os.path.join(reviews_dir,
+                                        f"{jira_key}-review.md")
+                os.rename(old_path, new_path)
+
+                # Update frontmatter
+                update_frontmatter(new_path,
+                                   {"rfe_id": jira_key},
+                                   "rfe-review")
+                break
+
+
+# ─── Index Rebuilding ───────────────────────────────────────────────────────────
+
+def rebuild_index(artifacts_dir):
+    """Rebuild artifacts/rfes.md from frontmatter across task and review files.
+
+    Scans rfe-tasks/ for task metadata and rfe-reviews/ for review scores.
+    Generates a summary table.
+
+    Returns:
+        The generated markdown string.
+    """
+    tasks = scan_task_files(artifacts_dir)
+    reviews = scan_review_files(artifacts_dir)
+
+    # Build review lookup by rfe_id
+    review_by_id = {}
+    for _, review_data in reviews:
+        review_by_id[review_data["rfe_id"]] = review_data
+
+    lines = [
+        "# RFE Summary",
+        "",
+        "| ID | Title | Priority | Size | Score | Rec | Status |",
+        "|-----|-------|----------|------|-------|-----|--------|",
+    ]
+
+    for _, task_data in tasks:
+        rfe_id = task_data["rfe_id"]
+        title = task_data.get("title", "Untitled")
+        priority = task_data.get("priority", "—")
+        size = task_data.get("size") or "—"
+        status = task_data.get("status", "—")
+
+        review = review_by_id.get(rfe_id)
+        if review:
+            score = f"{review['score']}/10"
+            rec = review["recommendation"]
+        else:
+            score = "—"
+            rec = "—"
+
+        # Strikethrough archived entries
+        if status == "Archived":
+            lines.append(
+                f"| ~~{rfe_id}~~ | ~~{title}~~ "
+                f"| ~~{priority}~~ | ~~{size}~~ | ~~{score}~~ "
+                f"| ~~{rec}~~ | {status} |"
+            )
+        else:
+            lines.append(
+                f"| {rfe_id} | {title} "
+                f"| {priority} | {size} | {score} "
+                f"| {rec} | {status} |"
+            )
+
+    content = "\n".join(lines) + "\n"
+
+    rfes_path = os.path.join(artifacts_dir, "rfes.md")
+    with open(rfes_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+    return content
+
+
+# ─── Legacy Compatibility ──────────────────────────────────────────────────────
+
+def parse_child_artifact(path):
+    """Parse a child RFE markdown file.
+
+    Returns: (title, priority, full_markdown, cleaned_markdown)
+    - full_markdown: original content (for archival comment)
+    - cleaned_markdown: metadata stripped (for Jira description)
+
+    Reads title and priority from frontmatter if available,
+    falls back to parsing markdown content.
+    """
+    from jira_utils import strip_metadata
+
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    data, body = read_frontmatter(path)
+
+    if data.get("title"):
+        title = data["title"]
+    else:
+        title_match = re.match(r'^#\s+RFE-\d+:\s+(.+)$', content,
+                               re.MULTILINE)
+        title = title_match.group(1).strip() if title_match else "Untitled"
+
+    if data.get("priority"):
+        priority = data["priority"]
+    else:
+        priority_match = re.search(r'^\*\*Priority\*\*:\s*(.+)$', content,
+                                   re.MULTILINE)
+        priority = priority_match.group(1).strip() \
+            if priority_match else "Normal"
+
+    cleaned = strip_metadata(content)
+    return title, priority, content, cleaned

--- a/scripts/frontmatter.py
+++ b/scripts/frontmatter.py
@@ -8,6 +8,7 @@ Usage:
     # Show schema for a file type
     python3 scripts/frontmatter.py schema rfe-task
     python3 scripts/frontmatter.py schema rfe-review
+    python3 scripts/frontmatter.py schema strat-task
     python3 scripts/frontmatter.py schema strat-review
 
     # Set/update frontmatter on a file (validates before writing)
@@ -74,6 +75,8 @@ def _detect_schema_type(path):
         return "rfe-review"
     if "/rfe-tasks/" in path or "rfe-tasks/" in path:
         return "rfe-task"
+    if "/strat-tasks/" in path or "strat-tasks/" in path:
+        return "strat-task"
     if "/strat-reviews/" in path or "strat-reviews/" in path:
         return "strat-review"
     return None

--- a/scripts/frontmatter.py
+++ b/scripts/frontmatter.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""CLI for reading, writing, and inspecting artifact frontmatter.
+
+Skills call this script instead of writing YAML by hand, ensuring
+schema-validated frontmatter on all artifact files.
+
+Usage:
+    # Show schema for a file type
+    python3 scripts/frontmatter.py schema rfe-task
+    python3 scripts/frontmatter.py schema rfe-review
+    python3 scripts/frontmatter.py schema strat-review
+
+    # Set/update frontmatter on a file (validates before writing)
+    python3 scripts/frontmatter.py set artifacts/rfe-tasks/RFE-001-foo.md \\
+        --rfe_id RFE-001 --title "My RFE" --priority Major --size M \\
+        --status Draft
+
+    # Set nested fields with dot notation
+    python3 scripts/frontmatter.py set artifacts/rfe-reviews/RFE-001-foo-review.md \\
+        --rfe_id RFE-001 --score 9 --pass true --recommendation submit \\
+        --feasibility feasible --revised false --needs_attention false \\
+        --scores.what 2 --scores.why 1 --scores.open_to_how 2 \\
+        --scores.not_a_task 2 --scores.right_sized 2
+
+    # Read and validate frontmatter from a file
+    python3 scripts/frontmatter.py read artifacts/rfe-tasks/RFE-001-foo.md
+
+    # Rebuild the rfes.md index from all task and review files
+    python3 scripts/frontmatter.py rebuild-index [--artifacts-dir artifacts]
+"""
+
+import argparse
+import json
+import os
+import sys
+
+from artifact_utils import (
+    SCHEMAS,
+    get_schema_yaml,
+    read_frontmatter,
+    read_frontmatter_validated,
+    write_frontmatter,
+    update_frontmatter,
+    rebuild_index,
+    ValidationError,
+)
+
+
+def _coerce_value(value_str, field_spec):
+    """Coerce a CLI string value to the correct type based on field spec."""
+    field_type = field_spec.get("type", "string")
+
+    if field_type == "bool":
+        if value_str.lower() in ("true", "1", "yes"):
+            return True
+        if value_str.lower() in ("false", "0", "no"):
+            return False
+        raise ValueError(f"Cannot convert '{value_str}' to bool")
+
+    if field_type == "int":
+        return int(value_str)
+
+    if field_type == "string":
+        if value_str.lower() == "null" or value_str.lower() == "none":
+            return None
+        return value_str
+
+    return value_str
+
+
+def _detect_schema_type(path):
+    """Detect schema type from file path."""
+    if "/rfe-reviews/" in path or "rfe-reviews/" in path:
+        return "rfe-review"
+    if "/rfe-tasks/" in path or "rfe-tasks/" in path:
+        return "rfe-task"
+    if "/strat-reviews/" in path or "strat-reviews/" in path:
+        return "strat-review"
+    return None
+
+
+def cmd_schema(args):
+    """Print the schema for a file type."""
+    try:
+        yaml_str = get_schema_yaml(args.schema_type)
+        print(yaml_str)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_read(args):
+    """Read and display frontmatter from a file."""
+    if not os.path.exists(args.file):
+        print(f"Error: {args.file} not found", file=sys.stderr)
+        sys.exit(1)
+
+    schema_type = args.schema_type or _detect_schema_type(args.file)
+
+    if schema_type:
+        try:
+            data, _ = read_frontmatter_validated(args.file, schema_type)
+        except ValidationError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        data, _ = read_frontmatter(args.file)
+        if not data:
+            print(f"Error: no frontmatter found in {args.file}",
+                  file=sys.stderr)
+            sys.exit(1)
+
+    # Output as JSON for easy parsing by callers
+    json.dump(data, sys.stdout, indent=2, default=str)
+    print()
+
+
+def cmd_set(args):
+    """Set/update frontmatter fields on a file."""
+    schema_type = args.schema_type or _detect_schema_type(args.file)
+    if not schema_type:
+        print("Error: cannot detect schema type from path. "
+              "Use --schema-type.", file=sys.stderr)
+        sys.exit(1)
+
+    schema = SCHEMAS[schema_type]
+
+    # Parse field=value pairs from remaining args
+    data = {}
+    for field_value in args.fields:
+        if "=" not in field_value:
+            print(f"Error: expected field=value, got '{field_value}'",
+                  file=sys.stderr)
+            sys.exit(1)
+
+        field_name, value_str = field_value.split("=", 1)
+
+        # Handle dot notation for nested fields (e.g., scores.what=2)
+        if "." in field_name:
+            parts = field_name.split(".", 1)
+            parent_name, child_name = parts
+            if parent_name not in schema:
+                print(f"Error: unknown field '{parent_name}'",
+                      file=sys.stderr)
+                sys.exit(1)
+            parent_spec = schema[parent_name]
+            if parent_spec.get("type") != "dict":
+                print(f"Error: '{parent_name}' is not a dict field",
+                      file=sys.stderr)
+                sys.exit(1)
+            nested_fields = parent_spec.get("fields", {})
+            if child_name not in nested_fields:
+                print(f"Error: unknown field '{field_name}'",
+                      file=sys.stderr)
+                sys.exit(1)
+            coerced = _coerce_value(value_str, nested_fields[child_name])
+            if parent_name not in data:
+                data[parent_name] = {}
+            data[parent_name][child_name] = coerced
+        else:
+            if field_name not in schema:
+                print(f"Error: unknown field '{field_name}' for schema "
+                      f"'{schema_type}'", file=sys.stderr)
+                sys.exit(1)
+            data[field_name] = _coerce_value(value_str, schema[field_name])
+
+    if os.path.exists(args.file):
+        try:
+            update_frontmatter(args.file, data, schema_type)
+        except ValidationError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        try:
+            write_frontmatter(args.file, data, schema_type)
+        except ValidationError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    print(f"OK: {args.file}")
+
+
+def cmd_rebuild_index(args):
+    """Rebuild rfes.md index from frontmatter."""
+    content = rebuild_index(args.artifacts_dir)
+    print(f"Rebuilt {args.artifacts_dir}/rfes.md")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Artifact frontmatter CLI",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # schema
+    p_schema = subparsers.add_parser("schema",
+                                     help="Show schema for a file type")
+    p_schema.add_argument("schema_type",
+                          choices=list(SCHEMAS.keys()),
+                          help="Schema type to display")
+    p_schema.set_defaults(func=cmd_schema)
+
+    # read
+    p_read = subparsers.add_parser("read",
+                                   help="Read frontmatter from a file")
+    p_read.add_argument("file", help="Path to the markdown file")
+    p_read.add_argument("--schema-type", dest="schema_type",
+                        choices=list(SCHEMAS.keys()),
+                        help="Schema type (auto-detected from path if omitted)")
+    p_read.set_defaults(func=cmd_read)
+
+    # set
+    p_set = subparsers.add_parser(
+        "set", help="Set/update frontmatter fields")
+    p_set.add_argument("file", help="Path to the markdown file")
+    p_set.add_argument("fields", nargs="+",
+                       help="Fields as field=value pairs. Use dot notation "
+                            "for nested fields (e.g., scores.what=2)")
+    p_set.add_argument("--schema-type", dest="schema_type",
+                       choices=list(SCHEMAS.keys()),
+                       help="Schema type (auto-detected from path if omitted)")
+    p_set.set_defaults(func=cmd_set)
+
+    # rebuild-index
+    p_rebuild = subparsers.add_parser("rebuild-index",
+                                     help="Rebuild rfes.md index")
+    p_rebuild.add_argument("--artifacts-dir", default="artifacts",
+                           help="Artifacts directory (default: artifacts)")
+    p_rebuild.set_defaults(func=cmd_rebuild_index)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -594,11 +594,9 @@ def strip_metadata(markdown):
 
     Strips:
     - YAML frontmatter (--- delimited block at start of file)
-    - # RFE-NNN: Title headings (duplicates Summary field)
-    - **Jira Key**: ... lines
-    - **Size**: ... lines
-    - **Split from**: ... lines
-    - **Priority**: ... lines
+    - # RFE-NNN: / # STRAT-NNN: Title headings (duplicates Summary field)
+    - Legacy inline metadata lines (now in frontmatter):
+      **Jira Key**, **Size**, **Split from**, **Priority**, **Source RFE**
     - ### Revision Notes sections (to next ## or EOF)
     - > *Review note: ...* blockquotes
     - <!-- REVISION NOTE: ... --> HTML comments
@@ -614,12 +612,13 @@ def strip_metadata(markdown):
     in_revision_notes = False
 
     for line in lines:
-        # Skip title heading (e.g. "# RFE-002: Title") — duplicates Summary
-        if re.match(r'^#\s+RFE-\d+:', line):
+        # Skip title heading — duplicates Summary
+        if re.match(r'^#\s+(RFE-\d+|STRAT-\d+):', line):
             continue
 
-        # Skip metadata lines
-        if re.match(r'^\*\*(Jira Key|Size|Split from|Priority)\*\*:', line):
+        # Skip metadata lines (legacy inline format, now in frontmatter)
+        if re.match(r'^\*\*(Jira Key|Size|Split from|Priority|'
+                    r'Source RFE)\*\*:', line):
             continue
 
         # Skip HTML revision comments

--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -592,14 +592,15 @@ def adf_to_markdown(node, list_depth=0):
 def strip_metadata(markdown):
     """Remove artifact metadata and revision notes from RFE markdown.
 
-    Strips:
+    Strips content that should not be pushed to Jira:
     - YAML frontmatter (--- delimited block at start of file)
-    - # RFE-NNN: / # STRAT-NNN: Title headings (duplicates Summary field)
+    - Title headings (# RFE-NNN: / # RHAIRFE-NNN: / # STRAT-NNN: / # RHAISTRAT-NNN:)
+      — title is in frontmatter and Jira's summary field
     - Legacy inline metadata lines (now in frontmatter):
       **Jira Key**, **Size**, **Split from**, **Priority**, **Source RFE**
-    - ### Revision Notes sections (to next ## or EOF)
-    - > *Review note: ...* blockquotes
-    - <!-- REVISION NOTE: ... --> HTML comments
+    - Legacy revision notes (now in review files):
+      ### Revision Notes sections, > *Review note: ...* blockquotes,
+      <!-- REVISION NOTE: ... --> HTML comments
     """
     # Strip YAML frontmatter if present
     frontmatter_match = re.match(r'^---\s*\n.*?\n---\s*\n', markdown,
@@ -613,7 +614,8 @@ def strip_metadata(markdown):
 
     for line in lines:
         # Skip title heading — duplicates Summary
-        if re.match(r'^#\s+(RFE-\d+|STRAT-\d+):', line):
+        if re.match(r'^#\s+(RFE-\d+|RHAIRFE-\d+|STRAT-\d+|RHAISTRAT-\d+):',
+                    line):
             continue
 
         # Skip metadata lines (legacy inline format, now in frontmatter)

--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -593,6 +593,7 @@ def strip_metadata(markdown):
     """Remove artifact metadata and revision notes from RFE markdown.
 
     Strips:
+    - YAML frontmatter (--- delimited block at start of file)
     - # RFE-NNN: Title headings (duplicates Summary field)
     - **Jira Key**: ... lines
     - **Size**: ... lines
@@ -602,6 +603,12 @@ def strip_metadata(markdown):
     - > *Review note: ...* blockquotes
     - <!-- REVISION NOTE: ... --> HTML comments
     """
+    # Strip YAML frontmatter if present
+    frontmatter_match = re.match(r'^---\s*\n.*?\n---\s*\n', markdown,
+                                 re.DOTALL)
+    if frontmatter_match:
+        markdown = markdown[frontmatter_match.end():]
+
     lines = markdown.split("\n")
     result = []
     in_revision_notes = False
@@ -641,88 +648,3 @@ def strip_metadata(markdown):
     return cleaned.strip()
 
 
-def find_artifact_file(artifacts_dir, rfe_id):
-    """Find the main artifact file for a given RFE ID."""
-    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
-    if not os.path.isdir(tasks_dir):
-        return None
-    for filename in os.listdir(tasks_dir):
-        if filename.startswith(rfe_id + "-") and filename.endswith(".md"):
-            if filename.endswith(("-comments.md", "-removed-context.md")):
-                continue
-            return os.path.join(tasks_dir, filename)
-    return None
-
-
-def find_removed_context_file(artifacts_dir, rfe_id):
-    """Find the removed-context file for a given RFE ID, if any."""
-    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
-    if not os.path.isdir(tasks_dir):
-        return None
-    for filename in os.listdir(tasks_dir):
-        if (filename.startswith(rfe_id + "-") and
-                filename.endswith("-removed-context.md")):
-            return os.path.join(tasks_dir, filename)
-    return None
-
-
-def parse_child_artifact(path):
-    """Parse a child RFE markdown file.
-
-    Returns: (title, priority, full_markdown, cleaned_markdown)
-    - full_markdown: original content (for archival comment)
-    - cleaned_markdown: metadata stripped (for Jira description)
-    """
-    with open(path, encoding="utf-8") as f:
-        content = f.read()
-
-    title_match = re.match(r'^#\s+RFE-\d+:\s+(.+)$', content, re.MULTILINE)
-    title = title_match.group(1).strip() if title_match else "Untitled"
-
-    priority_match = re.search(r'^\*\*Priority\*\*:\s*(.+)$', content,
-                               re.MULTILINE)
-    priority = priority_match.group(1).strip() if priority_match else "Normal"
-
-    cleaned = strip_metadata(content)
-    return title, priority, content, cleaned
-
-
-def check_needs_attention(artifacts_dir, rfe_id):
-    """Check the review report to determine if this RFE needs human attention.
-
-    Returns True if:
-    - Any criterion scored below full marks (2/2) after auto-revision
-    - The RFE has a recommendation other than 'submit'
-    """
-    report_path = os.path.join(artifacts_dir, "rfe-review-report.md")
-    if not os.path.exists(report_path):
-        return False
-
-    with open(report_path, encoding="utf-8") as f:
-        report = f.read()
-
-    in_rfe_section = False
-    for line in report.split("\n"):
-        if re.match(rf'^###\s+{re.escape(rfe_id)}:', line):
-            in_rfe_section = True
-            continue
-        if in_rfe_section and re.match(r'^###\s+RFE-', line):
-            break
-        if in_rfe_section:
-            score_match = re.match(r'^\|\s*\w.*?\|\s*(\d)/2\s*\|', line)
-            if score_match and int(score_match.group(1)) < 2:
-                return True
-            if re.match(r'^\*\*Recommendation\*\*:\s*(revise|split|reject)',
-                        line, re.IGNORECASE):
-                return True
-
-    return False
-
-
-def has_revision_notes(artifact_path):
-    """Check if an artifact contains Revision Notes (was auto-revised)."""
-    with open(artifact_path, encoding="utf-8") as f:
-        for line in f:
-            if re.match(r'^###?\s+Revision Notes', line):
-                return True
-    return False

--- a/scripts/rebuild_index.py
+++ b/scripts/rebuild_index.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Rebuild artifacts/rfes.md index from frontmatter across task and review files.
+
+Called at the end of batch/review/submit operations. Not called per-issue
+during parallel runs — only once after all per-issue work completes.
+
+Usage:
+    python3 scripts/rebuild_index.py [--artifacts-dir artifacts]
+"""
+
+import argparse
+import sys
+
+from artifact_utils import rebuild_index
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--artifacts-dir", default="artifacts",
+                        help="Artifacts directory (default: artifacts)")
+    args = parser.parse_args()
+
+    content = rebuild_index(args.artifacts_dir)
+    print(f"Rebuilt {args.artifacts_dir}/rfes.md")
+
+    # Count entries
+    lines = [l for l in content.split("\n")
+             if l.startswith("|") and not l.startswith("| ID")
+             and not l.startswith("|---")]
+    print(f"  {len(lines)} RFEs indexed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -5,6 +5,10 @@ Submits child RFEs produced by /rfe.split to Jira with proper linking and
 parent closure. Designed to be idempotent and resumable — uses Jira comments
 as the durable store for content and progress tracking.
 
+Reads all structured metadata from YAML frontmatter on task files.
+Identifies parent (status: Archived, rfe_id matches parent key) and children
+(parent_key matches parent's rfe_id) from frontmatter.
+
 Usage:
     python scripts/split_submit.py RHAIRFE-XXXX [--dry-run] [--artifacts-dir DIR]
 
@@ -32,48 +36,20 @@ from jira_utils import (
     markdown_to_adf,
     text_to_adf_paragraph,
     archival_comment_adf,
-    find_artifact_file,
-    parse_child_artifact,
-    check_needs_attention,
-    has_revision_notes,
+    strip_metadata,
 )
 
-
-# ─── rfes.md Parsing (split-specific) ───────────────────────────────────────
-
-def parse_rfes_md(path):
-    """Parse artifacts/rfes.md to find parent key and child RFE list.
-
-    Returns: (parent_key, [(rfe_id, title, priority), ...])
-    """
-    with open(path, encoding="utf-8") as f:
-        content = f.read()
-
-    parent_key = None
-    children = []
-
-    for line in content.split("\n"):
-        row_match = re.match(
-            r'^\|\s*~*\s*(RFE-\d+)\s*~*\s*\|\s*(.*?)\s*\|\s*(.*?)\s*\|'
-            r'\s*(.*?)\s*\|\s*(.*?)\s*\|\s*(.*?)\s*\|',
-            line
-        )
-        if not row_match:
-            continue
-
-        rfe_id = row_match.group(1).strip().strip("~")
-        title = row_match.group(2).strip().strip("~")
-        jira_key = row_match.group(3).strip().strip("~")
-        priority = row_match.group(4).strip().strip("~")
-        status = row_match.group(6).strip()
-
-        if ("Archived" in status or "Split" in status) and \
-                jira_key and jira_key != "—":
-            parent_key = jira_key
-        elif "Draft" in status and (jira_key == "—" or not jira_key):
-            children.append((rfe_id, title, priority))
-
-    return parent_key, children
+from artifact_utils import (
+    read_frontmatter,
+    read_frontmatter_validated,
+    update_frontmatter,
+    scan_task_files,
+    find_review_file,
+    rename_to_jira_key,
+    rebuild_index,
+    parse_child_artifact,
+    ValidationError,
+)
 
 
 # ─── Recovery / State Detection ──────────────────────────────────────────────
@@ -140,7 +116,7 @@ def discover_state(server, user, token, parent_key, expected_children):
             continue
         child_key = outward["key"]
         child_summary = outward.get("fields", {}).get("summary", "")
-        for idx, (_, title, _) in enumerate(expected_children, 1):
+        for idx, (_, title, _, _) in enumerate(expected_children, 1):
             if title == child_summary and idx not in state.phase2_done:
                 state.phase2_done[idx] = child_key
 
@@ -195,12 +171,20 @@ def phase2_create_link(server, user, token, parent_key, children, state,
         _, _, _, cleaned_markdown = parse_child_artifact(artifact_path)
         description_adf = markdown_to_adf(cleaned_markdown)
 
-        # Determine labels
+        # Determine labels from review frontmatter
         labels = ["rfe-creator-auto-created", "rfe-creator-split-result"]
-        if has_revision_notes(artifact_path):
-            labels.append("rfe-creator-auto-revised")
-        if check_needs_attention(artifacts_dir, rfe_id):
-            labels.append("rfe-creator-needs-attention")
+
+        review_path = find_review_file(artifacts_dir, rfe_id)
+        if review_path:
+            try:
+                review_data, _ = read_frontmatter_validated(
+                    review_path, "rfe-review")
+                if review_data.get("revised", False):
+                    labels.append("rfe-creator-auto-revised")
+                if review_data.get("needs_attention", False):
+                    labels.append("rfe-creator-needs-attention")
+            except (ValidationError, Exception):
+                pass  # proceed without review data
 
         if dry_run:
             print(f"  Phase 2: Would create RHAIRFE ticket for child "
@@ -318,41 +302,49 @@ def main():
               file=sys.stderr)
         sys.exit(1)
 
-    # Parse rfes.md
-    rfes_path = os.path.join(args.artifacts_dir, "rfes.md")
-    if not os.path.exists(rfes_path):
-        print(f"Error: {rfes_path} not found. Run /rfe.split first.",
+    # Scan task files to find parent and children via frontmatter
+    tasks = scan_task_files(args.artifacts_dir)
+    if not tasks:
+        print("Error: No task files found. Run /rfe.split first.",
               file=sys.stderr)
         sys.exit(1)
 
-    parent_key, child_refs = parse_rfes_md(rfes_path)
+    # Find parent: status=Archived with matching rfe_id
+    parent_task = None
+    for path, data in tasks:
+        if data.get("status") == "Archived" and \
+                data.get("rfe_id") == args.parent_key:
+            parent_task = (path, data)
+            break
 
-    if not parent_key:
-        print("Error: No archived (split) parent RFE found in rfes.md.",
-              file=sys.stderr)
+    if not parent_task:
+        print(f"Error: No archived parent with rfe_id={args.parent_key} "
+              f"found in task files.", file=sys.stderr)
         sys.exit(1)
 
-    if parent_key != args.parent_key:
-        print(f"Error: Parent key in rfes.md ({parent_key}) does not match "
-              f"argument ({args.parent_key}).", file=sys.stderr)
+    # Find children: parent_key matches the parent's rfe_id
+    child_tasks = []
+    for path, data in tasks:
+        if data.get("parent_key") == args.parent_key and \
+                data.get("status") != "Archived":
+            child_tasks.append((path, data))
+
+    if not child_tasks:
+        print("Error: No child RFEs found with parent_key="
+              f"{args.parent_key}.", file=sys.stderr)
         sys.exit(1)
 
-    if not child_refs:
-        print("Error: No draft child RFEs found in rfes.md.",
-              file=sys.stderr)
-        sys.exit(1)
-
-    # Resolve artifact files
+    # Build children list: (rfe_id, title, priority, artifact_path)
     children = []
-    for rfe_id, title, priority in child_refs:
-        artifact_path = find_artifact_file(args.artifacts_dir, rfe_id)
-        if not artifact_path:
-            print(f"Error: No artifact file found for {rfe_id} in "
-                  f"{args.artifacts_dir}/rfe-tasks/", file=sys.stderr)
-            sys.exit(1)
-        children.append((rfe_id, title, priority, artifact_path))
+    for path, data in child_tasks:
+        children.append((
+            data["rfe_id"],
+            data["title"],
+            data["priority"],
+            path,
+        ))
 
-    print(f"Split submission: {parent_key} -> {len(children)} children")
+    print(f"Split submission: {args.parent_key} -> {len(children)} children")
     for i, (rfe_id, title, priority, _) in enumerate(children, 1):
         print(f"  {i}. {rfe_id}: {title} (Priority: {priority})")
     print()
@@ -365,9 +357,8 @@ def main():
         state.total_children = len(children)
     else:
         print("Checking submission state...")
-        state = discover_state(server, user, token, parent_key,
-                               [(rfe_id, title, priority)
-                                for rfe_id, title, priority, _ in children])
+        state = discover_state(server, user, token, args.parent_key,
+                               children)
         if state.phase1_done:
             print(f"  Phase 1: {len(state.phase1_done)}/{len(children)} "
                   f"archival comments found")
@@ -382,34 +373,33 @@ def main():
 
     # Run phases
     print("Phase 1: Persisting child RFE content to parent comments...")
-    phase1_persist(server, user, token, parent_key, children, state,
+    phase1_persist(server, user, token, args.parent_key, children, state,
                    args.dry_run)
     print()
 
     print("Phase 2: Creating tickets and linking...")
-    phase2_create_link(server, user, token, parent_key, children, state,
+    phase2_create_link(server, user, token, args.parent_key, children, state,
                        args.artifacts_dir, args.dry_run)
     print()
 
     print("Phase 3: Closing parent...")
-    phase3_close(server, user, token, parent_key, children, state,
+    phase3_close(server, user, token, args.parent_key, children, state,
                  args.dry_run)
     print()
 
-    # Write local mapping file
-    mapping_path = os.path.join(args.artifacts_dir, "jira-tickets.md")
-    with open(mapping_path, "w", encoding="utf-8") as f:
-        f.write("# Jira Tickets\n\n")
-        f.write("| RFE | Jira Key | Title | Priority | URL |\n")
-        f.write("|-----|----------|-------|----------|-----|\n")
-        site = server.rstrip("/") if server else "https://example.atlassian.net"
-        for idx, (rfe_id, title, priority, _) in enumerate(children, 1):
-            key = state.phase2_done.get(idx, "—")
-            url = f"{site}/browse/{key}" if key != "—" else "—"
-            f.write(f"| {rfe_id} | {key} | {title} | {priority} "
-                    f"| {url} |\n")
+    # Post-submit: update frontmatter and rename files
+    for idx, (rfe_id, title, priority, artifact_path) in \
+            enumerate(children, 1):
+        assigned_key = state.phase2_done.get(idx)
+        if not assigned_key or assigned_key == "RHAIRFE-DRY":
+            continue
 
-    print(f"Done. Ticket mapping written to {mapping_path}")
+        rename_to_jira_key(args.artifacts_dir, rfe_id, assigned_key)
+        print(f"  {rfe_id}: Renamed artifacts to {assigned_key}")
+
+    # Rebuild index
+    rebuild_index(args.artifacts_dir)
+    print(f"Done. Index rebuilt at {args.artifacts_dir}/rfes.md")
 
 
 if __name__ == "__main__":

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -4,6 +4,9 @@
 Handles the standard (non-split) submission flow. For split submissions,
 use split_submit.py instead.
 
+Reads all structured metadata from YAML frontmatter on task and review files.
+No regex parsing of markdown prose.
+
 Usage:
     python scripts/submit.py [--dry-run] [--artifacts-dir DIR]
 
@@ -26,92 +29,20 @@ from jira_utils import (
     add_comment,
     strip_metadata,
     markdown_to_adf,
-    find_artifact_file,
-    find_removed_context_file,
-    check_needs_attention,
-    has_revision_notes,
 )
 
-
-def parse_rfes_md(path):
-    """Parse artifacts/rfes.md to find submittable RFEs.
-
-    Returns: [(rfe_id, title, jira_key_or_none, priority, size, status), ...]
-    Skips header/separator rows and archived/split entries.
-    """
-    with open(path, encoding="utf-8") as f:
-        content = f.read()
-
-    rfes = []
-    for line in content.split("\n"):
-        row_match = re.match(
-            r'^\|\s*~*\s*(RFE-\d+)\s*~*\s*\|'
-            r'\s*(.*?)\s*\|'
-            r'\s*(.*?)\s*\|'
-            r'\s*(.*?)\s*\|'
-            r'\s*(.*?)\s*\|'
-            r'\s*(.*?)\s*\|',
-            line
-        )
-        if not row_match:
-            continue
-
-        rfe_id = row_match.group(1).strip().strip("~")
-        title = row_match.group(2).strip().strip("~")
-        jira_key = row_match.group(3).strip().strip("~")
-        priority = row_match.group(4).strip().strip("~")
-        size = row_match.group(5).strip().strip("~")
-        status = row_match.group(6).strip()
-
-        # Skip archived/split entries
-        if "Split" in status or "Archived" in status or "split" in status:
-            continue
-
-        jira_key = jira_key if jira_key and jira_key != "—" else None
-        rfes.append((rfe_id, title, jira_key, priority, size, status))
-
-    return rfes
-
-
-def parse_review_report(artifacts_dir):
-    """Parse review report to find per-RFE recommendations.
-
-    Returns: {rfe_id: recommendation} or None if no report exists.
-    Recommendation is 'submit', 'revise', 'reject', or 'split'.
-    """
-    report_path = os.path.join(artifacts_dir, "rfe-review-report.md")
-    if not os.path.exists(report_path):
-        return None
-
-    recommendations = {}
-    current_rfe = None
-
-    with open(report_path, encoding="utf-8") as f:
-        for line in f:
-            rfe_match = re.match(r'^###\s+(RFE-\d+):', line)
-            if rfe_match:
-                current_rfe = rfe_match.group(1)
-                continue
-
-            if current_rfe:
-                rec_match = re.match(
-                    r'^\*\*Recommendation\*\*:\s*\*\*(\w+)\*\*', line
-                )
-                if rec_match:
-                    recommendations[current_rfe] = rec_match.group(1).lower()
-                    current_rfe = None
-
-    return recommendations
-
-
-def parse_artifact_title(path):
-    """Extract the title from an RFE artifact, without the RFE-NNN prefix."""
-    with open(path, encoding="utf-8") as f:
-        for line in f:
-            title_match = re.match(r'^#\s+(?:RFE-\d+:\s+)?(.+)$', line)
-            if title_match:
-                return title_match.group(1).strip()
-    return "Untitled"
+from artifact_utils import (
+    read_frontmatter,
+    read_frontmatter_validated,
+    update_frontmatter,
+    scan_task_files,
+    find_artifact_file,
+    find_removed_context_file,
+    find_review_file,
+    rename_to_jira_key,
+    rebuild_index,
+    ValidationError,
+)
 
 
 def main():
@@ -134,62 +65,69 @@ def main():
               file=sys.stderr)
         sys.exit(1)
 
-    # Parse rfes.md
-    rfes_path = os.path.join(args.artifacts_dir, "rfes.md")
-    if not os.path.exists(rfes_path):
-        print(f"Error: {rfes_path} not found.", file=sys.stderr)
+    # Scan task files for submittable RFEs
+    tasks = scan_task_files(args.artifacts_dir)
+    if not tasks:
+        print("Error: No RFE task files found.", file=sys.stderr)
         sys.exit(1)
 
-    rfes = parse_rfes_md(rfes_path)
-    if not rfes:
-        print("Error: No submittable RFEs found in rfes.md.", file=sys.stderr)
+    # Filter to non-archived RFEs
+    submittable = [(path, data) for path, data in tasks
+                   if data.get("status") != "Archived"]
+    if not submittable:
+        print("Error: No submittable RFEs found (all archived).",
+              file=sys.stderr)
         sys.exit(1)
-
-    # Parse review report
-    recommendations = parse_review_report(args.artifacts_dir)
-    if recommendations is None:
-        print("Warning: No review report found. Submitting without review "
-              "validation.", file=sys.stderr)
 
     # Build submission plan
     plan = []
-    for rfe_id, title, jira_key, priority, size, status in rfes:
-        artifact_path = find_artifact_file(args.artifacts_dir, rfe_id)
-        if not artifact_path:
-            print(f"Warning: No artifact file for {rfe_id}, skipping.",
-                  file=sys.stderr)
-            continue
+    for task_path, task_data in submittable:
+        rfe_id = task_data["rfe_id"]
+        title = task_data["title"]
+        is_existing = rfe_id.startswith("RHAIRFE-")
+        priority = task_data["priority"]
+        size = task_data.get("size", "M")
 
-        # Use title from artifact (cleaner than rfes.md table)
-        artifact_title = parse_artifact_title(artifact_path)
+        # Read review frontmatter if available
+        review_path = find_review_file(args.artifacts_dir, rfe_id)
+        review_data = None
+        if review_path:
+            try:
+                review_data, _ = read_frontmatter_validated(
+                    review_path, "rfe-review")
+            except (ValidationError, Exception) as e:
+                print(f"Warning: cannot read review for {rfe_id}: {e}",
+                      file=sys.stderr)
 
-        # Check review recommendation
-        rec = (recommendations or {}).get(rfe_id, "submit")
+        # Get recommendation from review
+        rec = "submit"
+        if review_data:
+            rec = review_data.get("recommendation", "submit")
+
         if rec == "reject":
             plan.append({
-                "rfe_id": rfe_id, "title": artifact_title,
-                "jira_key": jira_key, "priority": priority, "size": size,
+                "rfe_id": rfe_id, "title": title,
+                "is_existing": is_existing, "priority": priority, "size": size,
                 "action": "SKIP", "labels": [], "skip_reason": "rejected",
-                "artifact_path": artifact_path,
+                "task_path": task_path,
             })
             continue
 
         # Determine labels
         labels = []
-        if not jira_key:
+        if not is_existing:
             labels.append("rfe-creator-auto-created")
-        if has_revision_notes(artifact_path):
+        if review_data and review_data.get("revised", False):
             labels.append("rfe-creator-auto-revised")
-        if rec == "revise" or check_needs_attention(args.artifacts_dir,
-                                                     rfe_id):
+        if review_data and review_data.get("needs_attention", False):
             labels.append("rfe-creator-needs-attention")
 
-        action = f"Update {jira_key}" if jira_key else "Create"
+        action = f"Update {rfe_id}" if is_existing else "Create"
         plan.append({
-            "rfe_id": rfe_id, "title": artifact_title,
-            "jira_key": jira_key, "priority": priority, "size": size,
+            "rfe_id": rfe_id, "title": title,
+            "is_existing": is_existing, "priority": priority, "size": size,
             "action": action, "labels": labels, "skip_reason": None,
-            "artifact_path": artifact_path,
+            "task_path": task_path,
         })
 
     # Print summary
@@ -208,7 +146,7 @@ def main():
     print()
 
     # Execute
-    results = {}  # rfe_id -> jira_key
+    results = {}  # rfe_id -> assigned jira key
     for entry in plan:
         rfe_id = entry["rfe_id"]
         if entry["skip_reason"]:
@@ -216,27 +154,26 @@ def main():
             continue
 
         # Read and clean artifact content
-        with open(entry["artifact_path"], encoding="utf-8") as f:
+        with open(entry["task_path"], encoding="utf-8") as f:
             raw_content = f.read()
         cleaned = strip_metadata(raw_content)
         description_adf = markdown_to_adf(cleaned)
 
-        jira_key = entry["jira_key"]
         title = entry["title"]
         labels = entry["labels"]
 
-        if jira_key:
-            # Update existing ticket
+        if entry["is_existing"]:
+            # Update existing ticket (rfe_id is the Jira key)
             if args.dry_run:
-                print(f"  {rfe_id}: Would update {jira_key}")
+                print(f"  {rfe_id}: Would update")
             else:
-                update_issue(server, user, token, jira_key, title,
+                update_issue(server, user, token, rfe_id, title,
                              description_adf)
-                print(f"  {rfe_id}: Updated {jira_key}")
+                print(f"  {rfe_id}: Updated")
                 if labels:
-                    add_labels(server, user, token, jira_key, labels)
+                    add_labels(server, user, token, rfe_id, labels)
                     print(f"           Labels: {', '.join(labels)}")
-            results[rfe_id] = jira_key
+            results[rfe_id] = rfe_id
         else:
             # Create new ticket
             if args.dry_run:
@@ -268,28 +205,29 @@ def main():
 
     print()
 
-    # Write ticket mapping
-    mapping_path = os.path.join(args.artifacts_dir, "jira-tickets.md")
-    site = (server.rstrip("/") if server
-            else "https://example.atlassian.net")
-    with open(mapping_path, "w", encoding="utf-8") as f:
-        f.write("# Jira Tickets\n\n")
-        f.write("| RFE | Jira Key | Title | Priority | URL |\n")
-        f.write("|-----|----------|-------|----------|-----|\n")
-        for entry in plan:
-            rfe_id = entry["rfe_id"]
-            key = results.get(rfe_id, "—")
-            if entry["skip_reason"]:
-                key = f"SKIPPED ({entry['skip_reason']})"
-                url = "—"
-            elif key and key not in ("—", "RHAIRFE-DRY"):
-                url = f"{site}/browse/{key}"
-            else:
-                url = "—"
-            f.write(f"| {rfe_id} | {key} | {entry['title']} "
-                    f"| {entry['priority']} | {url} |\n")
+    # Post-submit: update frontmatter and rename files
+    for entry in plan:
+        rfe_id = entry["rfe_id"]
+        if entry["skip_reason"]:
+            continue
 
-    print(f"Done. Ticket mapping written to {mapping_path}")
+        assigned_key = results.get(rfe_id)
+        if not assigned_key or assigned_key == "RHAIRFE-DRY":
+            continue
+
+        if not entry["is_existing"]:
+            # New RFE: rename files from RFE-NNN to RHAIRFE-NNNN
+            rename_to_jira_key(args.artifacts_dir, rfe_id, assigned_key)
+            print(f"  {rfe_id}: Renamed artifacts to {assigned_key}")
+        else:
+            # Existing: just update status
+            update_frontmatter(entry["task_path"],
+                               {"status": "Submitted"},
+                               "rfe-task")
+
+    # Rebuild index
+    rebuild_index(args.artifacts_dir)
+    print(f"Done. Index rebuilt at {args.artifacts_dir}/rfes.md")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Replace monolithic review reports and regex-parsed markdown with per-issue files using YAML frontmatter, enabling parallel-safe batch review of many Jira issues
- Add `artifact_utils.py` (schema validation + frontmatter I/O), `frontmatter.py` (CLI for skills), and `rebuild_index.py` (index generation from frontmatter)
- Consolidate `rfe_id` and `jira_key` into a single `rfe_id` field accepting both `RFE-NNN` (local) and `RHAIRFE-NNNN` (Jira) patterns

## Problem

The artifact layout assumed a single session producing a small set of related RFEs. It breaks for batch review of many existing Jira issues: local `RFE-NNN` numbering collides across runs, monolithic files (`rfe-review-report.md`, `rfes.md`, `jira-tickets.md`) create write contention and overwrite risk, and there's no stable key linking files back to Jira issues.

## Design Decisions

1. **Single `rfe_id` field** accepts both `RFE-\d+` and `RHAIRFE-\d+` patterns. Pre-submission it's `RFE-001`, on submit it becomes `RHAIRFE-1595`. No separate `jira_key` field — `rfe_id.startswith("RHAIRFE-")` tells you if it's in Jira, and `status` field tracks submission state.
2. **Per-issue review files** in `rfe-reviews/` and `strat-reviews/` instead of monolithic reports. Parallel-safe, idempotent.
3. **YAML frontmatter** on task and review files for all machine-readable data. Scripts read frontmatter via `yaml.safe_load()`, no regex parsing of prose.
4. **`rfes.md` becomes a generated index** rebuilt from frontmatter across files. Not a source of truth.
5. **`rfe-review-report.md` eliminated.** Content splits into per-issue review files (detail) and `rfes.md` (summary).
6. **`jira-tickets.md` eliminated.** Jira keys are the `rfe_id` value, surfaced in `rfes.md`.
7. **Archive by frontmatter status**, not filename convention. `status: Archived` in frontmatter, `find_artifact_file()` filters by status.
8. **Schema-validated frontmatter.** Skills call `frontmatter.py` to read schema and write frontmatter. No hand-written YAML. Validation on both write and read.

## New Files (3)

| File | Purpose |
|------|---------|
| `scripts/artifact_utils.py` | Schema definitions, frontmatter read/write/validate, file discovery, rename-on-submit, `rebuild_index()` |
| `scripts/frontmatter.py` | CLI for skills: `schema`, `set`, `read`, `rebuild-index` commands |
| `scripts/rebuild_index.py` | Standalone index generator |

## Modified Files

| File | Change |
|------|--------|
| `scripts/jira_utils.py` | Removed file discovery functions (moved to `artifact_utils.py`). Added frontmatter stripping to `strip_metadata()`. |
| `scripts/submit.py` | Uses `rfe_id.startswith("RHAIRFE-")` for create vs update. Reads review frontmatter for labels/recommendations. Calls `rename_to_jira_key()` post-submit. |
| `scripts/split_submit.py` | Finds parent by `rfe_id` match + `status: Archived`. Finds children by `parent_key`. |
| 13 skill files | Updated to use `frontmatter.py` CLI for reading schemas and writing frontmatter. Removed `jira_key` references. |
| `CLAUDE.md` | Updated artifact conventions, frontmatter docs, file naming rules. |
| `.ambient/ambient.json` | Updated result paths for per-issue review files. |

## Frontmatter Schemas

### `rfe-task`
```yaml
rfe_id: RFE-001          # or RHAIRFE-1595 — required, pattern: ^(RFE-\d+|RHAIRFE-\d+)$
title: "..."              # required
priority: Major           # required, enum: Blocker|Critical|Major|Normal|Minor|Undefined
size: M                   # optional, enum: S|M|L|XL
status: Ready             # required, enum: Draft|Ready|Submitted|Archived
parent_key: null          # optional, pattern: ^(RFE-\d+|RHAIRFE-\d+)$
```

### `rfe-review`
```yaml
rfe_id: RFE-001           # required, same pattern as above
score: 9                  # required, int
pass: true                # required, bool
recommendation: submit    # required, enum: submit|revise|split|reject
feasibility: feasible     # required, enum: feasible|infeasible
revised: false            # required, bool
needs_attention: false    # required, bool
scores:                   # required, nested dict
  what: 2
  why: 1
  open_to_how: 2
  not_a_task: 2
  right_sized: 2
```

## How Batch Works After This

1. Fetch each issue → write `rfe-tasks/RHAIRFE-NNNN.md` with `rfe_id: RHAIRFE-NNNN`
2. Review each issue (parallelizable) → write `rfe-reviews/RHAIRFE-NNNN-review.md`
3. Run `rebuild_index.py` → generates `rfes.md` from frontmatter
4. Submit → `submit.py` reads frontmatter, updates `rfe_id` and `status`, rebuilds index

No contention, no overwrites, fully idempotent on re-run.

## Test plan

- [x] Schema validation: all field types, patterns, enums, required/optional, cross-pattern acceptance (134 tests)
- [x] Frontmatter I/O: read, write, update, body preservation, file discovery, rename-on-submit
- [x] Submit edge cases: create vs update, rejected/revised/needs_attention labels, archived exclusion
- [x] `frontmatter.py` CLI: schema, set, read, rebuild-index commands
- [x] `strip_metadata()`: frontmatter stripping before Jira upload
- [x] `submit.py --dry-run` and `split_submit.py --dry-run`
- [x] Live Jira read path: `fetch_issue.py` → task file → frontmatter → index
- [x] Live `/rfe.review` skill on local artifacts (full pipeline)
- [x] Live `/rfe.create` skill (full pipeline)
- [x] Live `/rfe.submit` with single test RFE → RHAIRFE-1598 created, renamed, closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)