### PR TITLE
Add finish.py for reliable headless completion signal

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -178,4 +178,10 @@ Present consolidated results:
 <e.g., /rfe.submit for passing RFEs, manual edits for failures>
 ```
 
+If `--headless` was set, after outputting the final summary run:
+
+```bash
+python3 scripts/finish.py
+```
+
 $ARGUMENTS

--- a/scripts/finish.py
+++ b/scripts/finish.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+"""Print completion marker for the auto-fix pipeline."""
+
+print("FULL RUN COMPLETE")


### PR DESCRIPTION
## Summary
- Adds `scripts/finish.py` that prints `FULL RUN COMPLETE` as a deterministic completion marker
- Updates `rfe.auto-fix` skill to invoke `finish.py` only when `--headless` is set
- Ensures the completion signal is code-executed rather than LLM-generated, making it reliable for CI/automation

## Test plan
- [ ] Run `/rfe.auto-fix --headless --jql "..."` and verify `FULL RUN COMPLETE` appears at the end
- [ ] Run `/rfe.auto-fix` (without `--headless`) and verify the message does **not** appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)