### PR TITLE
Rename autofix-pass label to autofix-rubric-pass

### DIFF
--- a/.claude/skills/rfe.submit/SKILL.md
+++ b/.claude/skills/rfe.submit/SKILL.md
@@ -63,6 +63,6 @@ The scripts automatically apply labels based on what happened during the pipelin
 | `rfe-creator-split-original` | Parent ticket that was decomposed into smaller RFEs |
 | `rfe-creator-split-result` | Child ticket produced by splitting another RFE |
 | `rfe-creator-needs-attention` | Automation couldn't fully resolve all issues — human review needed (review frontmatter `needs_attention: true`) |
-| `rfe-creator-autofix-pass` | RFE passed review (recommendation = "submit") — excluded from future auto-fix JQL queries |
+| `rfe-creator-autofix-rubric-pass` | RFE passed review (recommendation = "submit") — excluded from future auto-fix JQL queries |
 
 $ARGUMENTS

--- a/scripts/jql_query.py
+++ b/scripts/jql_query.py
@@ -72,7 +72,7 @@ def main():
               file=sys.stderr)
         sys.exit(1)
 
-    jql = f"({args.jql}) AND statusCategory != Done AND labels not in (rfe-creator-ignore, rfe-creator-autofix-pass)"
+    jql = f"({args.jql}) AND statusCategory != Done AND labels not in (rfe-creator-ignore, rfe-creator-autofix-rubric-pass)"
     search_issues(server, user, token, jql, args.limit)
 
 

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -188,7 +188,7 @@ def phase2_create_link(server, user, token, parent_key, children, state,
             except (ValidationError, Exception):
                 pass  # proceed without review data
         if review_rec == "submit":
-            labels.append("rfe-creator-autofix-pass")
+            labels.append("rfe-creator-autofix-rubric-pass")
 
         if dry_run:
             print(f"  Phase 2: Would create RHAIRFE ticket for child "

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -206,7 +206,7 @@ def main():
                     if review_data and review_data.get("needs_attention", False):
                         no_change_labels.append("rfe-creator-needs-attention")
                     if review_data and rec == "submit":
-                        no_change_labels.append("rfe-creator-autofix-pass")
+                        no_change_labels.append("rfe-creator-autofix-rubric-pass")
                     plan.append({
                         "rfe_id": rfe_id, "title": title,
                         "is_existing": is_existing, "priority": priority,
@@ -227,7 +227,7 @@ def main():
         if review_data and review_data.get("needs_attention", False):
             labels.append("rfe-creator-needs-attention")
         if review_data and rec == "submit":
-            labels.append("rfe-creator-autofix-pass")
+            labels.append("rfe-creator-autofix-rubric-pass")
 
         action = f"Update {rfe_id}" if is_existing else "Create"
         plan.append({

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -99,7 +99,7 @@ class TestContentDiffGuard:
         stdout, _, rc = _run_submit(art_dir)
         assert rc == 0
         assert "Label only" in stdout
-        assert "rfe-creator-autofix-pass" in stdout
+        assert "rfe-creator-autofix-rubric-pass" in stdout
 
     def test_existing_rfe_with_changes_submitted(self, art_dir):
         """Existing RFE with different content → update."""


### PR DESCRIPTION
## Summary
- Renames `rfe-creator-autofix-pass` → `rfe-creator-autofix-rubric-pass` across all scripts, tests, and skill docs
- Clarifies that the label means the RFE passed rubric scoring, not that it needs no human review — `needs-attention` can legitimately coexist when feasibility concerns warrant human eyes

## Test plan
- [ ] `python3 -m pytest tests/` — all 76 tests pass
- [ ] Verify JQL exclusion filter in `jql_query.py` uses the new label name

🤖 Generated with [Claude Code](https://claude.com/claude-code)