### PR TITLE
Fix report missing detail pages for split children

### DIFF
--- a/scripts/generate_review_pdf.py
+++ b/scripts/generate_review_pdf.py
@@ -808,7 +808,7 @@ def main():
 
     detail_rfes = [r for r in rfes if not r.get('error')]
     if args.revised_only:
-        detail_rfes = [r for r in detail_rfes if r['auto_revised'] or r['is_split_parent']]
+        detail_rfes = [r for r in detail_rfes if r['auto_revised'] or r['is_split_parent'] or r.get('is_leaf_child')]
 
     for r in detail_rfes:
         d = r['after_total'] - r['before_total']


### PR DESCRIPTION
## Summary
- The `--revised-only` filter in `generate_review_pdf.py` excluded split children from detail pages because they have `auto_revised=false` (new RFEs, never revised) and `is_split_parent=false`
- The rendering code for child detail pages (score table) existed at lines 906-938 but was never reached
- Added `is_leaf_child` to the filter so split children get detail pages

## Test plan
- [x] Regenerated report from CI run 20260402-112959 — 36 split children now have detail pages
- [ ] Verify links from summary table to child detail anchors work

🤖 Generated with [Claude Code](https://claude.com/claude-code)