### PR TITLE
Replace --headless with --announce-complete for completion signaling

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -14,6 +14,7 @@ Parse `$ARGUMENTS` for:
 - `--limit N`: Cap the number of IDs to process (useful for testing JQL queries)
 - `--batch-size N`: Override batch size (default: 5)
 - `--headless`: Suppress summaries (when called by speedrun)
+- `--announce-complete`: Print completion marker when done (for CI / eval harnesses)
 - Remaining arguments: explicit RFE IDs (RHAIRFE-NNNN)
 
 Persist parsed flags (survives context compression):
@@ -21,6 +22,7 @@ Persist parsed flags (survives context compression):
 ```bash
 mkdir -p tmp && cat > tmp/autofix-config.yaml << 'EOF'
 headless: <true/false>
+announce_complete: <true/false>
 batch_size: <N>
 EOF
 ```
@@ -178,7 +180,7 @@ Present consolidated results:
 <e.g., /rfe.submit for passing RFEs, manual edits for failures>
 ```
 
-If `--headless` was set, after outputting the final summary run:
+If `--announce-complete` was set, after outputting the final summary run:
 
 ```bash
 python3 scripts/finish.py

--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rfe.speedrun
-description: End-to-end RFE pipeline. Accepts a single idea, Jira key(s), or a YAML batch file. Creates, reviews, auto-fixes (with splits), and submits. Supports --headless and --dry-run for CI.
+description: End-to-end RFE pipeline. Accepts a single idea, Jira key(s), or a YAML batch file. Creates, reviews, auto-fixes (with splits), and submits. Supports --headless, --announce-complete, and --dry-run for CI.
 user-invocable: true
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion, Skill
 ---
@@ -12,6 +12,7 @@ You are running the full RFE pipeline in speedrun mode. Your goal is to go from 
 Parse `$ARGUMENTS` for:
 - `--input <path>`: Path to a YAML file with batch entries
 - `--headless`: Suppress questions and confirmations (for CI / eval)
+- `--announce-complete`: Print completion marker when done (for CI / eval harnesses)
 - `--dry-run`: Skip Jira writes in submit
 - `--batch-size N`: Override batch size (default 5), passed to auto-fix
 - Remaining arguments: either a single Jira key (RHAIRFE-NNNN) or a free-text idea
@@ -21,6 +22,7 @@ Clean temp state and persist parsed flags:
 ```bash
 rm -rf tmp/ && mkdir -p tmp && cat > tmp/speedrun-config.yaml << 'EOF'
 headless: <true/false>
+announce_complete: <true/false>
 dry_run: <true/false>
 batch_size: <N>
 input_file: <path or null>
@@ -77,10 +79,10 @@ If not headless, `/rfe.create` will ask clarifying questions. Collect created RF
 Build the auto-fix command with all created/provided IDs:
 
 ```
-/rfe.auto-fix [--headless] [--batch-size N] <all_IDs>
+/rfe.auto-fix [--headless] [--announce-complete] [--batch-size N] <all_IDs>
 ```
 
-Pass `--headless` through if set. Pass `--batch-size` if provided.
+Pass `--headless` and `--announce-complete` through if set. Pass `--batch-size` if provided.
 
 Auto-fix handles: assessment, feasibility checks, review, auto-revision, re-assessment, splitting oversized RFEs, retry queue, and report generation. Wait for it to complete.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Inspired by the [PRD/RFE workflow](https://github.com/ambient-code/workflows/tre
 /rfe.speedrun RHAIRFE-1234    # Fetch, review, revise, and update in one step
 
 # Batch operations
-/rfe.speedrun --input batch.yaml --headless --dry-run   # Batch create + review from YAML
+/rfe.speedrun --input batch.yaml --headless --dry-run              # Batch create + review from YAML
+/rfe.speedrun --input batch.yaml --headless --announce-complete    # Print completion marker for CI
 /rfe.auto-fix --jql "project = RHAIRFE AND ..."         # Batch review from JQL query
 /rfe.auto-fix RHAIRFE-1234 RHAIRFE-5678                 # Batch review explicit IDs
 
@@ -95,7 +96,7 @@ Auto-fix processes in batches (default 5), handles review, revision, splitting, 
 3. **Split**: Decompose an oversized RFE into right-sized pieces. Runs review on new RFEs, self-corrects right-sizing (up to 3 cycles), and checks scope coverage. Supports `--headless`.
 4. **Auto-fix**: Batch pipeline that orchestrates review + revision + split + retry across many RFEs. Accepts explicit IDs or a `--jql` query. Processes in configurable batches (`--batch-size N`, default 5). Generates run reports and HTML review reports.
 5. **Submit**: Creates new RHAIRFE tickets or updates existing ones in Jira. Supports `--dry-run` to validate without writing to Jira.
-6. **Speedrun**: End-to-end pipeline (create → auto-fix → submit). Supports `--input <yaml>` for batch creation, `--headless` for CI, `--dry-run` to skip Jira writes, and `--batch-size N`.
+6. **Speedrun**: End-to-end pipeline (create → auto-fix → submit). Supports `--input <yaml>` for batch creation, `--headless` for CI, `--announce-complete` for completion signaling, `--dry-run` to skip Jira writes, and `--batch-size N`.
 7. **Strat Create**: Clone approved RFEs to RHAISTRAT in Jira.
 8. **Strat Refine**: Add the HOW — technical approach, dependencies, components, non-functionals.
 9. **Strat Review**: Four independent forked reviewers (feasibility, testability, scope, architecture).
@@ -140,6 +141,12 @@ All orchestrator skills support `--headless` for non-interactive use in CI pipel
 
 ```bash
 claude -p "/rfe.speedrun --headless --dry-run --input batch.yaml"
+```
+
+Add `--announce-complete` to print a `FULL RUN COMPLETE` marker when the pipeline finishes — useful for CI harnesses that need a reliable completion signal:
+
+```bash
+claude -p "/rfe.speedrun --headless --announce-complete --input batch.yaml"
 ```
 
 Flag persistence: parsed arguments are written to `tmp/*.yaml` config files so they survive context compression during long batch runs.

--- a/scripts/finish.py
+++ b/scripts/finish.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
-"""Print completion marker for the auto-fix pipeline."""
+"""Print completion marker for the pipeline (triggered by --announce-complete)."""
 
 print("FULL RUN COMPLETE")


### PR DESCRIPTION
## Summary
- Decouples the `FULL RUN COMPLETE` completion marker from `--headless` into its own `--announce-complete` flag
- `--headless` continues to control interactivity (suppressing questions/summaries)
- `--announce-complete` independently controls printing the completion marker via `finish.py`
- Updated `rfe.auto-fix`, `rfe.speedrun`, and README with the new flag

## Test plan
- [ ] Run `/rfe.auto-fix --headless RHAIRFE-XXXX` — verify no completion marker is printed
- [ ] Run `/rfe.auto-fix --announce-complete RHAIRFE-XXXX` — verify `FULL RUN COMPLETE` is printed
- [ ] Run `/rfe.speedrun --headless --announce-complete --dry-run --input batch.yaml` — verify both flags work together

🤖 Generated with [Claude Code](https://claude.com/claude-code)