### PR TITLE
Harden skills against context compression state loss

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -20,11 +20,7 @@ Parse `$ARGUMENTS` for:
 Persist parsed flags (survives context compression):
 
 ```bash
-mkdir -p tmp && cat > tmp/autofix-config.yaml << 'EOF'
-headless: <true/false>
-announce_complete: <true/false>
-batch_size: <N>
-EOF
+python3 scripts/state.py init tmp/autofix-config.yaml headless=<true/false> announce_complete=<true/false> batch_size=<N>
 ```
 
 **JQL mode**: If `--jql` is present, run the query:
@@ -39,8 +35,12 @@ Parse the output: first line is `TOTAL=N`, remaining lines are IDs. These become
 
 If no IDs and no JQL query, stop with usage instructions.
 
-## Step 1: Bootstrap Pre-flight
+**Persist all IDs to disk** (survives context compression):
 
+```bash
+python3 scripts/state.py write-ids tmp/autofix-all-ids.txt <all_IDs>
+```
+## Step 1: Bootstrap Pre-flight
 Run bootstrap once before any batching:
 
 ```bash
@@ -56,36 +56,79 @@ bash scripts/bootstrap-assess-rfe.sh
 If the retry also fails, stop entirely: "assess-rfe bootstrap failed — cannot proceed. Check network connectivity and retry."
 
 ## Step 2: Resume Check
+Re-read the ID list from disk (in case context was compressed):
 
+```bash
+python3 scripts/state.py read-ids tmp/autofix-all-ids.txt
+```
 Check which IDs are already processed:
 
 ```bash
-python3 scripts/check_resume.py <all_IDs>
+python3 scripts/check_resume.py $(python3 scripts/state.py read-ids tmp/autofix-all-ids.txt)
 ```
 
-Parse output for `PROCESS=` and `SKIP=` lines. Remove already-processed IDs (pass=true, no error) from the processing list. Report skipped count if any.
+Parse output for `PROCESS=` and `SKIP=` lines. Remove already-processed IDs (pass=true, no error) from the processing list.
+Persist the filtered processing list to disk (survives context compression):
+
+```bash
+python3 scripts/state.py write-ids tmp/autofix-process-ids.txt <remaining_IDs>
+```
 
 ## Step 3: Batch Processing
 
-Split remaining IDs into batches of `batch-size` (default 5). Persist the start time so it survives context compression:
+Re-read the filtered ID list from disk (in case context was compressed):
 
 ```bash
-echo "start_time: $(python3 -c "from datetime import datetime,timezone; print(datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")" >> tmp/autofix-config.yaml
+python3 scripts/state.py read-ids tmp/autofix-process-ids.txt
+```
+Split remaining IDs into batches of `batch-size` (default 5).
+
+Persist the start time, batch count, and per-batch ID lists so they survive context compression:
+
+```bash
+python3 scripts/state.py set tmp/autofix-config.yaml start_time=$(python3 scripts/state.py timestamp) total_batches=<M>
+```
+
+```bash
+python3 scripts/state.py write-ids tmp/autofix-batch-1-ids.txt <batch_1_IDs>
+python3 scripts/state.py write-ids tmp/autofix-batch-2-ids.txt <batch_2_IDs>
+# ... one file per batch
 ```
 
 For each batch:
 
+Re-read config to recover batch position after potential context compression, then update the current batch tracker:
+
+```bash
+python3 scripts/state.py read tmp/autofix-config.yaml
+python3 scripts/state.py set tmp/autofix-config.yaml current_batch=<N>
+```
+
+Re-read this batch's IDs from disk (do not use IDs from memory — they may be hallucinated after compression):
+
+```bash
+python3 scripts/state.py read-ids tmp/autofix-batch-N-ids.txt
+```
 ### 3a: Review
 
-Invoke `/rfe.review` as an inline Skill:
+Invoke `/rfe.review` as an inline Skill, using IDs from the batch file:
 
 ```
-/rfe.review --headless <batch_IDs>
+/rfe.review --headless <batch_IDs_from_file>
 ```
 
 This runs the full review pipeline (fetch, assess, feasibility, review-and-revise, re-assess if needed). Wait for it to complete.
 
 ### 3b: Collect Results
+
+Re-read config and batch IDs from disk (context compression may have corrupted in-memory state):
+
+```bash
+python3 scripts/state.py read tmp/autofix-config.yaml
+python3 scripts/state.py read-ids tmp/autofix-batch-N-ids.txt
+```
+
+Use the IDs from the file (not memory) for all subsequent steps in this batch:
 
 ```bash
 python3 scripts/collect_recommendations.py <batch_IDs>
@@ -116,14 +159,25 @@ Output a progress update:
 ```
 
 ## Step 4: Retry Queue
-
-After all regular batches complete, scan ALL processed IDs for errors:
+After all regular batches complete, re-read the full ID list from disk:
 
 ```bash
-python3 scripts/collect_recommendations.py <all_processed_IDs>
+python3 scripts/state.py read-ids tmp/autofix-all-ids.txt
+```
+Scan ALL processed IDs for errors:
+
+```bash
+python3 scripts/collect_recommendations.py <all_IDs_from_file>
 ```
 
-Parse the `ERRORS=` line. If empty, skip to Step 5. For each error ID:
+Parse the `ERRORS=` line. If empty, skip to Step 5.
+
+If errors found, **persist retry IDs to disk** (do not rely on in-memory parsing — they may be lost to compression during the retry run):
+
+```bash
+python3 scripts/state.py write-ids tmp/autofix-retry-ids.txt <error_IDs>
+```
+For each error ID:
 
 1. For IDs with `split_failed` errors: clean up first:
 
@@ -137,22 +191,27 @@ python3 scripts/cleanup_partial_split.py <ID>
 python3 scripts/frontmatter.py set artifacts/rfe-reviews/<ID>-review.md error=null
 ```
 
-3. Run the retry batch through the full pipeline (Steps 3a-3c)
-
-4. If they fail again, report as permanent failures
-
-## Step 5: Generate Reports
-
-Re-read persisted config to recover flags and start time after potential context compression:
+3. Re-read retry IDs from disk before running the pipeline (compression may have lost them during cleanup):
 
 ```bash
-cat tmp/autofix-config.yaml
+python3 scripts/state.py read-ids tmp/autofix-retry-ids.txt
 ```
 
-Parse `start_time` from the output. Generate the run report:
+4. Run the retry batch through the full pipeline (Steps 3a-3c) using IDs from the file
+
+5. If they fail again, report as permanent failures
+
+## Step 5: Generate Reports
+Re-read persisted config and ID list to recover after potential context compression:
 
 ```bash
-python3 scripts/generate_run_report.py --start-time "<start_time>" --batch-size <N> [--retried <retry_IDs>] [--retry-successes <success_IDs>] <all_IDs>
+python3 scripts/state.py read tmp/autofix-config.yaml
+python3 scripts/state.py read-ids tmp/autofix-all-ids.txt
+```
+Parse `start_time` from the config. Use IDs from the file. Generate the run report:
+
+```bash
+python3 scripts/generate_run_report.py --start-time "<start_time>" --batch-size <N> [--retried <retry_IDs>] [--retry-successes <success_IDs>] <all_IDs_from_file>
 ```
 
 Parse the `run_id` from the script output (format: `YYYYMMDD-HHMMSS`). Generate the HTML review report using that `run_id`:
@@ -162,8 +221,20 @@ python3 scripts/generate_review_pdf.py --revised-only --output artifacts/auto-fi
 ```
 
 ## Step 6: Final Summary
+Re-read config and IDs from disk (context compression may have lost flags like `announce_complete`):
 
-Present consolidated results:
+```bash
+python3 scripts/state.py read tmp/autofix-config.yaml
+python3 scripts/state.py read-ids tmp/autofix-all-ids.txt
+```
+
+List split children (these are created during processing and are not in the persisted ID list):
+
+```bash
+ls artifacts/rfe-reviews/RFE-*-review.md 2>/dev/null | sed 's|artifacts/rfe-reviews/||;s|-review.md||'
+```
+
+Present consolidated results (combine persisted IDs with any split children found above):
 
 ```
 ## Auto-fix Complete

--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -40,7 +40,13 @@ If no IDs and no JQL query, stop with usage instructions.
 ```bash
 python3 scripts/state.py write-ids tmp/autofix-all-ids.txt <all_IDs>
 ```
+
+Output: `[AUTOFIX] Step 0: Parsed N IDs, batch_size=M`
+
 ## Step 1: Bootstrap Pre-flight
+
+Output: `[AUTOFIX] Step 1: Bootstrap`
+
 Run bootstrap once before any batching:
 
 ```bash
@@ -56,11 +62,17 @@ bash scripts/bootstrap-assess-rfe.sh
 If the retry also fails, stop entirely: "assess-rfe bootstrap failed — cannot proceed. Check network connectivity and retry."
 
 ## Step 2: Resume Check
+
+Output: `[AUTOFIX] Step 2: Resume Check`
+
 Re-read the ID list from disk (in case context was compressed):
 
 ```bash
 python3 scripts/state.py read-ids tmp/autofix-all-ids.txt
 ```
+
+Output: `[AUTOFIX] Recovered N IDs from autofix-all-ids.txt`
+
 Check which IDs are already processed:
 
 ```bash
@@ -68,6 +80,9 @@ python3 scripts/check_resume.py $(python3 scripts/state.py read-ids tmp/autofix-
 ```
 
 Parse output for `PROCESS=` and `SKIP=` lines. Remove already-processed IDs (pass=true, no error) from the processing list.
+
+Output: `[AUTOFIX] Step 2: N to process, M skipped`
+
 Persist the filtered processing list to disk (survives context compression):
 
 ```bash
@@ -81,7 +96,10 @@ Re-read the filtered ID list from disk (in case context was compressed):
 ```bash
 python3 scripts/state.py read-ids tmp/autofix-process-ids.txt
 ```
-Split remaining IDs into batches of `batch-size` (default 5).
+
+Output: `[AUTOFIX] Recovered N IDs from autofix-process-ids.txt`
+
+Split remaining IDs into batches of `batch-size` (default 5). Output: `[AUTOFIX] Step 3: Batch Processing (M batches of K)`
 
 Persist the start time, batch count, and per-batch ID lists so they survive context compression:
 
@@ -109,6 +127,9 @@ Re-read this batch's IDs from disk (do not use IDs from memory — they may be h
 ```bash
 python3 scripts/state.py read-ids tmp/autofix-batch-N-ids.txt
 ```
+
+Output: `[AUTOFIX] Batch N/M: K IDs`
+
 ### 3a: Review
 
 Invoke `/rfe.review` as an inline Skill, using IDs from the batch file:
@@ -159,24 +180,33 @@ Output a progress update:
 ```
 
 ## Step 4: Retry Queue
+
+Output: `[AUTOFIX] Step 4: Retry Queue`
+
 After all regular batches complete, re-read the full ID list from disk:
 
 ```bash
 python3 scripts/state.py read-ids tmp/autofix-all-ids.txt
 ```
+
+Output: `[AUTOFIX] Recovered N IDs from autofix-all-ids.txt`
+
 Scan ALL processed IDs for errors:
 
 ```bash
 python3 scripts/collect_recommendations.py <all_IDs_from_file>
 ```
 
-Parse the `ERRORS=` line. If empty, skip to Step 5.
+Parse the `ERRORS=` line. If empty, output `[AUTOFIX] Step 4: No errors, skipping retry` and skip to Step 5.
 
 If errors found, **persist retry IDs to disk** (do not rely on in-memory parsing — they may be lost to compression during the retry run):
 
 ```bash
 python3 scripts/state.py write-ids tmp/autofix-retry-ids.txt <error_IDs>
 ```
+
+Output: `[AUTOFIX] Step 4: Retrying N IDs: <error_IDs>`
+
 For each error ID:
 
 1. For IDs with `split_failed` errors: clean up first:
@@ -202,12 +232,18 @@ python3 scripts/state.py read-ids tmp/autofix-retry-ids.txt
 5. If they fail again, report as permanent failures
 
 ## Step 5: Generate Reports
+
+Output: `[AUTOFIX] Step 5: Generate Reports`
+
 Re-read persisted config and ID list to recover after potential context compression:
 
 ```bash
 python3 scripts/state.py read tmp/autofix-config.yaml
 python3 scripts/state.py read-ids tmp/autofix-all-ids.txt
 ```
+
+Output: `[AUTOFIX] Recovered N IDs from autofix-all-ids.txt`
+
 Parse `start_time` from the config. Use IDs from the file. Generate the run report:
 
 ```bash
@@ -221,6 +257,9 @@ python3 scripts/generate_review_pdf.py --revised-only --output artifacts/auto-fi
 ```
 
 ## Step 6: Final Summary
+
+Output: `[AUTOFIX] Step 6: Final Summary`
+
 Re-read config and IDs from disk (context compression may have lost flags like `announce_complete`):
 
 ```bash

--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -16,9 +16,13 @@ Parse `$ARGUMENTS` for flags and IDs:
 Persist parsed flags (survives context compression):
 
 ```bash
-mkdir -p tmp && cat > tmp/review-config.yaml << 'EOF'
-headless: <true/false>
-EOF
+python3 scripts/state.py init tmp/review-config.yaml headless=<true/false>
+```
+
+Persist all IDs to disk (survives context compression):
+
+```bash
+python3 scripts/state.py write-ids tmp/review-all-ids.txt <all_IDs>
 ```
 
 For each ID, check if `artifacts/rfe-tasks/<id>.md` already exists locally (use Glob, don't read the file). Separate IDs into:
@@ -36,7 +40,7 @@ Read .claude/skills/rfe.review/prompts/fetch-agent.md and follow all instruction
 Write IDs to poll file once, then poll using `NEXT_POLL` interval:
 
 ```bash
-echo "<all_remote_IDs>" > tmp/rfe-poll-fetch.txt
+python3 scripts/state.py write-ids tmp/rfe-poll-fetch.txt <all_remote_IDs>
 python3 scripts/check_review_progress.py --phase fetch --id-file tmp/rfe-poll-fetch.txt
 ```
 
@@ -95,8 +99,8 @@ Launch all agents for all IDs in parallel (2N agents total for N IDs).
 Write IDs to poll files once, then poll every 60 seconds:
 
 ```bash
-echo "<all_IDs>" > tmp/rfe-poll-assess.txt
-echo "<all_IDs>" > tmp/rfe-poll-feasibility.txt
+python3 scripts/state.py write-ids tmp/rfe-poll-assess.txt <all_IDs>
+python3 scripts/state.py write-ids tmp/rfe-poll-feasibility.txt <all_IDs>
 python3 scripts/check_review_progress.py --phase assess --id-file tmp/rfe-poll-assess.txt
 python3 scripts/check_review_progress.py --phase feasibility --id-file tmp/rfe-poll-feasibility.txt
 ```
@@ -121,7 +125,7 @@ Launch all review agents in parallel.
 Write IDs to poll file once, then poll using `NEXT_POLL` interval:
 
 ```bash
-echo "<all_IDs>" > tmp/rfe-poll-review.txt
+python3 scripts/state.py write-ids tmp/rfe-poll-review.txt <all_IDs>
 python3 scripts/check_review_progress.py --phase review --id-file tmp/rfe-poll-review.txt
 ```
 
@@ -129,10 +133,16 @@ Sleep for the `NEXT_POLL` seconds reported by the script before polling again. W
 
 ## Step 3.5: Launch Revise Agents
 
-After all review agents complete, determine which IDs need revision:
+After all review agents complete, re-read the ID list from disk (context compression may have corrupted in-memory lists):
 
 ```bash
-python3 scripts/filter_for_revision.py <all_IDs>
+python3 scripts/state.py read-ids tmp/review-all-ids.txt
+```
+
+Determine which IDs need revision:
+
+```bash
+python3 scripts/filter_for_revision.py <all_IDs_from_file>
 ```
 
 The script outputs the IDs that need revision (filters out passing, infeasible, and rejected IDs). If the output is empty, skip to Step 4.
@@ -148,13 +158,19 @@ Launch all revise agents in parallel.
 Write IDs to poll file once, then poll using `NEXT_POLL` interval:
 
 ```bash
-echo "<all_IDs_being_revised>" > tmp/rfe-poll-revise.txt
+python3 scripts/state.py write-ids tmp/rfe-poll-revise.txt <all_IDs_being_revised>
 python3 scripts/check_review_progress.py --phase revise --id-file tmp/rfe-poll-revise.txt
 ```
 
 Sleep for the `NEXT_POLL` seconds reported by the script before polling again. Wait for all to complete.
 
-**Post-processing: fix revised flag.** The revise agent may run out of budget before setting `revised=true`. After all agents complete, for each revised ID, verify the flag is correct:
+**Post-processing: fix revised flag.** The revise agent may run out of budget before setting `revised=true`. After all agents complete, re-read the revised ID list from the poll file (compression may have lost them during agent execution):
+
+```bash
+python3 scripts/state.py read-ids tmp/rfe-poll-revise.txt
+```
+
+For each revised ID, verify the flag is correct:
 
 ```bash
 python3 scripts/check_revised.py artifacts/rfe-originals/<ID>.md artifacts/rfe-tasks/<ID>.md
@@ -168,13 +184,43 @@ python3 scripts/frontmatter.py set artifacts/rfe-reviews/<ID>-review.md revised=
 
 ## Step 4: Re-assess if Revised (max 2 cycles)
 
+Re-read ID list from disk:
+
+```bash
+python3 scripts/state.py read-ids tmp/review-all-ids.txt
+```
+
 After all revise agents complete, check which IDs need re-assessment:
 
 ```bash
-python3 scripts/collect_recommendations.py --reassess <all_IDs>
+python3 scripts/collect_recommendations.py --reassess $(python3 scripts/state.py read-ids tmp/review-all-ids.txt)
 ```
 
-Parse output for `REASSESS=` line. For each ID needing re-assessment (revised=true, pass=false), and this is cycle 1:
+Parse output for `REASSESS=` line. For each ID needing re-assessment (revised=true, pass=false), initialize the cycle counter on disk (set-default is safe if compression causes re-entry — it won't reset an existing counter):
+
+```bash
+python3 scripts/state.py set-default tmp/review-config.yaml reassess_cycle=0
+```
+
+Before starting a cycle, re-read the cycle counter to guard against context compression:
+
+```bash
+python3 scripts/state.py read tmp/review-config.yaml
+```
+
+If `reassess_cycle` already shows 2 or higher, stop — max cycles reached. Otherwise, increment after each cycle:
+
+```bash
+python3 scripts/state.py set tmp/review-config.yaml reassess_cycle=<N+1>
+```
+
+For cycle 1:
+
+Persist reassess IDs to disk (needed across 4a–4e, may be lost to compression during agents):
+
+```bash
+python3 scripts/state.py write-ids tmp/review-reassess-ids.txt <all_reassess_IDs>
+```
 
 **4a. Save cumulative state and remove review files** so progress detection works:
 
@@ -209,16 +255,20 @@ Read .claude/skills/rfe.review/prompts/review-and-revise-agent.md and follow all
 
 Launch all review agents in parallel. Wait for all to complete (file existence check works because review files were removed in 4a).
 
-**4d. Restore before_scores and revision history:**
+**4d. Restore before_scores and revision history.** Re-read reassess IDs from disk:
 
 ```bash
-python3 scripts/preserve_review_state.py restore <all_reassess_IDs>
+python3 scripts/state.py read-ids tmp/review-reassess-ids.txt
+```
+
+```bash
+python3 scripts/preserve_review_state.py restore <all_reassess_IDs_from_file>
 ```
 
 **4e. Filter for revision** (also catches score regressions and sets autorevise_reject):
 
 ```bash
-python3 scripts/filter_for_revision.py <all_reassess_IDs>
+python3 scripts/filter_for_revision.py <all_reassess_IDs_from_file>
 ```
 
 Launch revise agents for the IDs returned (if any). Wait for all to complete, run post-processing revised flag fix (same as Step 3.5).
@@ -236,15 +286,15 @@ python3 scripts/frontmatter.py rebuild-index
 Re-read flags (in case context was compressed):
 
 ```bash
-cat tmp/review-config.yaml
+python3 scripts/state.py read tmp/review-config.yaml
 ```
 
 **If `headless: true`**: Stop here. Do not output any summary. The calling orchestrator handles reporting. **Resume the calling skill's next step immediately.**
 
-**If interactive (no `--headless`)**: Read results and present summary:
+**If interactive (no `--headless`)**: Re-read ID list and present summary:
 
 ```bash
-python3 scripts/batch_summary.py <all_IDs>
+python3 scripts/batch_summary.py $(python3 scripts/state.py read-ids tmp/review-all-ids.txt)
 ```
 
 Based on the output:

--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -20,13 +20,8 @@ Parse `$ARGUMENTS` for:
 Clean temp state and persist parsed flags:
 
 ```bash
-rm -rf tmp/ && mkdir -p tmp && cat > tmp/speedrun-config.yaml << 'EOF'
-headless: <true/false>
-announce_complete: <true/false>
-dry_run: <true/false>
-batch_size: <N>
-input_file: <path or null>
-EOF
+python3 scripts/state.py clean
+python3 scripts/state.py init tmp/speedrun-config.yaml headless=<true/false> announce_complete=<true/false> dry_run=<true/false> batch_size=<N> input_file=<path or null>
 ```
 
 Determine pipeline mode:
@@ -62,7 +57,7 @@ For each entry, invoke `/rfe.create` as an inline Skill:
 /rfe.create --headless [--priority <priority>] [--labels <labels>] <prompt>
 ```
 
-Collect all created RFE IDs from the output. Continue to Phase 2.
+Collect all created RFE IDs from the output.
 
 **Mode B (Existing RFE)**: Skip Phase 1. The Jira key(s) from arguments become the processing list.
 
@@ -74,12 +69,25 @@ Collect all created RFE IDs from the output. Continue to Phase 2.
 
 If not headless, `/rfe.create` will ask clarifying questions. Collect created RFE IDs.
 
+After Phase 1 (all modes), persist the ID list to disk:
+
+```bash
+python3 scripts/state.py write-ids tmp/speedrun-all-ids.txt <all_IDs>
+```
+
 ## Phase 2: Auto-fix
 
-Build the auto-fix command with all created/provided IDs:
+Re-read config and ID list from disk (in case context was compressed during Phase 1):
+
+```bash
+python3 scripts/state.py read tmp/speedrun-config.yaml
+python3 scripts/state.py read-ids tmp/speedrun-all-ids.txt
+```
+
+Build the auto-fix command using flags from the config file:
 
 ```
-/rfe.auto-fix [--headless] [--announce-complete] [--batch-size N] <all_IDs>
+/rfe.auto-fix [--headless] [--announce-complete] [--batch-size N] <all_IDs_from_file>
 ```
 
 Pass `--headless` and `--announce-complete` through if set. Pass `--batch-size` if provided.
@@ -91,13 +99,19 @@ Auto-fix handles: assessment, feasibility checks, review, auto-revision, re-asse
 Re-read flags (in case context was compressed):
 
 ```bash
-cat tmp/speedrun-config.yaml
+python3 scripts/state.py read tmp/speedrun-config.yaml
+```
+
+Re-read ID list from disk:
+
+```bash
+python3 scripts/state.py read-ids tmp/speedrun-all-ids.txt
 ```
 
 Collect passing IDs:
 
 ```bash
-python3 scripts/collect_recommendations.py <all_IDs>
+python3 scripts/collect_recommendations.py <all_IDs_from_file>
 ```
 
 Parse the `SUBMIT=` line for IDs ready to submit.
@@ -119,7 +133,7 @@ If headless: pass `--headless` so submit skips confirmation.
 Re-read flags:
 
 ```bash
-cat tmp/speedrun-config.yaml
+python3 scripts/state.py read tmp/speedrun-config.yaml
 ```
 
 If headless, output a brief machine-readable summary. If interactive, output:

--- a/.claude/skills/rfe.split/SKILL.md
+++ b/.claude/skills/rfe.split/SKILL.md
@@ -16,12 +16,16 @@ Parse `$ARGUMENTS` for flags and IDs:
 Persist parsed flags (survives context compression):
 
 ```bash
-mkdir -p tmp && cat > tmp/split-config.yaml << 'EOF'
-headless: <true/false>
-EOF
+python3 scripts/state.py init tmp/split-config.yaml headless=<true/false>
 ```
 
 If no arguments provided, stop with: "Usage: `/rfe.split <ID> [ID2 ...]`. Provide one or more RFE IDs."
+
+Persist all IDs to disk (survives context compression):
+
+```bash
+python3 scripts/state.py write-ids tmp/split-all-ids.txt <all_IDs>
+```
 
 For each ID, verify the task file exists via Glob (`artifacts/rfe-tasks/<ID>.md`). If missing, report and skip.
 
@@ -38,7 +42,7 @@ Launch all split agents in parallel.
 Write IDs to poll file once, then poll using `NEXT_POLL` interval:
 
 ```bash
-echo "<all_IDs>" > tmp/rfe-poll-split.txt
+python3 scripts/state.py write-ids tmp/rfe-poll-split.txt <all_IDs>
 python3 scripts/check_review_progress.py --phase split --id-file tmp/rfe-poll-split.txt
 ```
 
@@ -51,6 +55,12 @@ python3 scripts/frontmatter.py set artifacts/rfe-reviews/<ID>-review.md error="s
 ```
 
 ## Step 2: Collect Children and Review
+
+Re-read parent IDs from disk (context compression may have corrupted in-memory lists):
+
+```bash
+python3 scripts/state.py read-ids tmp/split-all-ids.txt
+```
 
 For each ID, read `artifacts/rfe-reviews/<ID>-split-status.yaml`. If `action: no-split`, update the review recommendation so downstream consumers don't treat it as needing a split:
 
@@ -76,7 +86,25 @@ This triggers the full agent delegation review pipeline on all children.
 
 ## Step 3: Right-sizing Self-Correction (up to 3 cycles)
 
-After `/rfe.review` completes on children, check right-sized scores. For each child:
+Initialize the correction cycle counter on disk (set-default is safe if compression causes re-entry — it won't reset an existing counter):
+
+```bash
+python3 scripts/state.py set-default tmp/split-config.yaml correction_cycle=0
+```
+
+After `/rfe.review` completes on children, re-read config and parent IDs (context compression may have lost them):
+
+```bash
+python3 scripts/state.py read tmp/split-config.yaml
+```
+
+If `correction_cycle` is 3 or higher, stop and report remaining right-sizing concerns. Otherwise, re-derive child IDs:
+
+```bash
+python3 scripts/collect_children.py $(python3 scripts/state.py read-ids tmp/split-all-ids.txt)
+```
+
+Check right-sized scores. For each child:
 
 ```bash
 python3 scripts/frontmatter.py read artifacts/rfe-reviews/<child_ID>-review.md
@@ -90,7 +118,13 @@ If any child scores below 2/2 on `scores.right_sized`:
 4. **Review new children**: Invoke `/rfe.review [--headless] <new_child_IDs>`
 5. **Check again**: Read right-sized scores for new children
 
-Repeat up to 3 cycles total. After 3 cycles, stop and report remaining right-sizing concerns.
+After each cycle, increment the counter on disk:
+
+```bash
+python3 scripts/state.py set tmp/split-config.yaml correction_cycle=<N+1>
+```
+
+Re-read config before starting the next cycle to check the counter. Stop after 3 cycles and report remaining right-sizing concerns.
 
 **Do not re-split for non-Right-sized criteria.** This loop only corrects grouping mistakes caught by the Right-sized score. Other criteria are handled by `/rfe.review`'s auto-revision.
 
@@ -105,7 +139,7 @@ python3 scripts/frontmatter.py rebuild-index
 Re-read flags (in case context was compressed):
 
 ```bash
-cat tmp/split-config.yaml
+python3 scripts/state.py read tmp/split-config.yaml
 ```
 
 **If `headless: true`**: Stop here. Do not output any summary. **Resume the calling skill's next step immediately.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,23 @@ python3 scripts/frontmatter.py read <path>
 python3 scripts/frontmatter.py rebuild-index
 ```
 
+### State Persistence
+
+Long-running skills use `scripts/state.py` to persist state to `tmp/` files so it survives context compression. All skills must use this utility instead of inline bash commands (cat, echo, mkdir) to avoid unnecessary auth prompts.
+
+```bash
+python3 scripts/state.py init <file> key=value ...    # Create config file
+python3 scripts/state.py set <file> key=value ...     # Update keys in place
+python3 scripts/state.py set-default <file> key=value ...  # Set only if key absent (cycle counters)
+python3 scripts/state.py read <file>                  # Print file contents
+python3 scripts/state.py write-ids <file> ID ...      # Write ID list (one per line, deduped)
+python3 scripts/state.py read-ids <file>              # Print IDs space-separated
+python3 scripts/state.py timestamp                    # Print current UTC time (ISO 8601)
+python3 scripts/state.py clean                        # Reset tmp/ directory
+```
+
+Each skill uses distinct file prefixes to avoid collisions during nested calls: `autofix-`, `review-`, `split-`, `speedrun-`.
+
 ### File Naming
 
 - **Existing Jira issues**: Use Jira key as filename and `rfe_id` (e.g., `RHAIRFE-1595.md` with `rfe_id: RHAIRFE-1595`)

--- a/scripts/state.py
+++ b/scripts/state.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""State persistence for skills — survives context compression.
+
+Usage:
+    # Initialize config (creates tmp/ dir, overwrites file)
+    python3 scripts/state.py init <file> key=value ...
+
+    # Set key-value pairs (updates existing keys in place)
+    python3 scripts/state.py set <file> key=value ...
+
+    # Set key-value pairs only if not already present
+    python3 scripts/state.py set-default <file> key=value ...
+
+    # Read a config or ID file (prints contents)
+    python3 scripts/state.py read <file>
+
+    # Write an ID list (one per line, overwrites)
+    python3 scripts/state.py write-ids <file> <ID> [ID ...]
+
+    # Read an ID list (prints space-separated on one line)
+    python3 scripts/state.py read-ids <file>
+
+    # Print current UTC timestamp (ISO 8601)
+    python3 scripts/state.py timestamp
+
+    # Clean tmp/ directory
+    python3 scripts/state.py clean
+"""
+import os
+import sys
+
+
+def cmd_init(args):
+    """Create tmp/ and write a fresh config file with key=value pairs."""
+    if len(args) < 1:
+        print("Usage: state.py init <file> [key=value ...]", file=sys.stderr)
+        sys.exit(1)
+    path = args[0]
+    os.makedirs(os.path.dirname(path) or "tmp", exist_ok=True)
+    pairs = _parse_pairs(args[1:])
+    with open(path, "w") as f:
+        for k, v in pairs:
+            f.write(f"{k}: {v}\n")
+
+
+def cmd_set(args):
+    """Set key-value pairs, updating existing keys in place.
+
+    Note: not atomic — assumes single-process sequential access (one
+    Claude session per working directory).
+    """
+    if len(args) < 2:
+        print("Usage: state.py set <file> key=value ...", file=sys.stderr)
+        sys.exit(1)
+    path = args[0]
+    pairs = _parse_pairs(args[1:])
+    update = {k: v for k, v in pairs}
+    os.makedirs(os.path.dirname(path) or "tmp", exist_ok=True)
+    # Read existing lines, update matching keys
+    lines = []
+    seen = set()
+    if os.path.exists(path):
+        with open(path) as f:
+            for line in f:
+                key = line.split(":")[0].strip() if ":" in line else None
+                if key in update:
+                    lines.append(f"{key}: {update[key]}\n")
+                    seen.add(key)
+                else:
+                    lines.append(line)
+    # Append any new keys not already in file
+    for k, v in pairs:
+        if k not in seen:
+            lines.append(f"{k}: {v}\n")
+    with open(path, "w") as f:
+        f.writelines(lines)
+
+
+def cmd_set_default(args):
+    """Set key-value pairs only if the key is not already present.
+
+    Safe for cycle counters and other values that must not be reset
+    if context compression causes re-entry to initialization code.
+    """
+    if len(args) < 2:
+        print("Usage: state.py set-default <file> key=value ...", file=sys.stderr)
+        sys.exit(1)
+    path = args[0]
+    pairs = _parse_pairs(args[1:])
+    existing_keys = set()
+    if os.path.exists(path):
+        with open(path) as f:
+            for line in f:
+                if ":" in line:
+                    existing_keys.add(line.split(":")[0].strip())
+    new_pairs = [(k, v) for k, v in pairs if k not in existing_keys]
+    if new_pairs:
+        os.makedirs(os.path.dirname(path) or "tmp", exist_ok=True)
+        with open(path, "a") as f:
+            for k, v in new_pairs:
+                f.write(f"{k}: {v}\n")
+
+
+def cmd_read(args):
+    """Print contents of a file."""
+    if len(args) < 1:
+        print("Usage: state.py read <file>", file=sys.stderr)
+        sys.exit(1)
+    path = args[0]
+    if not os.path.exists(path):
+        print(f"State file not found: {path} — was it persisted in a prior step?", file=sys.stderr)
+        sys.exit(1)
+    with open(path) as f:
+        print(f.read(), end="")
+
+
+def cmd_write_ids(args):
+    """Write IDs to a file, one per line. Accepts zero IDs (writes empty file)."""
+    if len(args) < 1:
+        print("Usage: state.py write-ids <file> [ID ...]", file=sys.stderr)
+        sys.exit(1)
+    path = args[0]
+    ids = list(dict.fromkeys(args[1:]))  # deduplicate, preserve order
+    os.makedirs(os.path.dirname(path) or "tmp", exist_ok=True)
+    with open(path, "w") as f:
+        for id_ in ids:
+            f.write(f"{id_}\n")
+
+
+def cmd_read_ids(args):
+    """Read IDs from a file, print space-separated."""
+    if len(args) < 1:
+        print("Usage: state.py read-ids <file>", file=sys.stderr)
+        sys.exit(1)
+    path = args[0]
+    if not os.path.exists(path):
+        print(f"State file not found: {path} — was it persisted in a prior step?", file=sys.stderr)
+        sys.exit(1)
+    with open(path) as f:
+        ids = [line.strip() for line in f if line.strip()]
+    print(" ".join(ids))
+
+
+def cmd_timestamp(args):
+    """Print current UTC timestamp in ISO 8601 format."""
+    from datetime import datetime, timezone
+    print(datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+
+def cmd_clean(args):
+    """Remove and recreate tmp/. Only call from top-level entry points."""
+    import shutil
+    if os.path.exists("tmp"):
+        shutil.rmtree("tmp")
+    os.makedirs("tmp", exist_ok=True)
+
+
+def _parse_pairs(args):
+    """Parse key=value arguments into (key, value) tuples."""
+    pairs = []
+    for arg in args:
+        if "=" not in arg:
+            print(f"Invalid key=value: {arg}", file=sys.stderr)
+            sys.exit(1)
+        k, v = arg.split("=", 1)
+        pairs.append((k, v))
+    return pairs
+
+
+COMMANDS = {
+    "init": cmd_init,
+    "set": cmd_set,
+    "set-default": cmd_set_default,
+    "read": cmd_read,
+    "write-ids": cmd_write_ids,
+    "read-ids": cmd_read_ids,
+    "timestamp": cmd_timestamp,
+    "clean": cmd_clean,
+}
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2 or sys.argv[1] not in COMMANDS:
+        print(f"Commands: {', '.join(COMMANDS)}", file=sys.stderr)
+        sys.exit(1)
+    COMMANDS[sys.argv[1]](sys.argv[2:])

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Tests for scripts/state.py."""
+import os
+import subprocess
+import pytest
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "state.py")
+
+
+def run_state(*args):
+    """Run state.py and return (stdout, stderr, returncode)."""
+    result = subprocess.run(
+        ["python3", SCRIPT, *args],
+        capture_output=True, text=True,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+@pytest.fixture
+def tmp_dir(tmp_path):
+    """Run tests from a temp directory to isolate state files."""
+    orig = os.getcwd()
+    os.chdir(tmp_path)
+    yield tmp_path
+    os.chdir(orig)
+
+
+class TestInitAndRead:
+    def test_init_creates_file(self, tmp_dir):
+        run_state("init", "tmp/config.yaml", "headless=true", "batch_size=5")
+        out, _, rc = run_state("read", "tmp/config.yaml")
+        assert rc == 0
+        assert "headless: true" in out
+        assert "batch_size: 5" in out
+
+    def test_init_overwrites(self, tmp_dir):
+        run_state("init", "tmp/config.yaml", "a=1")
+        run_state("init", "tmp/config.yaml", "b=2")
+        out, _, _ = run_state("read", "tmp/config.yaml")
+        assert "a: 1" not in out
+        assert "b: 2" in out
+
+
+class TestSet:
+    def test_set_adds_new_key(self, tmp_dir):
+        run_state("init", "tmp/config.yaml", "a=1")
+        run_state("set", "tmp/config.yaml", "b=2")
+        out, _, _ = run_state("read", "tmp/config.yaml")
+        assert "a: 1" in out
+        assert "b: 2" in out
+
+    def test_set_updates_existing_key_in_place(self, tmp_dir):
+        run_state("init", "tmp/config.yaml", "batch_size=5", "current_batch=0")
+        run_state("set", "tmp/config.yaml", "current_batch=1")
+        run_state("set", "tmp/config.yaml", "current_batch=2")
+        out, _, _ = run_state("read", "tmp/config.yaml")
+        assert out.count("current_batch") == 1
+        assert "current_batch: 2" in out
+        assert "batch_size: 5" in out
+
+    def test_set_preserves_key_order(self, tmp_dir):
+        run_state("init", "tmp/config.yaml", "a=1", "b=2", "c=3")
+        run_state("set", "tmp/config.yaml", "b=updated")
+        out, _, _ = run_state("read", "tmp/config.yaml")
+        lines = [l for l in out.strip().split("\n") if l]
+        assert lines[0] == "a: 1"
+        assert lines[1] == "b: updated"
+        assert lines[2] == "c: 3"
+
+    def test_set_value_with_equals(self, tmp_dir):
+        run_state("init", "tmp/config.yaml")
+        run_state("set", "tmp/config.yaml", "start_time=2026-04-01T18:20:38Z")
+        out, _, _ = run_state("read", "tmp/config.yaml")
+        assert "start_time: 2026-04-01T18:20:38Z" in out
+
+    def test_set_creates_directory(self, tmp_dir):
+        run_state("set", "tmp/config.yaml", "a=1")
+        out, _, rc = run_state("read", "tmp/config.yaml")
+        assert rc == 0
+        assert "a: 1" in out
+
+
+class TestSetDefault:
+    def test_sets_when_absent(self, tmp_dir):
+        run_state("init", "tmp/config.yaml", "headless=true")
+        run_state("set-default", "tmp/config.yaml", "cycle=0")
+        out, _, _ = run_state("read", "tmp/config.yaml")
+        assert "cycle: 0" in out
+
+    def test_skips_when_present(self, tmp_dir):
+        run_state("init", "tmp/config.yaml", "cycle=2")
+        run_state("set-default", "tmp/config.yaml", "cycle=0")
+        out, _, _ = run_state("read", "tmp/config.yaml")
+        assert out.count("cycle") == 1
+        assert "cycle: 2" in out
+
+    def test_compression_reentry_safe(self, tmp_dir):
+        """Simulates the exact failure: counter set, incremented, then re-entered."""
+        run_state("init", "tmp/config.yaml", "headless=true")
+        run_state("set-default", "tmp/config.yaml", "reassess_cycle=0")
+        run_state("set", "tmp/config.yaml", "reassess_cycle=1")
+        # Compression re-entry: init code runs again
+        run_state("set-default", "tmp/config.yaml", "reassess_cycle=0")
+        out, _, _ = run_state("read", "tmp/config.yaml")
+        assert "reassess_cycle: 1" in out  # must NOT reset to 0
+
+
+class TestWriteAndReadIds:
+    def test_round_trip(self, tmp_dir):
+        run_state("write-ids", "tmp/ids.txt", "RHAIRFE-1001", "RHAIRFE-1002", "RHAIRFE-1003")
+        out, _, rc = run_state("read-ids", "tmp/ids.txt")
+        assert rc == 0
+        assert out.strip() == "RHAIRFE-1001 RHAIRFE-1002 RHAIRFE-1003"
+
+    def test_deduplicates(self, tmp_dir):
+        run_state("write-ids", "tmp/ids.txt", "RHAIRFE-1001", "RHAIRFE-1002", "RHAIRFE-1001")
+        out, _, _ = run_state("read-ids", "tmp/ids.txt")
+        assert out.strip() == "RHAIRFE-1001 RHAIRFE-1002"
+
+    def test_empty_id_list(self, tmp_dir):
+        run_state("write-ids", "tmp/ids.txt")
+        out, _, rc = run_state("read-ids", "tmp/ids.txt")
+        assert rc == 0
+        assert out.strip() == ""
+
+    def test_write_overwrites(self, tmp_dir):
+        run_state("write-ids", "tmp/ids.txt", "A", "B")
+        run_state("write-ids", "tmp/ids.txt", "C", "D")
+        out, _, _ = run_state("read-ids", "tmp/ids.txt")
+        assert out.strip() == "C D"
+
+
+class TestErrorHandling:
+    def test_read_missing_file(self, tmp_dir):
+        _, err, rc = run_state("read", "tmp/nonexistent.yaml")
+        assert rc != 0
+        assert "State file not found" in err
+
+    def test_read_ids_missing_file(self, tmp_dir):
+        _, err, rc = run_state("read-ids", "tmp/nonexistent.txt")
+        assert rc != 0
+        assert "State file not found" in err
+
+
+class TestTimestamp:
+    def test_returns_iso8601(self, tmp_dir):
+        import re
+        out, _, rc = run_state("timestamp")
+        assert rc == 0
+        assert re.match(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", out.strip())
+
+    def test_round_trips_through_set(self, tmp_dir):
+        run_state("init", "tmp/config.yaml")
+        ts, _, _ = run_state("timestamp")
+        run_state("set", "tmp/config.yaml", f"start_time={ts.strip()}")
+        out, _, _ = run_state("read", "tmp/config.yaml")
+        assert f"start_time: {ts.strip()}" in out
+
+
+class TestClean:
+    def test_clean_removes_and_recreates(self, tmp_dir):
+        run_state("init", "tmp/config.yaml", "a=1")
+        run_state("write-ids", "tmp/ids.txt", "X")
+        run_state("clean")
+        assert os.path.isdir("tmp")
+        assert not os.path.exists("tmp/config.yaml")
+        assert not os.path.exists("tmp/ids.txt")


### PR DESCRIPTION
## Summary

Context compression in long-running Claude Code CI sessions causes the LLM to lose in-memory state, leading to hallucinated IDs, infinite loops, and missed completion signals. This PR adds centralized state persistence and diagnostics across all four orchestrator skills.

**Observed failures fixed:**
- **ID hallucination**: 38/50 IDs fabricated as sequential numbers after batch 1 split (jobs 26, 35); retry queue IDs hallucinated in job 36
- **CI spin**: 45-min waste in job 35 when `announce_complete` flag lost to compression, `finish.py` never ran
- **Potential infinite loops**: reassess and correction cycle counters were in-memory only

**Changes:**
- Add `scripts/state.py` — centralized state persistence utility replacing ~25 inline bash commands, also reducing auth prompts per run
- Persist all ID lists to disk with mandatory re-reads at every step boundary
- Persist cycle counters and config flags to survive compression
- Add `[AUTOFIX]` step markers and ID count logging for CI trace debugging

## Files changed

| File | Change |
|------|--------|
| `scripts/state.py` | New: centralized state persistence utility |
| `.claude/skills/rfe.auto-fix/SKILL.md` | ID persistence, retry fix, diagnostics, bash-to-python |
| `.claude/skills/rfe.review/SKILL.md` | ID persistence, cycle counter, bash-to-python |
| `.claude/skills/rfe.split/SKILL.md` | ID persistence, cycle counter, bash-to-python |
| `.claude/skills/rfe.speedrun/SKILL.md` | Config/ID persistence, bash-to-python |

## Test plan

- [ ] Run multi-batch auto-fix (20+ IDs, batch_size=5) — verify no ID hallucination across batches
- [ ] Run with `--announce-complete` — verify `finish.py` executes after Step 6
- [ ] Verify `[AUTOFIX]` markers appear in CI trace and ID counts match expectations
- [ ] Verify retry queue uses persisted IDs when errors occur

Generated with [Claude Code](https://claude.com/claude-code)