### PR TITLE
Fold conflict detection into submit.py

### DIFF
--- a/.claude/skills/rfe.submit/SKILL.md
+++ b/.claude/skills/rfe.submit/SKILL.md
@@ -25,28 +25,13 @@ Check if `JIRA_SERVER`, `JIRA_USER`, and `JIRA_TOKEN` environment variables are 
 >
 > After environment variables are set, re-run `/rfe.submit`.
 
-## Step 1: Conflict Detection
-
-Run the conflict check script:
-
-```bash
-python3 scripts/check_conflicts.py --artifacts-dir artifacts
-```
-
-Parse the output and exit code:
-- **Exit code 0**: No conflicts. Proceed to Step 2.
-- **Exit code 1**: Conflicts detected. Report each `CONFLICT:` line to the user and stop. Tell them to re-fetch from Jira by running `/rfe.review <rfe_id>`, then re-apply changes.
-- **Exit code 2**: Missing credentials. Show the credential setup instructions from Step 0 and stop.
-
-Skip conflict detection for `--dry-run` — go directly to Step 2.
-
-## Step 2: Run Submission
+## Step 1: Run Submission
 
 ```bash
 python3 scripts/submit.py [--dry-run] [--artifacts-dir artifacts]
 ```
 
-## Step 3: Report Results
+## Step 2: Report Results
 
 After the script completes, read `artifacts/rfes.md` (rebuilt by the script) and report the results.
 

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -31,9 +31,12 @@ from jira_utils import (
     update_issue,
     add_labels,
     add_comment,
+    get_issue,
+    adf_to_markdown,
     strip_metadata,
     markdown_to_adf,
 )
+from check_conflicts import _normalize_for_compare
 
 from artifact_utils import (
     read_frontmatter,
@@ -229,6 +232,39 @@ def main():
                 "attn_reason": None, "original_labels": original_labels,
             })
             continue
+
+        # For existing RFEs, check for Jira conflicts
+        if is_existing and not args.dry_run:
+            original_path = os.path.join(
+                args.artifacts_dir, "rfe-originals", f"{rfe_id}.md")
+            if os.path.exists(original_path):
+                try:
+                    with open(original_path, encoding="utf-8") as f:
+                        orig_snap = _normalize_for_compare(f.read())
+                    issue = get_issue(server, user, token, rfe_id,
+                                      fields=["description"])
+                    desc_raw = issue.get("fields", {}).get("description")
+                    if isinstance(desc_raw, dict):
+                        jira_desc = _normalize_for_compare(
+                            adf_to_markdown(desc_raw))
+                    elif desc_raw is None:
+                        jira_desc = ""
+                    else:
+                        jira_desc = _normalize_for_compare(str(desc_raw))
+                    if orig_snap != jira_desc:
+                        plan.append({
+                            "rfe_id": rfe_id, "title": title,
+                            "is_existing": is_existing, "priority": priority,
+                            "size": size,
+                            "action": "SKIP", "labels": [],
+                            "skip_reason": "Jira conflict — description "
+                                           "modified since fetch",
+                            "task_path": task_path,
+                        })
+                        continue
+                except Exception as e:
+                    print(f"Warning: conflict check failed for {rfe_id}: "
+                          f"{e}", file=sys.stderr)
 
         # For existing RFEs, check if content has changed
         if is_existing:


### PR DESCRIPTION
## Summary
- Moves conflict detection from a separate script + LLM orchestration step into submit.py's plan-building loop
- Each existing RHAIRFE is checked against Jira before updating — conflicts are skipped (not blocking), so the rest of the batch submits normally
- Removes the conflict detection step from the submit skill (no more exit code parsing or halt-on-conflict behavior)

## Test plan
- [ ] Run `python3 scripts/submit.py --dry-run` and verify plan builds without errors
- [ ] Run with real credentials on a batch with a known conflict — confirm conflicted RFE is skipped and others submit
- [ ] Run `python3 -m pytest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)