### PR TITLE
Post Jira comment explaining needs-attention flag

### DIFF
--- a/.claude/skills/rfe.review/prompts/fetch-agent.md
+++ b/.claude/skills/rfe.review/prompts/fetch-agent.md
@@ -7,7 +7,7 @@ Fetch Jira issue {KEY} and write artifacts. Steps:
 2. Write the Jira description to artifacts/rfe-tasks/{KEY}.md as-is — preserve the original markdown structure, headings, and content exactly as fetched. Do not restructure, reformat, or fit it into any template. Do not add a title heading — the title lives in frontmatter only.
 
 3. Run: python3 scripts/frontmatter.py schema rfe-task
-   Then: python3 scripts/frontmatter.py set artifacts/rfe-tasks/{KEY}.md rfe_id={KEY} title="<title>" priority=<priority> size=<inferred> status=Ready
+   Then: python3 scripts/frontmatter.py set artifacts/rfe-tasks/{KEY}.md rfe_id={KEY} title="<title>" priority=<priority> size=<inferred> status=Ready original_labels="<comma-separated labels or null if none>"
 
 4. Save a raw copy of just the description to artifacts/rfe-originals/{KEY}.md (create directory if needed). This file is the baseline for before/after analysis and submit-time conflict detection. It is never modified after creation.
 

--- a/.claude/skills/rfe.review/prompts/review-agent.md
+++ b/.claude/skills/rfe.review/prompts/review-agent.md
@@ -42,10 +42,13 @@ Parse the score table from the assessment result file. Determine recommendation:
 - reject: fundamentally infeasible or needs rethinking
 Do NOT recommend split when capabilities are delivery-coupled.
 
+Set `needs_attention=true` when the RFE needs human review despite its score — e.g., feasibility is indeterminate/infeasible, references non-existent components, or has concerns the rubric doesn't capture. When true, also set `needs_attention_reason` to a concise explanation (1-2 sentences) of what needs human attention. When false, set `needs_attention_reason=null`.
+
 ```bash
 python3 scripts/frontmatter.py set artifacts/rfe-reviews/{ID}-review.md \
     rfe_id={ID} score=<total> pass=<true/false> recommendation=<rec> \
     feasibility=<feasible/infeasible/indeterminate> auto_revised=<true/false> needs_attention=<true/false> \
+    needs_attention_reason="<reason or null>" \
     scores.what=<n> scores.why=<n> scores.open_to_how=<n> scores.not_a_task=<n> scores.right_sized=<n>
 ```
 

--- a/.claude/skills/rfe.review/prompts/revise-agent.md
+++ b/.claude/skills/rfe.review/prompts/revise-agent.md
@@ -37,10 +37,10 @@ For each criterion the assessor flagged:
 **Immediately after editing the task file**, run:
 
 ```bash
-python3 scripts/frontmatter.py set artifacts/rfe-reviews/{ID}-review.md auto_revised=true needs_attention=<true/false>
+python3 scripts/frontmatter.py set artifacts/rfe-reviews/{ID}-review.md auto_revised=true needs_attention=<true/false> needs_attention_reason="<reason or null>"
 ```
 
-Set `needs_attention=true` if human review is still needed (e.g., missing evidence the author must provide). This is the most important step — do not skip it.
+Set `needs_attention=true` if human review is still needed (e.g., missing evidence the author must provide). When true, set `needs_attention_reason` to a concise explanation (1-2 sentences) of what the human needs to address. When false, set `needs_attention_reason=null`. This is the most important step — do not skip it.
 
 ## Step 4: Content Preservation
 

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -58,6 +58,11 @@ SCHEMAS = {
             "pattern": r"^(RFE-\d+|RHAIRFE-\d+)$",
             "default": None,
         },
+        "original_labels": {
+            "type": "list",
+            "required": False,
+            "default": None,
+        },
     },
     "rfe-review": {
         "rfe_id": {
@@ -111,6 +116,11 @@ SCHEMAS = {
         },
         "before_score": {
             "type": "int",
+            "required": False,
+            "default": None,
+        },
+        "needs_attention_reason": {
+            "type": "string",
             "required": False,
             "default": None,
         },
@@ -241,6 +251,11 @@ def _validate_field(name, value, spec, path=""):
         if not isinstance(value, bool):
             errors.append(
                 f"{full_name}: expected bool, got {type(value).__name__}")
+
+    elif expected_type == "list":
+        if not isinstance(value, list):
+            errors.append(
+                f"{full_name}: expected list, got {type(value).__name__}")
 
     elif expected_type == "dict":
         if not isinstance(value, dict):

--- a/scripts/frontmatter.py
+++ b/scripts/frontmatter.py
@@ -61,6 +61,12 @@ def _coerce_value(value_str, field_spec):
     if field_type == "int":
         return int(value_str)
 
+    if field_type == "list":
+        if value_str.lower() in ("null", "none", "[]"):
+            return None
+        # Accept comma-separated values
+        return [v.strip() for v in value_str.split(",") if v.strip()]
+
     if field_type == "string":
         if value_str.lower() == "null" or value_str.lower() == "none":
             return None

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -176,6 +176,7 @@ def phase2_create_link(server, user, token, parent_key, children, state,
 
         review_path = find_review_file(artifacts_dir, rfe_id)
         review_rec = None
+        attn_reason = None
         if review_path:
             try:
                 review_data, _ = read_frontmatter_validated(
@@ -185,6 +186,7 @@ def phase2_create_link(server, user, token, parent_key, children, state,
                     labels.append("rfe-creator-auto-revised")
                 if review_data.get("needs_attention", False):
                     labels.append("rfe-creator-needs-attention")
+                    attn_reason = review_data.get("needs_attention_reason")
             except (ValidationError, Exception):
                 pass  # proceed without review data
         if review_rec == "submit":
@@ -195,6 +197,8 @@ def phase2_create_link(server, user, token, parent_key, children, state,
                   f"{idx}/{total}: {title} (priority: {priority})")
             print(f"           Labels: {', '.join(labels)}")
             print(f"           Would link to {parent_key} via 'Issue split'")
+            if attn_reason:
+                print(f"           Would post needs-attention comment")
             state.phase2_done[idx] = "RHAIRFE-DRY"
             continue
 
@@ -216,6 +220,16 @@ def phase2_create_link(server, user, token, parent_key, children, state,
                         f"parent. (ref: child {idx} of {total})")
         add_comment(server, user, token, parent_key,
                     text_to_adf_paragraph(confirm_text))
+
+        # 4. Post needs-attention comment on the new child ticket
+        if attn_reason:
+            attn_md = (
+                "*[RFE Creator]* This RFE has been flagged for human "
+                f"review:\n\n{attn_reason}"
+            )
+            add_comment(server, user, token, child_key,
+                        markdown_to_adf(attn_md))
+            print(f"           Posted needs-attention comment")
 
         state.phase2_done[idx] = child_key
 

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -81,6 +81,40 @@ def _render_jira_comment(yaml_path):
     return preamble + "\n\n" + "\n\n".join(sections)
 
 
+def _post_needs_attention_comment(server, user, token, entry, results,
+                                  dry_run):
+    """Post a Jira comment explaining why human attention is needed.
+
+    Only posts if:
+    - needs_attention_reason is set in the review
+    - The issue did not already have the rfe-creator-needs-attention label
+      when it was fetched from Jira (checked via original_labels)
+    """
+    reason = entry.get("attn_reason")
+    if not reason:
+        return
+
+    original_labels = entry.get("original_labels") or []
+    if "rfe-creator-needs-attention" in original_labels:
+        return  # Already flagged in a prior run
+
+    target_key = results.get(entry["rfe_id"])
+    if dry_run:
+        print(f"  {entry['rfe_id']}: Would post needs-attention comment")
+        return
+
+    if not target_key:
+        return
+
+    comment_md = (
+        "*[RFE Creator]* This RFE has been flagged for human review:\n\n"
+        f"{reason}"
+    )
+    comment_adf = markdown_to_adf(comment_md)
+    add_comment(server, user, token, target_key, comment_adf)
+    print(f"  {entry['rfe_id']}: Posted needs-attention comment")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -180,12 +214,19 @@ def main():
         if review_data:
             rec = review_data.get("recommendation", "submit")
 
+        # Collect needs-attention info for Jira comment
+        original_labels = task_data.get("original_labels") or []
+        attn_reason = None
+        if review_data and review_data.get("needs_attention", False):
+            attn_reason = review_data.get("needs_attention_reason")
+
         if rec in ("reject", "autorevise_reject"):
             plan.append({
                 "rfe_id": rfe_id, "title": title,
                 "is_existing": is_existing, "priority": priority, "size": size,
                 "action": "SKIP", "labels": [], "skip_reason": "rejected",
                 "task_path": task_path,
+                "attn_reason": None, "original_labels": original_labels,
             })
             continue
 
@@ -215,6 +256,8 @@ def main():
                         "labels": no_change_labels,
                         "skip_reason": None if no_change_labels else "no changes",
                         "task_path": task_path,
+                        "attn_reason": attn_reason,
+                        "original_labels": original_labels,
                     })
                     continue
 
@@ -235,6 +278,7 @@ def main():
             "is_existing": is_existing, "priority": priority, "size": size,
             "action": action, "labels": labels, "skip_reason": None,
             "task_path": task_path,
+            "attn_reason": attn_reason, "original_labels": original_labels,
         })
 
     # Print summary
@@ -268,6 +312,8 @@ def main():
                 add_labels(server, user, token, rfe_id, labels)
                 print(f"  {rfe_id}: Labels: {', '.join(labels)}")
             results[rfe_id] = rfe_id
+            _post_needs_attention_comment(
+                server, user, token, entry, results, args.dry_run)
             continue
 
         # Read and clean artifact content
@@ -320,6 +366,10 @@ def main():
                 comment_adf = markdown_to_adf(comment_md)
                 add_comment(server, user, token, target_key, comment_adf)
                 print(f"  {rfe_id}: Posted removed-context comment")
+
+        # Post needs-attention comment if newly flagged
+        _post_needs_attention_comment(
+            server, user, token, entry, results, args.dry_run)
 
     print()
 


### PR DESCRIPTION
## Summary
- When an RFE is flagged `needs_attention`, the submit pipeline now posts a `[RFE Creator]` comment on the Jira ticket explaining what the human reviewer needs to address
- Only posts for **newly flagged** RFEs — skips if the ticket already had the `rfe-creator-needs-attention` label when fetched (tracked via new `original_labels` field in task frontmatter)
- Review and revise agents both write `needs_attention_reason` alongside the boolean flag (last writer wins — no conflicts)
- Adds `list` type support to the schema/validation system for `original_labels`

## Test plan
- [ ] `python3 -m pytest tests/` — all 76 tests pass
- [ ] `python3 scripts/submit.py --dry-run` shows "Would post needs-attention comment" for flagged RFEs
- [ ] Verify dry-run does NOT call `add_comment` (fixed guard for existing ticket keys)
- [ ] Verify RFEs with `rfe-creator-needs-attention` already in `original_labels` do NOT get a comment posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)