### PR TITLE
Print the actual JQL query executed by jql_query.py

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -29,7 +29,7 @@ python3 scripts/state.py init tmp/autofix-config.yaml headless=<true/false> anno
 python3 scripts/jql_query.py "<query>" [--limit N]
 ```
 
-Parse the output: first line is `TOTAL=N`, remaining lines are IDs. These become the processing list.
+The script prints the actual JQL it runs (with added filters) to stderr. Output this to the user: `[AUTOFIX] JQL: <jql>`. Parse stdout: first line is `TOTAL=N`, remaining lines are IDs. These become the processing list.
 
 **Explicit mode**: Use the provided IDs directly.
 

--- a/scripts/jql_query.py
+++ b/scripts/jql_query.py
@@ -73,6 +73,7 @@ def main():
         sys.exit(1)
 
     jql = f"({args.jql}) AND statusCategory != Done AND labels not in (rfe-creator-ignore, rfe-creator-autofix-rubric-pass)"
+    print(f"JQL={jql}", file=sys.stderr)
     search_issues(server, user, token, jql, args.limit)
 
 


### PR DESCRIPTION
## Summary
- Logs the final JQL (with appended statusCategory and label filters) to stderr for debugging visibility
- Updates the auto-fix skill to surface the JQL as `[AUTOFIX] JQL: <jql>` output

## Test plan
- [ ] Run `python3 scripts/jql_query.py "project = RHAIRFE"` and verify JQL appears on stderr
- [ ] Run `/rfe.auto-fix --jql "..."` and verify the JQL is printed in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)