### PR TITLE
Fix submit pipeline for multi-level splits

### DIFF
--- a/.claude/skills/rfe.submit/SKILL.md
+++ b/.claude/skills/rfe.submit/SKILL.md
@@ -40,42 +40,11 @@ Parse the output and exit code:
 
 Skip conflict detection for `--dry-run` — go directly to Step 2.
 
-## Step 2: Detect Mode and Run
-
-Check task file frontmatter to determine whether this is a split submission or standard submission.
-
-### Split Submission
-
-If any task file has `status: Archived` and other task files have a matching `parent_key`, this is a split submission. Find the parent's `rfe_id` from its frontmatter and run:
-
-```bash
-python3 scripts/split_submit.py <PARENT_KEY> [--dry-run] [--artifacts-dir artifacts]
-```
-
-The split submit script handles:
-- Persisting child RFE content as comments on the parent (durable backup)
-- Creating child tickets with proper "Issue split" linking to the parent
-- Closing the parent ticket as Obsolete
-- Idempotent recovery if interrupted
-- Renaming local files from RFE-NNN to RHAIRFE-NNNN after submission
-- Rebuilding the rfes.md index
-
-### Standard Submission
-
-Otherwise, run:
+## Step 2: Run Submission
 
 ```bash
 python3 scripts/submit.py [--dry-run] [--artifacts-dir artifacts]
 ```
-
-The standard submit script handles:
-- Reading review recommendations from `rfe-reviews/` frontmatter and skipping rejected RFEs
-- Creating new RHAIRFE tickets for RFEs with local IDs (RFE-NNN)
-- Updating existing tickets for RFEs with Jira IDs (RHAIRFE-NNNN)
-- Applying labels from the labeling scheme (see below)
-- Posting removed-context Jira comments where applicable (from `*-removed-context.yaml` — posts `genuine` and `unclassified` blocks)
-- Renaming local files from RFE-NNN to RHAIRFE-NNNN after submission
-- Rebuilding the rfes.md index
 
 ## Step 3: Report Results
 

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -326,12 +326,27 @@ def main():
               f"found in task files.", file=sys.stderr)
         sys.exit(1)
 
-    # Find children: parent_key matches the parent's rfe_id
-    child_tasks = []
+    # Find leaf children: walk the tree recursively to collect all
+    # non-archived descendants.  Intermediary nodes (archived local IDs
+    # like RFE-017) are stepping stones — their children belong to the
+    # RHAIRFE parent for Jira linking purposes.
+    tasks_by_parent = {}
     for path, data in tasks:
-        if data.get("parent_key") == args.parent_key and \
-                data.get("status") != "Archived":
-            child_tasks.append((path, data))
+        pk = data.get("parent_key")
+        if pk:
+            tasks_by_parent.setdefault(pk, []).append((path, data))
+
+    def _collect_leaves(parent_id):
+        leaves = []
+        for path, data in tasks_by_parent.get(parent_id, []):
+            if data.get("status") == "Archived":
+                # Intermediary — recurse into its children
+                leaves.extend(_collect_leaves(data["rfe_id"]))
+            else:
+                leaves.append((path, data))
+        return leaves
+
+    child_tasks = _collect_leaves(args.parent_key)
 
     if not child_tasks:
         print("Error: No child RFEs found with parent_key="

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Submit RFE artifacts to Jira — create new or update existing tickets.
 
-Handles the standard (non-split) submission flow. For split submissions,
-use split_submit.py instead.
+Handles both split and standard submissions in one pass. Split parents
+(RHAIRFE with status: Archived) are submitted via split_submit.py first,
+then regular RFEs are updated/created directly.
 
 Reads all structured metadata from YAML frontmatter on task and review files.
 No regex parsing of markdown prose.
@@ -19,6 +20,7 @@ Environment variables:
 import argparse
 import os
 import re
+import subprocess
 import sys
 
 import yaml
@@ -99,19 +101,59 @@ def main():
               file=sys.stderr)
         sys.exit(1)
 
-    # Scan task files for submittable RFEs
+    # Scan task files
     tasks = scan_task_files(args.artifacts_dir)
     if not tasks:
         print("Error: No RFE task files found.", file=sys.stderr)
         sys.exit(1)
 
-    # Filter to non-archived RFEs
+    # --- Phase 1: Submit splits via split_submit.py ---
+    # Find RHAIRFE parents that were split (Archived + have children)
+    child_parent_keys = {data.get("parent_key") for _, data in tasks
+                         if data.get("parent_key")}
+    split_parents = [data["rfe_id"] for _, data in tasks
+                     if data.get("status") == "Archived"
+                     and data["rfe_id"].startswith("RHAIRFE-")
+                     and data["rfe_id"] in child_parent_keys]
+
+    if split_parents:
+        print(f"Phase 1: Submitting {len(split_parents)} split parent(s)\n")
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        split_script = os.path.join(script_dir, "split_submit.py")
+
+        for parent_key in sorted(split_parents):
+            cmd = [sys.executable, split_script, parent_key,
+                   "--artifacts-dir", args.artifacts_dir]
+            if args.dry_run:
+                cmd.append("--dry-run")
+            print(f"--- {parent_key} ---")
+            result = subprocess.run(cmd)
+            if result.returncode != 0:
+                print(f"Error: split_submit.py failed for {parent_key} "
+                      f"(exit code {result.returncode})", file=sys.stderr)
+                sys.exit(result.returncode)
+            print()
+
+    # --- Phase 2: Submit regular (non-split) RFEs ---
+    # Re-scan after splits may have renamed files
+    tasks = scan_task_files(args.artifacts_dir)
+
+    # Filter to non-archived RFEs without a parent (split children were
+    # already handled by split_submit.py in Phase 1)
     submittable = [(path, data) for path, data in tasks
-                   if data.get("status") != "Archived"]
+                   if data.get("status") != "Archived"
+                   and not data.get("parent_key")]
     if not submittable:
-        print("Error: No submittable RFEs found (all archived).",
-              file=sys.stderr)
+        if split_parents:
+            # All RFEs were splits — nothing left for Phase 2
+            rebuild_index(args.artifacts_dir)
+            print(f"Done. Index rebuilt at {args.artifacts_dir}/rfes.md")
+            return
+        print("Error: No submittable RFEs found.", file=sys.stderr)
         sys.exit(1)
+
+    if split_parents:
+        print(f"Phase 2: Submitting {len(submittable)} regular RFE(s)\n")
 
     # Build submission plan
     plan = []


### PR DESCRIPTION
## Summary
- **split_submit.py**: Walk split tree recursively to find all leaf children — multi-level splits (3+ levels) now correctly link all leaves to the RHAIRFE parent with "Issue split" links instead of orphaning grandchildren
- **submit.py**: Auto-detect split parents and delegate to split_submit.py in Phase 1, then handle regular RFEs in Phase 2 — eliminates fragile LLM-driven split detection
- **rfe.submit SKILL.md**: Simplified to just call submit.py, which now handles both split and standard submissions internally

## Test plan
- [ ] Run `python3 -m pytest tests/` — all 76 tests pass
- [ ] Run `/rfe.submit --dry-run` on a dataset with multi-level splits and verify all leaf children are accounted for
- [ ] Verify split parents show Phase 1 output with correct child counts
- [ ] Verify regular RFEs show Phase 2 output without any split children mixed in

🤖 Generated with [Claude Code](https://claude.com/claude-code)