### PR TITLE
Fix rfe-scorer subagent_type namespace prefix

### DIFF
--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -78,7 +78,7 @@ For each ID being reviewed:
 python3 scripts/prep_assess.py <ID>
 ```
 
-**Launch assess agent** (model: opus, run_in_background: true, subagent_type: assess-rfe:rfe-scorer):
+**Launch assess agent** (model: opus, run_in_background: true, subagent_type: rfe-scorer):
 
 ```
 Read .claude/skills/rfe.review/prompts/assess-agent.md and follow all instructions. Substitute: {KEY}=<ID>, {DATA_FILE}=/tmp/rfe-assess/single/<ID>.md, {RUN_DIR}=/tmp/rfe-assess/single, {PROMPT_PATH}=.context/assess-rfe/scripts/agent_prompt.md
@@ -231,7 +231,7 @@ rm artifacts/rfe-reviews/<ID>-review.md  # for each reassess ID
 python3 scripts/prep_assess.py <ID>
 ```
 
-Launch an **assess agent** (model: opus, run_in_background: true, subagent_type: assess-rfe:rfe-scorer) for each reassess ID:
+Launch an **assess agent** (model: opus, run_in_background: true, subagent_type: rfe-scorer) for each reassess ID:
 
 ```
 Read .claude/skills/rfe.review/prompts/assess-agent.md and follow all instructions. Substitute: {KEY}=<ID>, {DATA_FILE}=/tmp/rfe-assess/single/<ID>.md, {RUN_DIR}=/tmp/rfe-assess/single, {PROMPT_PATH}=.context/assess-rfe/scripts/agent_prompt.md

--- a/.claude/skills/rfe.review/prompts/assess-agent.md
+++ b/.claude/skills/rfe.review/prompts/assess-agent.md
@@ -9,6 +9,6 @@ Issue key: {KEY}
 Data file: {DATA_FILE}
 Run directory: {RUN_DIR}
 
-Launch with: subagent_type: assess-rfe:rfe-scorer
+Launch with: subagent_type: rfe-scorer
 
 Do not return a summary. Your work is complete when the result file exists.


### PR DESCRIPTION
## Summary
- Drop `assess-rfe:` namespace prefix from `subagent_type` — the namespaced form only works when assess-rfe is installed as a native plugin, not when the agent definition is copied to `.claude/agents/`

Fixes: `The assess-rfe:rfe-scorer agent type is not available`

## Test plan
- [ ] Run `/rfe.review RHAIRFE-<id>` and verify assess agents launch successfully with `rfe-scorer` subagent type

🤖 Generated with [Claude Code](https://claude.com/claude-code)