### PR TITLE
Add rfe-creator-autofix-pass label to skip re-assessing passing RFEs

### DIFF
--- a/.claude/skills/rfe.submit/SKILL.md
+++ b/.claude/skills/rfe.submit/SKILL.md
@@ -94,5 +94,6 @@ The scripts automatically apply labels based on what happened during the pipelin
 | `rfe-creator-split-original` | Parent ticket that was decomposed into smaller RFEs |
 | `rfe-creator-split-result` | Child ticket produced by splitting another RFE |
 | `rfe-creator-needs-attention` | Automation couldn't fully resolve all issues — human review needed (review frontmatter `needs_attention: true`) |
+| `rfe-creator-autofix-pass` | RFE passed review (recommendation = "submit") — excluded from future auto-fix JQL queries |
 
 $ARGUMENTS

--- a/scripts/jql_query.py
+++ b/scripts/jql_query.py
@@ -72,7 +72,7 @@ def main():
               file=sys.stderr)
         sys.exit(1)
 
-    jql = f"({args.jql}) AND statusCategory != Done AND labels not in (rfe-creator-ignore)"
+    jql = f"({args.jql}) AND statusCategory != Done AND labels not in (rfe-creator-ignore, rfe-creator-autofix-pass)"
     search_issues(server, user, token, jql, args.limit)
 
 

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -175,16 +175,20 @@ def phase2_create_link(server, user, token, parent_key, children, state,
         labels = ["rfe-creator-auto-created", "rfe-creator-split-result"]
 
         review_path = find_review_file(artifacts_dir, rfe_id)
+        review_rec = None
         if review_path:
             try:
                 review_data, _ = read_frontmatter_validated(
                     review_path, "rfe-review")
+                review_rec = review_data.get("recommendation")
                 if review_data.get("auto_revised", False):
                     labels.append("rfe-creator-auto-revised")
                 if review_data.get("needs_attention", False):
                     labels.append("rfe-creator-needs-attention")
             except (ValidationError, Exception):
                 pass  # proceed without review data
+        if review_rec == "submit":
+            labels.append("rfe-creator-autofix-pass")
 
         if dry_run:
             print(f"  Phase 2: Would create RHAIRFE ticket for child "

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -147,7 +147,7 @@ def main():
             })
             continue
 
-        # For existing RFEs, skip if content hasn't changed
+        # For existing RFEs, check if content has changed
         if is_existing:
             original_path = os.path.join(
                 args.artifacts_dir, "rfe-originals", f"{rfe_id}.md")
@@ -157,11 +157,21 @@ def main():
                 with open(task_path, encoding="utf-8") as f:
                     current_body = strip_metadata(f.read())
                 if original_body.strip() == current_body.strip():
+                    # No content changes — still apply labels (e.g. pass marker)
+                    no_change_labels = []
+                    if review_data and review_data.get("auto_revised", False):
+                        no_change_labels.append("rfe-creator-auto-revised")
+                    if review_data and review_data.get("needs_attention", False):
+                        no_change_labels.append("rfe-creator-needs-attention")
+                    if review_data and rec == "submit":
+                        no_change_labels.append("rfe-creator-autofix-pass")
                     plan.append({
                         "rfe_id": rfe_id, "title": title,
                         "is_existing": is_existing, "priority": priority,
-                        "size": size, "action": "SKIP", "labels": [],
-                        "skip_reason": "no changes",
+                        "size": size,
+                        "action": "Label only" if no_change_labels else "SKIP",
+                        "labels": no_change_labels,
+                        "skip_reason": None if no_change_labels else "no changes",
                         "task_path": task_path,
                     })
                     continue
@@ -174,6 +184,8 @@ def main():
             labels.append("rfe-creator-auto-revised")
         if review_data and review_data.get("needs_attention", False):
             labels.append("rfe-creator-needs-attention")
+        if review_data and rec == "submit":
+            labels.append("rfe-creator-autofix-pass")
 
         action = f"Update {rfe_id}" if is_existing else "Create"
         plan.append({
@@ -204,6 +216,16 @@ def main():
         rfe_id = entry["rfe_id"]
         if entry["skip_reason"]:
             print(f"  {rfe_id}: Skipping — {entry['skip_reason']}")
+            continue
+
+        if entry["action"] == "Label only":
+            labels = entry["labels"]
+            if args.dry_run:
+                print(f"  {rfe_id}: Would add labels: {', '.join(labels)}")
+            else:
+                add_labels(server, user, token, rfe_id, labels)
+                print(f"  {rfe_id}: Labels: {', '.join(labels)}")
+            results[rfe_id] = rfe_id
             continue
 
         # Read and clean artifact content

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -83,8 +83,8 @@ def art_dir(tmp_path):
 
 
 class TestContentDiffGuard:
-    def test_existing_rfe_no_changes_skipped(self, art_dir):
-        """Existing RFE with identical content → SKIP no changes."""
+    def test_existing_rfe_no_changes_label_only(self, art_dir):
+        """Existing RFE with identical content and passing review → Label only."""
         body = "## Problem\n\nSame content.\n"
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
                TASK_FM.format(rfe_id="RHAIRFE-1234") )
@@ -98,8 +98,8 @@ class TestContentDiffGuard:
 
         stdout, _, rc = _run_submit(art_dir)
         assert rc == 0
-        assert "SKIP" in stdout
-        assert "no changes" in stdout
+        assert "Label only" in stdout
+        assert "rfe-creator-autofix-pass" in stdout
 
     def test_existing_rfe_with_changes_submitted(self, art_dir):
         """Existing RFE with different content → update."""


### PR DESCRIPTION
## Summary

- Apply `rfe-creator-autofix-pass` label during submit (standard + split paths) when an RFE has a confirmed passing review (`recommendation=submit`)
- JQL queries now exclude `rfe-creator-autofix-pass` labeled issues, so future auto-fix runs skip already-passing RFEs
- Existing RFEs with no content changes but a passing review get a new "Label only" action — applies labels via the API without rewriting the ticket description
- Guarded against false positives: label requires actual review data present, not just the default `rec=submit` fallback

## Test plan

- [x] All 76 existing tests pass
- [ ] Dry-run submit with a passing RFE — verify `rfe-creator-autofix-pass` in label list
- [ ] Dry-run submit with no review file — verify label is NOT applied
- [ ] Dry-run submit with unchanged existing RFE — verify "Label only" action shown
- [ ] JQL query excludes issues with `rfe-creator-autofix-pass` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)