### PR TITLE
Add content preservation tracking and review report generation

### DIFF
--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -21,7 +21,7 @@ python3 scripts/fetch_issue.py RHAIRFE-1234 --fields summary,description,priorit
 
 The script outputs JSON to stdout with description and comment bodies already converted to markdown. Parse `fields.description`, `fields.summary`, `fields.priority.name`, and `comments` array.
 
-Write the RFE to `artifacts/rfe-tasks/<jira_key>.md` (using the Jira key as the filename) using the RFE template format (read `${CLAUDE_SKILL_DIR}/../rfe.create/rfe-template.md` for the format).
+Write the Jira description to `artifacts/rfe-tasks/<jira_key>.md` as-is — preserve the original markdown structure, headings, and content exactly as fetched. Do not restructure, reformat, or fit it into any template. Only add YAML frontmatter (via `scripts/frontmatter.py set`). Do not add a title heading — the title lives in frontmatter only.
 
 First, read the schema to know exact field names and allowed values:
 
@@ -172,13 +172,7 @@ Always attempt at least one auto-revision cycle when any criterion scores below 
 
 **Reframe, don't remove.** When the assessor flags sections for HOW violations, the problem may not be the information — it's the framing. Prescriptive architecture and implementation directives can almost always be reframed into non-prescriptive context that preserves useful information while fixing the rubric score. For example, a section that assigns components to architectural roles can be reframed as a flat context list with a disclaimer that engineering should determine the design. Only remove content as a last resort when there is nothing reframeable (pure implementation detail with no business-facing content).
 
-**If content must be removed**, preserve it for Jira-sourced RFEs by writing it to `artifacts/rfe-tasks/{id}-removed-context.md` (using the same id prefix as the main file — Jira key or RFE-NNN-slug) so `/rfe.submit` can post it as a comment, prefixed with:
-
-```
-*[RFE Creator]* The following technical implementation details were removed from the RFE description during review. This content is better suited for a RHAISTRAT and is preserved here for reference:
-```
-
-This file must NOT be merged back into the RFE description.
+**If content must be removed**, it will be tracked automatically. The content preservation check (`check_content_preservation.py --write-yaml`) detects missing blocks and writes them to `artifacts/rfe-tasks/{id}-removed-context.yaml` as structured blocks with `type: unclassified`. This file must NOT be merged back into the RFE description.
 
 **When a section mixes WHAT and HOW and the assessor did not flag it**, leave it alone. Do not proactively scan for additional HOW content beyond what the assessor identified.
 
@@ -191,13 +185,25 @@ This file must NOT be merged back into the RFE description.
 1. Read the **full** review feedback for each failing RFE (from the review file just written)
 2. Read the comments file (`artifacts/rfe-tasks/{id}-comments.md`) if it exists — stakeholder comments may explain why certain content is intentional
 3. For each criterion the assessor flagged, follow its specific recommendations:
-   - **Open to HOW**: Reframe flagged sections to remove prescriptive framing while preserving useful context. If content cannot be reframed, remove it and write it to `artifacts/rfe-tasks/{id}-removed-context.md` for preservation as a Jira comment during `/rfe.submit`
+   - **Open to HOW**: Reframe flagged sections to remove prescriptive framing while preserving useful context. If content cannot be reframed, remove it from the RFE — the preservation check will track it automatically
    - **WHY**: Strengthen with available evidence (stakeholder comments, strategic alignment references); flag gaps the author must fill (named customers, revenue data)
    - **Right-sized**: Report the recommendation only; do not split or remove scope. Advise the user to run `/rfe.split` if splitting is needed
    - **WHAT / Not a task**: Follow assessor guidance if provided
-4. Document what changed and why in the review file's `## Revision History` section. Do NOT add revision notes to the RFE artifact itself — keep RFE files clean with only frontmatter and business content. Gaps that require author input (e.g., missing named customers) also belong in the review file, not in the artifact.
-5. Update the review file frontmatter: set `revised=true` if content was modified, set `needs_attention=true` if human review is still needed
-6. Re-run the review (go back to Step 2) on the revised artifacts
+4. **Content preservation check**: After each revision, run:
+   ```bash
+   python3 scripts/check_content_preservation.py artifacts/rfe-originals/<id>.md artifacts/rfe-tasks/<id>.md --write-yaml
+   ```
+   The `--write-yaml` flag automatically writes any missing blocks to `artifacts/rfe-tasks/{id}-removed-context.yaml` with `type: unclassified`. This ensures no content is silently dropped.
+
+5. **Classify removed blocks**: Read the YAML file and update each block's `type` field:
+   - **`reworded`**: The information is still in the RFE, just expressed differently (e.g., prescriptive rules reframed as user outcomes). This block will NOT be posted to Jira.
+   - **`genuine`**: Implementation specifics (API names, parameter schemas, architecture decisions) not present in the RFE that would be useful RHAISTRAT context. This block WILL be posted as a Jira comment during `/rfe.submit`.
+   - **`non-substantive`**: Marketing filler, empty template placeholders, or generic statements with no recoverable substance. This block will NOT be posted to Jira.
+
+   **After classifying, verify all blocks have been classified** — scan the YAML for any remaining `type: unclassified` entries and fix them. As a safety net, `/rfe.submit` treats `unclassified` blocks the same as `genuine` (they get posted) to prevent unintentional data loss.
+6. Document what changed and why in the review file's `## Revision History` section. Do NOT add revision notes to the RFE artifact itself — keep RFE files clean with only frontmatter and business content. Gaps that require author input (e.g., missing named customers) also belong in the review file, not in the artifact.
+7. Update the review file frontmatter: set `revised=true` if content was modified, set `needs_attention=true` if human review is still needed
+8. Re-run the review (go back to Step 2) on the revised artifacts
 
 **Revision limits**:
 - Maximum 2 auto-revision cycles

--- a/.claude/skills/rfe.split/SKILL.md
+++ b/.claude/skills/rfe.split/SKILL.md
@@ -22,7 +22,7 @@ python3 scripts/fetch_issue.py RHAIRFE-1234 --fields summary,description,priorit
 
 The script outputs JSON to stdout with the description already converted to markdown. Parse `fields.description`, `fields.summary`, and `fields.priority.name`.
 
-Write it to `artifacts/rfe-tasks/<jira_key>.md` using the RFE template format (read `${CLAUDE_SKILL_DIR}/../rfe.create/rfe-template.md` for the format).
+Write the Jira description to `artifacts/rfe-tasks/<jira_key>.md` as-is — preserve the original markdown structure, headings, and content exactly as fetched. Do not restructure, reformat, or fit it into any template. Only add YAML frontmatter (via `scripts/frontmatter.py set`). Do not add a title heading — the title lives in frontmatter only.
 
 First, read the schema to know exact field names and allowed values:
 

--- a/.claude/skills/rfe.submit/SKILL.md
+++ b/.claude/skills/rfe.submit/SKILL.md
@@ -82,7 +82,7 @@ The standard submit script handles:
 - Creating new RHAIRFE tickets for RFEs with local IDs (RFE-NNN)
 - Updating existing tickets for RFEs with Jira IDs (RHAIRFE-NNNN)
 - Applying labels from the labeling scheme (see below)
-- Posting removed-context comments where applicable
+- Posting removed-context Jira comments where applicable (from `*-removed-context.yaml` — posts `genuine` and `unclassified` blocks)
 - Renaming local files from RFE-NNN to RHAIRFE-NNNN after submission
 - Rebuilding the rfes.md index
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .context/
 artifacts/
 .claude/skills/assess-rfe/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,8 @@ artifacts/
   rfe-tasks/                # Individual RFE files with YAML frontmatter
     RHAIRFE-1595.md          # Existing Jira issue (keyed by Jira key)
     RHAIRFE-1595-comments.md # Companion: stakeholder comment history
-    RHAIRFE-1595-removed-context.md  # Companion: content removed during revision
+    RHAIRFE-1595-removed-context.yaml  # Companion: structured removed content with type classification
+    RHAIRFE-1595-removed-context.md  # Legacy companion (markdown, being phased out)
     RFE-001-slug.md          # New RFE (pre-submission, renamed on submit)
 
   rfe-originals/            # Raw Jira descriptions at time of fetch (not templated)

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -457,7 +457,8 @@ def update_frontmatter(path, updates, schema_type):
 
 def _is_companion_file(filename):
     """Check if a filename is a companion file (comments, removed-context)."""
-    return filename.endswith(("-comments.md", "-removed-context.md"))
+    return (filename.endswith(("-comments.md", "-removed-context.md"))
+            or filename.endswith("-removed-context.yaml"))
 
 
 def find_artifact_file(artifacts_dir, identifier):
@@ -527,6 +528,28 @@ def find_artifact_file_including_archived(artifacts_dir, identifier):
 
         if identifier.startswith("RFE-"):
             if filename.startswith(identifier + "-"):
+                return os.path.join(tasks_dir, filename)
+
+    return None
+
+
+def find_removed_context_yaml(artifacts_dir, identifier):
+    """Find the removed-context YAML file for a given RFE ID or Jira key."""
+    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
+    if not os.path.isdir(tasks_dir):
+        return None
+
+    for filename in sorted(os.listdir(tasks_dir)):
+        if not filename.endswith("-removed-context.yaml"):
+            continue
+
+        if identifier.startswith("RHAIRFE-"):
+            if filename == f"{identifier}-removed-context.yaml":
+                return os.path.join(tasks_dir, filename)
+
+        if identifier.startswith("RFE-"):
+            if filename.startswith(identifier + "-") and \
+                    filename.endswith("-removed-context.yaml"):
                 return os.path.join(tasks_dir, filename)
 
     return None
@@ -654,13 +677,15 @@ def rename_to_jira_key(artifacts_dir, rfe_id, jira_key):
         for filename in list(os.listdir(tasks_dir)):
             if not filename.startswith(rfe_id + "-"):
                 continue
-            if not filename.endswith(".md"):
+            if not (filename.endswith(".md") or filename.endswith(".yaml")):
                 continue
 
             old_path = os.path.join(tasks_dir, filename)
 
             if filename.endswith("-comments.md"):
                 new_name = f"{jira_key}-comments.md"
+            elif filename.endswith("-removed-context.yaml"):
+                new_name = f"{jira_key}-removed-context.yaml"
             elif filename.endswith("-removed-context.md"):
                 new_name = f"{jira_key}-removed-context.md"
             else:

--- a/scripts/check_content_preservation.py
+++ b/scripts/check_content_preservation.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Check that content from rfe-originals/ is preserved in rfe-tasks/.
+
+Compares original Jira snapshots to their current task files and flags
+any content blocks that were dropped during revision. Content is considered
+preserved if it appears in the task file OR the removed-context YAML file.
+
+When missing blocks are found, writes them to a structured YAML file
+({id}-removed-context.yaml) with type: unclassified for later semantic
+classification.
+
+Usage:
+    python3 scripts/check_content_preservation.py <original> <task_file>
+    python3 scripts/check_content_preservation.py --batch
+    python3 scripts/check_content_preservation.py --batch --verbose
+    python3 scripts/check_content_preservation.py --batch --json
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+import yaml
+
+# Add parent directory to path for artifact_utils
+sys.path.insert(0, os.path.dirname(__file__))
+from artifact_utils import read_frontmatter, find_removed_context_yaml
+
+
+def strip_frontmatter(content):
+    """Remove YAML frontmatter from markdown content."""
+    match = re.match(r'^---\s*\n.*?\n---\s*\n', content, re.DOTALL)
+    if match:
+        return content[match.end():]
+    return content
+
+
+def split_into_blocks(content):
+    """Split markdown content into heading-delimited blocks.
+
+    Returns list of (heading, lines) tuples. Content before the first
+    heading gets heading="(preamble)".
+    """
+    lines = content.split('\n')
+    blocks = []
+    current_heading = "(preamble)"
+    current_lines = []
+
+    for line in lines:
+        if re.match(r'^#{1,3}\s+', line):
+            if current_lines:
+                blocks.append((current_heading, current_lines))
+            current_heading = line.strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    if current_lines:
+        blocks.append((current_heading, current_lines))
+
+    return blocks
+
+
+def get_signature_lines(lines):
+    """Extract signature lines from a block — non-blank lines with 5+ words."""
+    sig = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped and len(stripped.split()) >= 5:
+            sig.append(normalize(stripped))
+    return sig
+
+
+def normalize(text):
+    """Normalize whitespace for comparison."""
+    return re.sub(r'\s+', ' ', text.strip().lower())
+
+
+def load_removed_context_yaml(yaml_path):
+    """Load existing removed-context YAML and return blocks + full target text."""
+    if not yaml_path or not os.path.exists(yaml_path):
+        return [], ""
+
+    with open(yaml_path, encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+
+    if not data or 'blocks' not in data:
+        return [], ""
+
+    blocks = data['blocks'] or []
+    # Build target text from all block content
+    parts = []
+    for block in blocks:
+        content = block.get('content', '')
+        if content:
+            parts.append(normalize(content))
+    return blocks, ' '.join(parts)
+
+
+def check_preservation(original_path, task_path, yaml_path=None,
+                       verbose=False):
+    """Compare original to task file and find missing content blocks.
+
+    Returns list of dicts with 'heading', 'sig_count', 'missing_count',
+    'content', and optionally 'missing_lines'.
+    """
+    with open(original_path, encoding='utf-8') as f:
+        original = strip_frontmatter(f.read())
+
+    with open(task_path, encoding='utf-8') as f:
+        task = strip_frontmatter(f.read())
+
+    # Build the full target text (task + removed-context YAML content)
+    target_text = normalize(task)
+    existing_blocks, rc_text = load_removed_context_yaml(yaml_path)
+    if rc_text:
+        target_text += ' ' + rc_text
+
+    original_blocks = split_into_blocks(original)
+    missing = []
+
+    for heading, lines in original_blocks:
+        sig_lines = get_signature_lines(lines)
+        if not sig_lines:
+            continue
+
+        found = 0
+        missing_lines_list = []
+        for sig in sig_lines:
+            if sig in target_text:
+                found += 1
+            else:
+                missing_lines_list.append(sig)
+
+        preservation_rate = found / len(sig_lines)
+        if preservation_rate < 0.6:
+            entry = {
+                'heading': heading,
+                'sig_count': len(sig_lines),
+                'missing_count': len(sig_lines) - found,
+                'preservation_rate': round(preservation_rate, 2),
+                'content': '\n'.join(lines).strip(),
+            }
+            if verbose:
+                entry['missing_lines'] = missing_lines_list
+            missing.append(entry)
+
+    return missing
+
+
+def write_removed_context_yaml(yaml_path, missing_blocks, existing_blocks=None):
+    """Write or merge missing blocks into the removed-context YAML file.
+
+    New blocks get type: unclassified. Existing blocks with a type set
+    by the semantic classifier are preserved.
+    """
+    # Index existing blocks by heading for merge
+    existing_by_heading = {}
+    if existing_blocks:
+        for block in existing_blocks:
+            existing_by_heading[block.get('heading', '')] = block
+
+    merged = []
+
+    # Keep existing classified blocks
+    for block in (existing_blocks or []):
+        merged.append(block)
+
+    # Add new missing blocks (not already tracked)
+    for m in missing_blocks:
+        heading = m['heading']
+        if heading not in existing_by_heading:
+            merged.append({
+                'heading': heading,
+                'type': 'unclassified',
+                'content': m['content'],
+            })
+
+    if not merged:
+        return
+
+    data = {'blocks': merged}
+    os.makedirs(os.path.dirname(yaml_path), exist_ok=True)
+    with open(yaml_path, 'w', encoding='utf-8') as f:
+        yaml.dump(data, f, default_flow_style=False, allow_unicode=True,
+                  sort_keys=False, width=200)
+
+
+def get_yaml_path_for_task(task_path):
+    """Derive the removed-context YAML path from a task file path."""
+    tasks_dir = os.path.dirname(task_path)
+    basename = os.path.basename(task_path).replace('.md', '')
+    return os.path.join(tasks_dir, f"{basename}-removed-context.yaml")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Check content preservation between originals and tasks')
+    parser.add_argument('original', nargs='?',
+                        help='Path to original file')
+    parser.add_argument('task_file', nargs='?',
+                        help='Path to task file')
+    parser.add_argument('--batch', action='store_true',
+                        help='Scan all originals in artifacts/rfe-originals/')
+    parser.add_argument('--verbose', action='store_true',
+                        help='Show missing lines')
+    parser.add_argument('--json', action='store_true',
+                        help='Output as JSON')
+    parser.add_argument('--write-yaml', action='store_true',
+                        help='Write missing blocks to removed-context YAML')
+
+    args = parser.parse_args()
+
+    if args.batch:
+        originals_dir = os.path.join('artifacts', 'rfe-originals')
+        tasks_dir = os.path.join('artifacts', 'rfe-tasks')
+
+        if not os.path.isdir(originals_dir):
+            print("No artifacts/rfe-originals/ directory found", file=sys.stderr)
+            sys.exit(1)
+
+        all_results = {}
+        any_missing = False
+
+        for filename in sorted(os.listdir(originals_dir)):
+            if not filename.endswith('.md'):
+                continue
+
+            key = filename.replace('.md', '')
+            original_path = os.path.join(originals_dir, filename)
+            task_path = os.path.join(tasks_dir, filename)
+
+            if not os.path.exists(task_path):
+                if not args.json:
+                    print(f"SKIP {key}: no task file")
+                continue
+
+            yaml_path = find_removed_context_yaml('artifacts', key)
+            missing = check_preservation(
+                original_path, task_path, yaml_path, verbose=args.verbose)
+
+            if missing:
+                any_missing = True
+                all_results[key] = missing
+                if not args.json:
+                    print(f"FAIL {key}: {len(missing)} block(s) missing")
+                    for m in missing:
+                        print(f"  - {m['heading']}: "
+                              f"{m['missing_count']}/{m['sig_count']} "
+                              f"signature lines missing "
+                              f"({m['preservation_rate']:.0%} preserved)")
+                        if args.verbose and 'missing_lines' in m:
+                            for line in m['missing_lines']:
+                                print(f"    > {line[:100]}")
+
+                if args.write_yaml:
+                    yp = yaml_path or get_yaml_path_for_task(task_path)
+                    existing, _ = load_removed_context_yaml(yaml_path)
+                    write_removed_context_yaml(yp, missing, existing)
+                    if not args.json:
+                        print(f"       Wrote {len(missing)} block(s) to "
+                              f"{os.path.basename(yp)}")
+            else:
+                if not args.json:
+                    print(f"OK   {key}")
+
+        if args.json:
+            print(json.dumps(all_results, indent=2))
+
+        sys.exit(1 if any_missing else 0)
+
+    elif args.original and args.task_file:
+        if not os.path.exists(args.original):
+            print(f"File not found: {args.original}", file=sys.stderr)
+            sys.exit(1)
+        if not os.path.exists(args.task_file):
+            print(f"File not found: {args.task_file}", file=sys.stderr)
+            sys.exit(1)
+
+        # Try to find removed-context YAML
+        key = os.path.basename(args.task_file).replace('.md', '')
+        artifacts_dir = os.path.dirname(os.path.dirname(args.task_file))
+        yaml_path = find_removed_context_yaml(artifacts_dir, key)
+
+        missing = check_preservation(
+            args.original, args.task_file, yaml_path, verbose=args.verbose)
+
+        if args.json:
+            print(json.dumps(missing, indent=2))
+        elif missing:
+            print(f"FAIL: {len(missing)} block(s) missing")
+            for m in missing:
+                print(f"  - {m['heading']}: "
+                      f"{m['missing_count']}/{m['sig_count']} "
+                      f"signature lines missing "
+                      f"({m['preservation_rate']:.0%} preserved)")
+                if args.verbose and 'missing_lines' in m:
+                    for line in m['missing_lines']:
+                        print(f"    > {line[:100]}")
+
+            if args.write_yaml:
+                yp = yaml_path or get_yaml_path_for_task(args.task_file)
+                existing, _ = load_removed_context_yaml(yaml_path)
+                write_removed_context_yaml(yp, missing, existing)
+                print(f"Wrote {len(missing)} block(s) to "
+                      f"{os.path.basename(yp)}")
+        else:
+            print("OK: all content preserved")
+
+        sys.exit(1 if missing else 0)
+
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/generate_review_pdf.py
+++ b/scripts/generate_review_pdf.py
@@ -1,0 +1,684 @@
+#!/usr/bin/env python3
+"""Generate an HTML review report from RFE review artifacts."""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import yaml
+
+ARTIFACTS = os.path.join(os.path.dirname(__file__), '..', 'artifacts')
+REVIEWS_DIR = os.path.join(ARTIFACTS, 'rfe-reviews')
+TASKS_DIR = os.path.join(ARTIFACTS, 'rfe-tasks')
+ORIGINALS_DIR = os.path.join(ARTIFACTS, 'rfe-originals')
+
+def read_frontmatter(path):
+    """Read YAML frontmatter from a markdown file."""
+    with open(path) as f:
+        content = f.read()
+    if not content.startswith('---'):
+        return {}, content
+    parts = content.split('---', 2)
+    if len(parts) < 3:
+        return {}, content
+    fm = yaml.safe_load(parts[1])
+    body = parts[2].strip()
+    return fm or {}, body
+
+def get_revision_history(body):
+    """Extract revision history section from review body."""
+    m = re.search(r'## Revision History\s*\n(.*)', body, re.DOTALL)
+    return m.group(1).strip() if m else ''
+
+def parse_before_scores(revision_history, after_scores):
+    """Reconstruct before scores from revision history annotations like WHY (0->1)."""
+    before = dict(after_scores)
+    name_map = {
+        'WHY': 'why', 'WHAT': 'what', 'HOW': 'open_to_how',
+        'Open to HOW': 'open_to_how', 'Not-a-task': 'not_a_task',
+        'Not a task': 'not_a_task', 'Right-sized': 'right_sized',
+        'Right-sizing': 'right_sized', 'NAT': 'not_a_task',
+        'RS': 'right_sized',
+    }
+    for match in re.finditer(r'(\w[\w\s-]*?)\s*\((\d+)(?:→|->)+(\d+)\)', revision_history):
+        name = match.group(1).strip()
+        before_val = int(match.group(2))
+        key = name_map.get(name)
+        if key:
+            before[key] = before_val
+    return before
+
+def read_removed_context(rfe_id):
+    """Read removed-context YAML file if it exists."""
+    path = os.path.join(TASKS_DIR, f'{rfe_id}-removed-context.yaml')
+    if not os.path.exists(path):
+        return None
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+def generate_diff(rfe_id):
+    """Generate unified diff between original and revised RFE."""
+    orig = os.path.join(ORIGINALS_DIR, f'{rfe_id}.md')
+    revised = os.path.join(TASKS_DIR, f'{rfe_id}.md')
+    if not os.path.exists(orig) or not os.path.exists(revised):
+        return None
+
+    with open(revised) as f:
+        revised_content = f.read()
+    if revised_content.startswith('---'):
+        parts = revised_content.split('---', 2)
+        if len(parts) >= 3:
+            revised_content = parts[2].lstrip('\n')
+
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as tmp:
+        tmp.write(revised_content)
+        tmp_path = tmp.name
+
+    try:
+        result = subprocess.run(
+            ['diff', '-u', orig, tmp_path],
+            capture_output=True, text=True
+        )
+        return result.stdout
+    finally:
+        os.unlink(tmp_path)
+
+def html_escape(text):
+    return text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;').replace("'", '&#x27;')
+
+def diff_to_html(diff_text):
+    if not diff_text or not diff_text.strip():
+        return '<div class="no-changes">No description changes</div>'
+
+    lines = diff_text.split('\n')
+    html_parts = []
+    for line in lines:
+        if line.startswith('---') or line.startswith('+++'):
+            continue
+        if line.startswith('@@'):
+            html_parts.append(f'<div class="diff-hunk">{html_escape(line)}</div>')
+        elif line.startswith('+'):
+            html_parts.append(f'<div class="diff-add">{html_escape(line)}</div>')
+        elif line.startswith('-'):
+            html_parts.append(f'<div class="diff-del">{html_escape(line)}</div>')
+        elif line.startswith(' '):
+            html_parts.append(f'<div class="diff-ctx">{html_escape(line)}</div>')
+
+    return '\n'.join(html_parts)
+
+def badge(passed):
+    if passed:
+        return '<span class="badge-pass">PASS</span>'
+    return '<span class="badge-fail">FAIL</span>'
+
+def delta_class(d):
+    if d > 0: return 'delta-pos'
+    if d < 0: return 'delta-neg'
+    return 'delta-zero'
+
+def delta_text(d):
+    if d > 0: return f'+{d}'
+    return str(d)
+
+def score_change_class(before, after):
+    if after > before: return 'score-up'
+    if after < before: return 'score-down'
+    return 'score-same'
+
+def score_change_text(before, after, max_val=2):
+    if after > before:
+        return f'{before}/{max_val} &rarr; {after}/{max_val} &#x25B2;'
+    if after < before:
+        return f'{before}/{max_val} &rarr; {after}/{max_val} &#x25BC;'
+    return f'{after}/{max_val}'
+
+def type_badge(block_type):
+    colors = {
+        'reworded': ('#6c5ce7', '#f0eeff'),
+        'genuine': ('#e17055', '#fff3ef'),
+        'non-substantive': ('#636e72', '#f0f0f0'),
+        'unclassified': ('#d63031', '#ffeaea'),
+    }
+    color, bg = colors.get(block_type, ('#636e72', '#f0f0f0'))
+    return f'<span style="display:inline-block;background:{bg};color:{color};font-size:8pt;font-weight:700;padding:2pt 8pt;border-radius:3pt;border:1px solid {color};letter-spacing:0.5pt;text-transform:uppercase">{html_escape(block_type)}</span>'
+
+def main():
+    rfes = []
+    review_files = sorted([f for f in os.listdir(REVIEWS_DIR) if f.endswith('-review.md')])
+
+    for rf in review_files:
+        rfe_id = rf.replace('-review.md', '')
+        review_fm, review_body = read_frontmatter(os.path.join(REVIEWS_DIR, rf))
+
+        task_path = os.path.join(TASKS_DIR, f'{rfe_id}.md')
+        task_fm = {}
+        if os.path.exists(task_path):
+            task_fm, _ = read_frontmatter(task_path)
+        title = task_fm.get('title', rfe_id)
+
+        after_scores = review_fm.get('scores', {})
+        revision_history = get_revision_history(review_body)
+        before_scores = parse_before_scores(revision_history, after_scores)
+
+        before_total = sum(before_scores.values())
+        after_total = review_fm.get('score', sum(after_scores.values()))
+
+        before_pass = before_total >= 8 and all(v > 0 for v in before_scores.values())
+        after_pass = review_fm.get('pass', False)
+
+        diff_text = generate_diff(rfe_id)
+        removed_context = read_removed_context(rfe_id)
+
+        rfes.append({
+            'rfe_id': rfe_id,
+            'title': title,
+            'before_scores': before_scores,
+            'after_scores': after_scores,
+            'before_total': before_total,
+            'after_total': after_total,
+            'before_pass': before_pass,
+            'after_pass': after_pass,
+            'feasibility': review_fm.get('feasibility', ''),
+            'revised': review_fm.get('revised', False),
+            'needs_attention': review_fm.get('needs_attention', False),
+            'recommendation': review_fm.get('recommendation', ''),
+            'diff_text': diff_text,
+            'removed_context': removed_context,
+            'revision_history': revision_history,
+        })
+
+    n = len(rfes)
+    before_passing = sum(1 for r in rfes if r['before_pass'])
+    after_passing = sum(1 for r in rfes if r['after_pass'])
+    avg_before = sum(r['before_total'] for r in rfes) / n if n else 0
+    avg_after = sum(r['after_total'] for r in rfes) / n if n else 0
+
+    removed_count = sum(1 for r in rfes if r['removed_context'])
+    total_blocks = sum(len(r['removed_context'].get('blocks', [])) for r in rfes if r['removed_context'])
+    genuine_blocks = sum(1 for r in rfes if r['removed_context'] for b in r['removed_context'].get('blocks', []) if b.get('type') == 'genuine')
+    reworded_blocks = sum(1 for r in rfes if r['removed_context'] for b in r['removed_context'].get('blocks', []) if b.get('type') == 'reworded')
+
+    css = '''
+    @page {
+        size: letter;
+        margin: 0.75in;
+    }
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+        font-size: 10pt;
+        line-height: 1.4;
+        color: #1a1a2e;
+        margin: 0;
+        padding: 0;
+    }
+    .page {
+        page-break-after: always;
+    }
+    .page:last-child {
+        page-break-after: avoid;
+    }
+    h1 {
+        font-size: 18pt;
+        color: #0f3460;
+        margin: 0 0 2pt 0;
+        padding-bottom: 4pt;
+        border-bottom: 3px solid #e94560;
+    }
+    h2 {
+        font-size: 12pt;
+        color: #555;
+        font-weight: 400;
+        margin: 4pt 0 14pt 0;
+    }
+    h3 {
+        font-size: 11pt;
+        color: #0f3460;
+        margin: 14pt 0 6pt 0;
+    }
+    .score-section { margin-bottom: 14pt; }
+    .score-summary {
+        display: flex;
+        align-items: center;
+        gap: 12pt;
+        margin-bottom: 10pt;
+    }
+    .score-box {
+        text-align: center;
+        padding: 8pt 16pt;
+        border-radius: 6pt;
+        min-width: 80pt;
+    }
+    .before-box {
+        background: #fef3f3;
+        border: 1px solid #e8c4c4;
+    }
+    .after-box {
+        background: #f0f9f0;
+        border: 1px solid #b8d4b8;
+    }
+    .score-label {
+        font-size: 8pt;
+        text-transform: uppercase;
+        letter-spacing: 0.5pt;
+        color: #888;
+        margin-bottom: 2pt;
+    }
+    .score-value {
+        font-size: 20pt;
+        font-weight: 700;
+        color: #1a1a2e;
+    }
+    .score-result { margin-top: 2pt; }
+    .score-arrow { font-size: 18pt; color: #999; }
+    .score-delta {
+        font-size: 16pt;
+        font-weight: 700;
+        padding: 4pt 8pt;
+        border-radius: 4pt;
+    }
+    .delta-pos { color: #2d6a2d; background: #e8f5e8; }
+    .delta-zero { color: #888; background: #f5f5f5; }
+    .delta-neg { color: #a03030; background: #fde8e8; }
+    .badge-pass {
+        display: inline-block;
+        background: #2d6a2d;
+        color: white;
+        font-size: 8pt;
+        font-weight: 700;
+        padding: 2pt 8pt;
+        border-radius: 3pt;
+        letter-spacing: 0.5pt;
+    }
+    .badge-fail {
+        display: inline-block;
+        background: #c0392b;
+        color: white;
+        font-size: 8pt;
+        font-weight: 700;
+        padding: 2pt 8pt;
+        border-radius: 3pt;
+        letter-spacing: 0.5pt;
+    }
+    .score-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 9pt;
+    }
+    .score-table th {
+        background: #0f3460;
+        color: white;
+        padding: 4pt 8pt;
+        text-align: left;
+        font-weight: 600;
+    }
+    .score-table td {
+        padding: 3pt 8pt;
+        border-bottom: 1px solid #eee;
+    }
+    .score-table tr:nth-child(even) { background: #fafafa; }
+    .criterion { font-weight: 600; color: #333; }
+    .score-same { color: #888; }
+    .score-up { color: #2d6a2d; font-weight: 600; }
+    .score-down { color: #a03030; font-weight: 600; }
+    .diff {
+        font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+        font-size: 7.5pt;
+        line-height: 1.35;
+        border: 1px solid #ddd;
+        border-radius: 4pt;
+        overflow: hidden;
+    }
+    .diff-hunk {
+        background: #f0f0ff;
+        color: #666;
+        padding: 2pt 8pt;
+        border-top: 1px solid #ddd;
+        border-bottom: 1px solid #ddd;
+        font-style: italic;
+    }
+    .diff-add {
+        background: #e6ffec;
+        color: #1a7f37;
+        padding: 1pt 8pt;
+        white-space: pre-wrap;
+        word-break: break-word;
+    }
+    .diff-del {
+        background: #ffebe9;
+        color: #cf222e;
+        padding: 1pt 8pt;
+        white-space: pre-wrap;
+        word-break: break-word;
+    }
+    .diff-ctx {
+        background: white;
+        color: #444;
+        padding: 1pt 8pt;
+        white-space: pre-wrap;
+        word-break: break-word;
+    }
+    .no-changes {
+        color: #888;
+        font-style: italic;
+        padding: 8pt;
+        text-align: center;
+        border: 1px solid #eee;
+        border-radius: 4pt;
+        background: #fafafa;
+    }
+    .summary-page .subtitle {
+        font-size: 11pt;
+        color: #666;
+        margin-top: 4pt;
+    }
+    .summary-stats {
+        display: flex;
+        align-items: center;
+        gap: 12pt;
+        margin: 16pt 0;
+        flex-wrap: wrap;
+    }
+    .stat-box {
+        text-align: center;
+        padding: 10pt 16pt;
+        background: #f8f9fa;
+        border: 1px solid #dee2e6;
+        border-radius: 6pt;
+        min-width: 90pt;
+    }
+    .stat-value {
+        font-size: 22pt;
+        font-weight: 700;
+        color: #0f3460;
+    }
+    .stat-label {
+        font-size: 8pt;
+        text-transform: uppercase;
+        letter-spacing: 0.5pt;
+        color: #888;
+        margin-top: 2pt;
+    }
+    .stat-arrow { font-size: 18pt; color: #999; }
+    .summary-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 9pt;
+        margin: 12pt 0;
+    }
+    .summary-table th {
+        background: #0f3460;
+        color: white;
+        padding: 5pt 8pt;
+        text-align: left;
+    }
+    .summary-table td {
+        padding: 4pt 8pt;
+        border-bottom: 1px solid #eee;
+    }
+    .summary-table tr:nth-child(even) { background: #fafafa; }
+    .key-col {
+        font-family: monospace;
+        font-weight: 600;
+        font-size: 8pt;
+    }
+    .revision-summary {
+        margin-top: 14pt;
+        padding: 10pt;
+        background: #f8f9fa;
+        border: 1px solid #dee2e6;
+        border-radius: 6pt;
+    }
+    .revision-summary ul {
+        margin: 6pt 0;
+        padding-left: 16pt;
+    }
+    .revision-summary li { margin-bottom: 4pt; }
+    .removed-context { margin-top: 14pt; }
+    .removed-block {
+        margin-bottom: 10pt;
+        border: 1px solid #ddd;
+        border-radius: 4pt;
+        overflow: hidden;
+    }
+    .removed-block-header {
+        display: flex;
+        align-items: center;
+        gap: 8pt;
+        padding: 6pt 10pt;
+        background: #f8f9fa;
+        border-bottom: 1px solid #ddd;
+        font-size: 9pt;
+    }
+    .removed-block-heading {
+        font-weight: 600;
+        color: #333;
+    }
+    .removed-block-content {
+        padding: 8pt 10pt;
+        font-size: 8.5pt;
+        line-height: 1.4;
+        color: #444;
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+        background: #fafafa;
+    }
+    .no-removed {
+        color: #888;
+        font-style: italic;
+        font-size: 9pt;
+    }
+'''
+
+    html = f'''<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+{css}
+</style>
+</head>
+<body>
+
+    <div class="page summary-page">
+        <h1>RFE Review &amp; Remediation Report</h1>
+        <p class="subtitle">{n} RFEs assessed, auto-revised, and re-assessed</p>
+
+        <div class="summary-stats">
+            <div class="stat-box">
+                <div class="stat-value">{before_passing}/{n}</div>
+                <div class="stat-label">Passing Before</div>
+            </div>
+            <div class="stat-arrow">&rarr;</div>
+            <div class="stat-box">
+                <div class="stat-value">{after_passing}/{n}</div>
+                <div class="stat-label">Passing After</div>
+            </div>
+            <div class="stat-box">
+                <div class="stat-value">{avg_before:.1f}</div>
+                <div class="stat-label">Avg Score Before</div>
+            </div>
+            <div class="stat-arrow">&rarr;</div>
+            <div class="stat-box">
+                <div class="stat-value">{avg_after:.1f}</div>
+                <div class="stat-label">Avg Score After</div>
+            </div>
+        </div>
+
+        <table class="summary-table">
+            <thead>
+                <tr>
+                    <th>RFE</th>
+                    <th>Before</th>
+                    <th></th>
+                    <th>After</th>
+                    <th></th>
+                    <th>&Delta;</th>
+                    <th>Removed</th>
+                </tr>
+            </thead>
+            <tbody>
+'''
+
+    for r in rfes:
+        d = r['after_total'] - r['before_total']
+        rc = r['removed_context']
+        if rc:
+            blocks = rc.get('blocks', [])
+            rc_text = f'{len(blocks)} block{"s" if len(blocks)!=1 else ""}'
+        else:
+            rc_text = '&mdash;'
+
+        html += f'''        <tr>
+            <td class="key-col">{html_escape(r['rfe_id'])}</td>
+            <td>{r['before_total']}/10</td>
+            <td>{badge(r['before_pass'])}</td>
+            <td>{r['after_total']}/10</td>
+            <td>{badge(r['after_pass'])}</td>
+            <td class="{delta_class(d)}">{delta_text(d)}</td>
+            <td>{rc_text}</td>
+        </tr>
+'''
+
+    # Build revision summary bullets dynamically
+    summary_bullets = []
+
+    # Summarize per-criterion changes
+    criterion_labels = {'what': 'WHAT', 'why': 'WHY', 'open_to_how': 'HOW', 'not_a_task': 'Not-a-task', 'right_sized': 'Right-sized'}
+    for key, label in criterion_labels.items():
+        improved = [r for r in rfes if r['before_scores'].get(key, 0) < r['after_scores'].get(key, 0)]
+        degraded = [r for r in rfes if r['before_scores'].get(key, 0) > r['after_scores'].get(key, 0)]
+        if improved:
+            ids = ', '.join(r['rfe_id'] for r in improved)
+            if len(improved) == n:
+                summary_bullets.append(f'<li><strong>{label}:</strong> All {n} RFEs improved ({improved[0]["before_scores"].get(key, 0)}&rarr;{improved[0]["after_scores"].get(key, 0)}).</li>')
+            else:
+                summary_bullets.append(f'<li><strong>{label} improved:</strong> {len(improved)} RFE{"s" if len(improved)!=1 else ""} ({ids}).</li>')
+        if degraded:
+            ids = ', '.join(r['rfe_id'] for r in degraded)
+            summary_bullets.append(f'<li><strong>{label} degraded:</strong> {len(degraded)} RFE{"s" if len(degraded)!=1 else ""} ({ids}).</li>')
+
+    # Remaining gaps — criteria still below max
+    for key, label in criterion_labels.items():
+        below_max = [r for r in rfes if r['after_scores'].get(key, 0) < 2]
+        if below_max:
+            summary_bullets.append(f'<li><strong>{label} gap:</strong> {len(below_max)} RFE{"s" if len(below_max)!=1 else ""} still below 2/2 (requires author input).</li>')
+
+    if removed_count:
+        summary_bullets.append(f'<li><strong>Removed context:</strong> {removed_count} RFE{"s" if removed_count!=1 else ""} had content removed during revision ({total_blocks} block{"s" if total_blocks!=1 else ""} total: {reworded_blocks} reworded, {genuine_blocks} genuine implementation context preserved for strategy reference).</li>')
+
+    html += '''            </tbody>
+        </table>
+
+        <div class="revision-summary">
+            <h3>Revision Summary</h3>
+            <ul>
+'''
+    for bullet in summary_bullets:
+        html += f'                {bullet}\n'
+    html += '''            </ul>
+        </div>
+    </div>
+
+'''
+
+    criteria = [
+        ('WHAT', 'what'),
+        ('WHY', 'why'),
+        ('Open to HOW', 'open_to_how'),
+        ('Not a task', 'not_a_task'),
+        ('Right-sized', 'right_sized'),
+    ]
+
+    for r in rfes:
+        d = r['after_total'] - r['before_total']
+
+        html += f'''
+        <div class="page">
+            <h1>{html_escape(r['rfe_id'])}</h1>
+            <h2>{html_escape(r['title'])}</h2>
+
+            <div class="score-section">
+                <div class="score-summary">
+                    <div class="score-box before-box">
+                        <div class="score-label">Before</div>
+                        <div class="score-value">{r['before_total']}/10</div>
+                        <div class="score-result">{badge(r['before_pass'])}</div>
+                    </div>
+                    <div class="score-arrow">&rarr;</div>
+                    <div class="score-box after-box">
+                        <div class="score-label">After</div>
+                        <div class="score-value">{r['after_total']}/10</div>
+                        <div class="score-result">{badge(r['after_pass'])}</div>
+                    </div>
+                    <div class="score-delta {delta_class(d)}">{delta_text(d)}</div>
+                </div>
+
+                <table class="score-table">
+                    <thead>
+                        <tr>
+                            <th>Criterion</th>
+                            <th>Before</th>
+                            <th>After</th>
+                            <th>Change</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+'''
+        for crit_name, crit_key in criteria:
+            bv = r['before_scores'].get(crit_key, 0)
+            av = r['after_scores'].get(crit_key, 0)
+            html += f'''                        <tr>
+                            <td class="criterion">{crit_name}</td>
+                            <td>{bv}/2</td>
+                            <td>{av}/2</td>
+                            <td class="{score_change_class(bv, av)}">{score_change_text(bv, av)}</td>
+                        </tr>
+'''
+
+        html += '''                    </tbody>
+                </table>
+            </div>
+
+'''
+        html += '            <h3>Description Changes</h3>\n'
+        html += '            <div class="diff">\n'
+        html += diff_to_html(r['diff_text'])
+        html += '\n            </div>\n'
+
+        rc = r['removed_context']
+        if rc and rc.get('blocks'):
+            html += '\n            <h3>Removed Context</h3>\n'
+            html += '            <div class="removed-context">\n'
+            for block in rc['blocks']:
+                heading = block.get('heading', '(untitled)')
+                btype = block.get('type', 'unclassified')
+                content = block.get('content', '')
+                html += f'''                <div class="removed-block">
+                    <div class="removed-block-header">
+                        <span class="removed-block-heading">{html_escape(heading)}</span>
+                        {type_badge(btype)}
+                    </div>
+                    <div class="removed-block-content">{html_escape(content)}</div>
+                </div>
+'''
+            html += '            </div>\n'
+
+        html += '        </div>\n'
+
+    html += '''
+</body>
+</html>
+'''
+
+    output_path = os.path.join(ARTIFACTS, 'review-report.html')
+    with open(output_path, 'w') as f:
+        f.write(html)
+    print(f'Report written to {output_path}')
+    print(f'{n} RFEs, {before_passing}/{n} passing before, {after_passing}/{n} passing after')
+    print(f'{removed_count} RFEs with removed context ({total_blocks} blocks)')
+
+if __name__ == '__main__':
+    main()

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -21,6 +21,8 @@ import os
 import re
 import sys
 
+import yaml
+
 from jira_utils import (
     require_env,
     create_issue,
@@ -37,12 +39,44 @@ from artifact_utils import (
     update_frontmatter,
     scan_task_files,
     find_artifact_file,
-    find_removed_context_file,
+    find_removed_context_yaml,
     find_review_file,
     rename_to_jira_key,
     rebuild_index,
     ValidationError,
 )
+
+
+def _render_jira_comment(yaml_path):
+    """Read removed-context YAML and render postable blocks as markdown.
+
+    Posts blocks with type 'genuine' or 'unclassified' (safety fallback).
+    Skips blocks with type 'reworded' or 'non-substantive'.
+    Returns empty string if no blocks qualify.
+    """
+    with open(yaml_path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if not data or "blocks" not in data:
+        return ""
+
+    postable_types = {"genuine", "unclassified"}
+    sections = []
+    for block in data["blocks"]:
+        btype = block.get("type", "unclassified")
+        if btype in postable_types:
+            heading = block.get("heading", "")
+            content = block.get("content", "")
+            sections.append(f"## {heading}\n{content}")
+
+    if not sections:
+        return ""
+
+    preamble = ("*[RFE Creator]* The following technical implementation "
+                "details were removed from the RFE description during review. "
+                "This content is better suited for a RHAISTRAT and is "
+                "preserved here for reference:")
+    return preamble + "\n\n" + "\n\n".join(sections)
 
 
 def main():
@@ -189,17 +223,18 @@ def main():
                     print(f"           Labels: {', '.join(labels)}")
                 results[rfe_id] = new_key
 
-        # Post removed-context comment if applicable
-        removed_path = find_removed_context_file(args.artifacts_dir, rfe_id)
-        if removed_path:
-            with open(removed_path, encoding="utf-8") as f:
-                removed_content = f.read()
+        # Post removed-context Jira comment if applicable
+        yaml_path = find_removed_context_yaml(args.artifacts_dir, rfe_id)
+        if yaml_path:
+            comment_md = _render_jira_comment(yaml_path)
             target_key = results.get(rfe_id)
-            if args.dry_run:
+            if not comment_md:
+                pass  # No postable blocks
+            elif args.dry_run:
                 print(f"  {rfe_id}: Would post removed-context comment "
-                      f"({len(removed_content)} chars)")
+                      f"({len(comment_md)} chars)")
             elif target_key:
-                comment_adf = markdown_to_adf(removed_content)
+                comment_adf = markdown_to_adf(comment_md)
                 add_comment(server, user, token, target_key, comment_adf)
                 print(f"  {rfe_id}: Posted removed-context comment")
 


### PR DESCRIPTION
## Summary
- Adds `check_content_preservation.py` to detect content removed during RFE revision and classify blocks as reworded/genuine/non-substantive
- Adds `generate_review_pdf.py` for HTML/PDF report generation with before/after scoring, diffs, and removed context sections
- Updates review skill to integrate content preservation checks into the auto-revision workflow
- Updates submit skill to post genuine removed blocks as Jira comments
- Adds .DS_Store to .gitignore

## Test plan
- [x] Run `/rfe.review` on an RFE that requires HOW revisions — verify `*-removed-context.yaml` is generated with classified blocks
- [x] Run `python3 scripts/generate_review_pdf.py` with review artifacts present — verify HTML report includes removed context sections with correct badges
- [x] Run `/rfe.submit` on a revised RFE with genuine removed context — verify comment is posted to Jira

🤖 Generated with [Claude Code](https://claude.com/claude-code)