### PR TITLE
Add snapshot-based incremental JQL fetching

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -13,6 +13,7 @@ Parse `$ARGUMENTS` for:
 - `--jql "<query>"`: JQL query to fetch IDs from Jira
 - `--limit N`: Cap the number of IDs to process (useful for testing JQL queries)
 - `--batch-size N`: Override batch size (default: 5)
+- `--data-dir "<path>"`: Local directory with previous run results (for snapshot diffing)
 - `--headless`: Suppress summaries (when called by speedrun)
 - `--announce-complete`: Print completion marker when done (for CI / eval harnesses)
 - Remaining arguments: explicit RFE IDs (RHAIRFE-NNNN)
@@ -23,25 +24,24 @@ Persist parsed flags (survives context compression):
 python3 scripts/state.py init tmp/autofix-config.yaml headless=<true/false> announce_complete=<true/false> batch_size=<N>
 ```
 
-**JQL mode**: If `--jql` is present, run the query:
+**JQL mode**: If `--jql` is present, run the snapshot fetch:
 
 ```bash
-python3 scripts/jql_query.py "<query>" [--limit N]
+python3 scripts/snapshot_fetch.py fetch "<query>" --ids-file tmp/autofix-all-ids.txt --changed-file tmp/autofix-changed-ids.txt [--limit N] [--data-dir "<path>"]
 ```
 
-The script prints the actual JQL it runs (with added filters) to stderr. Output this to the user: `[AUTOFIX] JQL: <jql>`. Parse stdout: first line is `TOTAL=N`, remaining lines are IDs. These become the processing list.
+The script prints the actual JQL to stderr. Output this to the user: `[AUTOFIX] JQL: <jql>`. The script writes all IDs to process to `tmp/autofix-all-ids.txt` and changed-only IDs to `tmp/autofix-changed-ids.txt`. Parse stdout for counts: `TOTAL=N`, `CHANGED=N`, `NEW=N`.
 
-**Explicit mode**: Use the provided IDs directly.
-
-If no IDs and no JQL query, stop with usage instructions.
-
-**Persist all IDs to disk** (survives context compression):
+**Explicit mode**: Use the provided IDs directly. Persist to disk:
 
 ```bash
 python3 scripts/state.py write-ids tmp/autofix-all-ids.txt <all_IDs>
+python3 scripts/state.py write-ids tmp/autofix-changed-ids.txt
 ```
 
-Output: `[AUTOFIX] Step 0: Parsed N IDs, batch_size=M`
+If no IDs and no JQL query, stop with usage instructions.
+
+Output: `[AUTOFIX] Step 0: Parsed N IDs (C changed, W new), batch_size=M`
 
 ## Step 1: Bootstrap Pre-flight
 
@@ -65,29 +65,15 @@ If the retry also fails, stop entirely: "assess-rfe bootstrap failed — cannot 
 
 Output: `[AUTOFIX] Step 2: Resume Check`
 
-Re-read the ID list from disk (in case context was compressed):
+Run the resume check. The script reads IDs and changed IDs from files, bypasses the resume check for changed IDs (their Jira content changed, so local reviews are stale), and writes the final process list:
 
 ```bash
-python3 scripts/state.py read-ids tmp/autofix-all-ids.txt
+python3 scripts/check_resume.py --ids-file tmp/autofix-all-ids.txt --changed-file tmp/autofix-changed-ids.txt --output-file tmp/autofix-process-ids.txt
 ```
 
-Output: `[AUTOFIX] Recovered N IDs from autofix-all-ids.txt`
+Parse stdout for counts: `PROCESS=N`, `SKIP=N`, `CHANGED=N`.
 
-Check which IDs are already processed:
-
-```bash
-python3 scripts/check_resume.py $(python3 scripts/state.py read-ids tmp/autofix-all-ids.txt)
-```
-
-Parse output for `PROCESS=` and `SKIP=` lines. Remove already-processed IDs (pass=true, no error) from the processing list.
-
-Output: `[AUTOFIX] Step 2: N to process, M skipped`
-
-Persist the filtered processing list to disk (survives context compression):
-
-```bash
-python3 scripts/state.py write-ids tmp/autofix-process-ids.txt <remaining_IDs>
-```
+Output: `[AUTOFIX] Step 2: N to process (C changed), M skipped`
 
 ## Step 3: Batch Processing
 
@@ -292,6 +278,7 @@ Present consolidated results (combine persisted IDs with any split children foun
 ### Reports
 - Run report: artifacts/auto-fix-runs/<run_id>.yaml
 - Review report: artifacts/auto-fix-runs/<run_id>-report.html
+- Snapshot: artifacts/auto-fix-runs/issue-snapshot-<ts>.yaml (written during fetch)
 
 ### Remaining Issues
 <Any issues that could not be auto-fixed, or "None">

--- a/docs/snapshot-incremental-fetch.md
+++ b/docs/snapshot-incremental-fetch.md
@@ -1,0 +1,283 @@
+# Snapshot-Based Incremental Fetch
+
+## Problem
+
+The original auto-fix pipeline processed RFEs by running a JQL query
+against Jira and processing every result. Two issues:
+
+1. **Blind spots**: Labels like `rfe-creator-autofix-rubric-pass` were
+   excluded at the JQL level. If someone later edited the description of
+   a passing RFE, the system never saw it again.
+
+2. **Wasted work**: Every run re-fetched and re-evaluated issues whose
+   descriptions hadn't changed. The only gate was `check_resume`, which
+   skipped issues with passing local reviews — but couldn't distinguish
+   "unchanged in Jira" from "changed but we happen to have a local
+   review."
+
+## Solution
+
+Instead of filtering at the JQL level and relying on labels to decide
+what to process, the snapshot system fetches **all** open issues (minus
+permanent exclusions), computes a content hash of each description, and
+compares against the previous run's hashes. Only issues whose description
+actually changed get processed.
+
+## Hard vs Soft Filters
+
+| Filter | Before | After | Rationale |
+|--------|--------|-------|-----------|
+| `statusCategory != Done` | JQL | JQL | Closed issues never need processing |
+| `rfe-creator-ignore` | JQL | JQL | Permanent human override — never touch |
+| `rfe-creator-autofix-rubric-pass` | JQL | Hash diff | If someone edits a passing RFE, we should see it |
+| `rfe-creator-needs-attention` | Not filtered | Hash diff | If a human resolves the flag and revises the description, we should re-evaluate |
+
+Soft-filtered labels are no longer excluded from the query. Issues with
+these labels are fetched and hashed like everything else. If their
+description hasn't changed, the diff naturally skips them. If it has
+changed, they surface for processing regardless of labels.
+
+## Files
+
+```
+artifacts/auto-fix-runs/
+  issue-snapshot-<YYYYMMDD-HHMMSS>.yaml   # Snapshot: {key: content_hash}
+```
+
+### Snapshot (`issue-snapshot-*.yaml`)
+
+Written by `snapshot_fetch.py fetch` at the start of each run. Updated
+by `submit.py` after Jira writes with post-submit hashes. Contains the
+content hash of every issue's description.
+
+```yaml
+query_timestamp: "2026-04-02T19:54:36Z"
+timestamp: "2026-04-02T19:54:37Z"
+bootstrapped_from: "20260402-195436"   # only present on bootstrap snapshots
+issues:
+  RHAIRFE-1234: "a1b2c3..."
+  RHAIRFE-5678: "d4e5f6..."
+```
+
+## Content Hashing Pipeline
+
+```
+Jira ADF description
+  -> adf_to_markdown()
+  -> normalize_for_hash()     # collapse whitespace, normalize quotes
+  -> SHA256
+```
+
+The normalization step ensures that trivial formatting differences
+(indentation, blank lines, curly vs straight quotes) don't produce false
+positives.
+
+Both fetch and submit use the same pipeline. `submit.py` converts its
+markdown to ADF (via `markdown_to_adf`) before hashing with
+`compute_content_hash`, ensuring the hash matches what fetch will compute
+from Jira's stored ADF. This avoids false positives from markdown-to-ADF
+conversion differences (tables, blockquotes, nested lists).
+
+## Command Sequence
+
+A full CI run executes these steps in order:
+
+```bash
+# 1. Fetch and diff
+#    Reads:   artifacts/auto-fix-runs/issue-snapshot-*.yaml  (previous snapshot)
+#    Writes:  artifacts/auto-fix-runs/issue-snapshot-<ts>.yaml (new snapshot)
+#             tmp/autofix-all-ids.txt                        (all IDs to process)
+#             tmp/autofix-changed-ids.txt                    (changed-only IDs)
+python3 scripts/snapshot_fetch.py fetch "<jql>" \
+  --ids-file tmp/autofix-all-ids.txt \
+  --changed-file tmp/autofix-changed-ids.txt \
+  [--limit 100] [--data-dir "<path>"]
+
+# 2. Review and process (auto-fix pipeline steps 1-5)
+#    Reads:   tmp/autofix-all-ids.txt, tmp/autofix-changed-ids.txt
+#    Writes:  artifacts/rfe-tasks/*, artifacts/rfe-reviews/*
+#             artifacts/auto-fix-runs/<run-id>.yaml (run report)
+
+# 3. Submit to Jira
+#    Reads:   artifacts/rfe-tasks/*, artifacts/rfe-reviews/*
+#    Updates: artifacts/auto-fix-runs/issue-snapshot-<ts>.yaml (post-submit hashes)
+python3 scripts/submit.py
+
+# 4. Push everything
+git add artifacts/
+git commit -m "run results"
+git push
+```
+
+### State Files
+
+| File | Written by | Read by | Lifetime |
+|------|-----------|---------|----------|
+| `artifacts/auto-fix-runs/issue-snapshot-<ts>.yaml` | `snapshot_fetch.py fetch`, updated by `submit.py` | `snapshot_fetch.py fetch` (next run) | Permanent (accumulates) |
+| `tmp/autofix-all-ids.txt` | `snapshot_fetch.py fetch` | auto-fix pipeline | Current run only |
+| `tmp/autofix-changed-ids.txt` | `snapshot_fetch.py fetch` | `check_resume.py` | Current run only |
+
+### Ordering Constraints
+
+The command sequence is ordered to minimize data loss on failure:
+
+1. **Submit updates the snapshot**: After Jira API calls succeed,
+   `submit.py` updates the snapshot with post-submit hashes so the
+   next fetch doesn't re-flag our own changes.
+
+2. **Single push at the end**: Everything is pushed once after all
+   work is done. If the push fails, submitted issues are re-processed
+   on the next run (safe but redundant — the conflict check in
+   `submit.py` catches identical content).
+
+## Pipeline Data Flow (Steady State)
+
+```
+  from previous run
+  ─────────────────
+
+  issue-snapshot ──► ┌──────────────────────────────────┐
+                     │ 1. FETCH                          │
+                     │    load previous snapshot          │
+                     │    fetch current Jira state        │
+                     │    diff current vs previous        │
+                     │    write new issue-snapshot        │
+                     └───────────────┬──────────────────┘
+                                     │
+                            changed + new IDs
+                                     │
+                     ┌───────────────┴──────────────────┐
+                     │ 2. REVIEW / PROCESS               │
+                     │    (auto-fix pipeline)             │
+                     └───────────────┬──────────────────┘
+                                     │
+                     ┌───────────────┴──────────────────┐
+                     │ 3. SUBMIT                         │
+                     │    Jira API calls                  │
+                     │    update issue-snapshot in place   │
+                     └───────────────┬──────────────────┘
+                                     │
+                     ┌───────────────┴──────────────────┐
+                     │ 4. GIT PUSH                       │
+                     │    snapshot + results              │
+                     └──────────────────────────────────┘
+```
+
+## Diffing Logic
+
+`diff_snapshots(current_issues, previous_data)` compares each issue's
+current content hash against the previous snapshot:
+
+- **Hash matches**: issue is unchanged, excluded from output
+- **Hash differs**: issue is "changed", included in output
+- **Not in previous**: issue is "new", included in output
+- **In previous but not current**: issue left scope (closed, filtered),
+  silently dropped
+
+## Post-Submit Snapshot Update
+
+When `submit.py` updates or creates an issue in Jira, the description
+in Jira changes. Without intervention, the next fetch would see a hash
+mismatch and flag the issue as "changed" — re-processing our own work.
+
+After all Jira writes succeed, `submit.py` updates the current
+snapshot's issue hashes with the post-submit content hashes. This way
+the snapshot reflects what Jira now has, and the next fetch correctly
+treats these issues as unchanged.
+
+This also handles newly created issues. Without the post-submit hash,
+a new issue would appear as "new" on the next run. With it in the
+snapshot, the issue is treated as known.
+
+## Failure Modes
+
+**Job dies during submit (before push):**
+The snapshot was written during fetch but not yet updated with
+post-submit hashes. On the next run, submitted issues show as
+"changed" (hash mismatch) and get re-processed. This is safe but
+redundant — the conflict check in `submit.py` catches identical
+content, and the review pipeline is idempotent.
+
+**Job dies before fetch completes:**
+Nothing was written. Next run starts from the same snapshot as this
+run. All work is re-done. Safe.
+
+## Hard Filters
+
+The JQL query is wrapped with constraints that should not change the
+desired processing outcome:
+
+```
+(<user-jql>) AND statusCategory != Done
+             AND labels not in (rfe-creator-ignore)
+```
+
+These filters are "hard" because an issue matching them should always be
+processed if its content has changed. Contrast with soft filters (e.g.
+`labels in (needs-tech-review)`) which control which issues are
+candidates but shouldn't affect change detection.
+
+## Bootstrap
+
+`bootstrap_snapshot.py` creates the initial snapshot for a project that
+has prior CI run history, before the first incremental fetch.
+
+```
+  results directory                Jira
+  ─────────────────                ────
+
+  run dirs ──► find latest    hard-filter JQL ──► fetch all current
+               run timestamp                      issues + hashes
+               │                                       │
+               ▼                                       │
+          run timestamp                                │
+               │                                       ▼
+               │                  updated >= run ──► updated issue keys
+               │                  timestamp               │
+               │                                          │
+               │         ┌────────────────────────────────┘
+               │         │
+               │         ▼  for each updated issue:
+               │    ┌─────────────────────────────────┐
+               │    │ changelog lookup                 │
+               │    │   description at run time → hash │
+               │    │   status at run time → exclude   │
+               │    │     if Done                      │
+               │    └──────────────┬──────────────────┘
+               │                   │
+               ▼                   ▼
+  run report ──► find auto-   historical hashes
+                 revised IDs  (pre-submit state)
+                      │            │
+                      ▼            ▼
+                 ┌──────────────────────────┐
+                 │ build snapshot            │
+                 │   unchanged → current hash│
+                 │   updated → historical    │
+                 │   auto-revised → current  │
+                 │   Done at run time → skip │
+                 └─────────────┬────────────┘
+                               │
+                               ▼
+                        issue-snapshot
+                     (initial snapshot for
+                      first incremental fetch)
+```
+
+The bootstrap snapshot accounts for:
+- Historical descriptions at the run time (for externally modified issues)
+- Current descriptions for auto-revised issues (our own submissions)
+- Exclusion of issues that were out of scope (Done) at run time
+
+This ensures the first incremental fetch after bootstrap only surfaces
+issues that genuinely changed since the last CI run. The Done-status
+check prevents reopened issues from being silently treated as "unchanged"
+when they were never processed.
+
+## Scripts
+
+| Script | Role |
+|--------|------|
+| `scripts/snapshot_fetch.py` | Fetch, diff, write snapshot |
+| `scripts/submit.py` | Jira writes, update snapshot with post-submit hashes |
+| `scripts/bootstrap_snapshot.py` | Initial snapshot from Jira history |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest
+jira-emulator @ git+https://github.com/jctanner/jira-emulator.git

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Bootstrap the snapshot system from a previous CI run.
+
+Reconstructs the Jira description state at the time of the last run
+by examining issue changelogs, creating an accurate baseline snapshot
+for incremental change detection.
+
+The run timestamp comes from the results directory name (YYYYMMDD-HHMMSS).
+Issues not updated since that time keep their current hash (unchanged).
+Issues updated since then get a changelog lookup to find the description
+that was current at the run time.
+
+Usage:
+    python3 scripts/bootstrap_snapshot.py --results-dir <path> "<jql>"
+    python3 scripts/bootstrap_snapshot.py --dry-run --results-dir <path> "<jql>"
+
+Environment variables:
+    JIRA_SERVER  Jira server URL
+    JIRA_USER    Jira username/email
+    JIRA_TOKEN   Jira API token
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.parse
+from datetime import datetime, timezone
+
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from jira_utils import require_env, api_call_with_retry
+from snapshot_fetch import (
+    fetch_all_issues,
+    compute_content_hash,
+    _fetch_paginated,
+    SNAPSHOT_DIR,
+)
+
+
+def find_latest_run_timestamp(results_dir):
+    """Find the timestamp of the latest run from directory names.
+
+    Follows 'latest' symlink if present, otherwise uses newest dir.
+    Run directories are named YYYYMMDD-HHMMSS.
+    Returns (name, datetime_utc) or (None, None).
+    """
+    latest = os.path.join(results_dir, "latest")
+    if os.path.islink(latest):
+        name = os.path.basename(os.readlink(latest))
+        try:
+            dt = datetime.strptime(name, "%Y%m%d-%H%M%S")
+            return name, dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+
+    for name in sorted(os.listdir(results_dir), reverse=True):
+        if name.startswith(".") or name == "latest":
+            continue
+        if not os.path.isdir(os.path.join(results_dir, name)):
+            continue
+        try:
+            dt = datetime.strptime(name, "%Y%m%d-%H%M%S")
+            return name, dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+
+    return None, None
+
+
+def _fetch_changelog(server, user, token, key):
+    """Fetch the full changelog for an issue.
+
+    Returns list of entries, each with 'created' (datetime) and
+    'items' (list of change items).
+    """
+    entries = []
+    start_at = 0
+
+    while True:
+        path = (f"/issue/{urllib.parse.quote(key, safe='')}/changelog"
+                f"?startAt={start_at}&maxResults=100")
+        data = api_call_with_retry(server, path, user, token)
+
+        for history in data.get("values", []):
+            created_str = history.get("created", "")
+            try:
+                created = datetime.fromisoformat(
+                    created_str.replace("+0000", "+00:00"))
+            except (ValueError, TypeError):
+                continue
+            entries.append({
+                "created": created,
+                "items": history.get("items", []),
+            })
+
+        total = data.get("total", 0)
+        values = data.get("values", [])
+        start_at += len(values)
+        if start_at >= total or not values:
+            break
+
+    return entries
+
+
+def _description_at_time(changelog, target_dt):
+    """Extract the description ADF at target_dt from changelog entries.
+
+    Returns ADF dict, or None if no description changes exist.
+    """
+    desc_changes = []
+    for entry in changelog:
+        for item in entry["items"]:
+            if item.get("field") == "description":
+                desc_changes.append({
+                    "created": entry["created"],
+                    "from": item.get("from"),
+                    "to": item.get("to"),
+                })
+
+    if not desc_changes:
+        return None
+
+    desc_changes.sort(key=lambda x: x["created"])
+
+    # If the earliest change is after target, use the 'from' value.
+    if desc_changes[0]["created"] > target_dt:
+        return _parse_adf(desc_changes[0]["from"])
+
+    # Otherwise, take the 'to' of the last change at or before target.
+    result = None
+    for change in desc_changes:
+        if change["created"] <= target_dt:
+            result = _parse_adf(change["to"])
+        else:
+            break
+
+    return result
+
+
+_DONE_STATUS_PATTERNS = (
+    "done", "closed", "resolved", "completed",
+    "won't do", "won't fix", "rejected",
+    "cancelled", "canceled", "archived",
+)
+
+
+def _is_done_status(status_name):
+    """Heuristic check for Done-category status names."""
+    if not status_name:
+        return False
+    lower = status_name.lower().strip()
+    return any(p in lower for p in _DONE_STATUS_PATTERNS)
+
+
+def _was_done_at_time(changelog, target_dt):
+    """Check if the issue was in a Done-like status at target_dt.
+
+    Uses status change history from the changelog. If no status
+    changes exist, assumes the issue's current status (which passed
+    the statusCategory != Done filter) was always its status.
+    """
+    status_changes = []
+    for entry in changelog:
+        for item in entry["items"]:
+            if item.get("field") == "status":
+                status_changes.append({
+                    "created": entry["created"],
+                    "fromString": item.get("fromString", ""),
+                    "toString": item.get("toString", ""),
+                })
+
+    if not status_changes:
+        return False
+
+    status_changes.sort(key=lambda x: x["created"])
+
+    if status_changes[0]["created"] > target_dt:
+        return _is_done_status(status_changes[0]["fromString"])
+
+    status_at_time = None
+    for change in status_changes:
+        if change["created"] <= target_dt:
+            status_at_time = change["toString"]
+        else:
+            break
+
+    return _is_done_status(status_at_time) if status_at_time else False
+
+
+def get_description_at_time(server, user, token, key, target_dt):
+    """Get the description ADF that was current at target_dt.
+
+    Fetches the changelog and finds the description at the target time.
+    Returns ADF dict, or None if description has never changed.
+    """
+    changelog = _fetch_changelog(server, user, token, key)
+    return _description_at_time(changelog, target_dt)
+
+
+def _parse_adf(value):
+    """Parse a changelog value as ADF.
+
+    Changelog stores ADF as a JSON string in from/to fields.
+    Returns dict (ADF), or None.
+    """
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("jql", help="JQL query (same as auto-fix uses)")
+    parser.add_argument("--results-dir", required=True,
+                        help="Path to results repo with run directories")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print what would be done without writing")
+    parser.add_argument("--artifacts-dir", default=None,
+                        help="Output directory (default: repo artifacts/)")
+    args = parser.parse_args()
+
+    server, user, token = require_env()
+    if not all([server, user, token]):
+        print("Error: JIRA_SERVER, JIRA_USER, and JIRA_TOKEN required",
+              file=sys.stderr)
+        sys.exit(1)
+
+    # Step 1: Find the last run timestamp
+    run_name, run_dt = find_latest_run_timestamp(args.results_dir)
+    if not run_dt:
+        print("Error: no valid run directories found", file=sys.stderr)
+        sys.exit(1)
+    print(f"Last run: {run_name} ({run_dt.isoformat()})", file=sys.stderr)
+
+    # Step 2: Fetch all current issues with hard filters
+    jql = (f"({args.jql}) AND statusCategory != Done "
+           f"AND labels not in (rfe-creator-ignore)")
+    print(f"JQL: {jql}", file=sys.stderr)
+
+    current = fetch_all_issues(server, user, token, jql)
+    print(f"Fetched {len(current)} issues from Jira", file=sys.stderr)
+
+    # Step 3: Find which issues were updated since the run
+    run_jql_ts = run_dt.strftime("%Y-%m-%d %H:%M")
+    updated_jql = (f"{jql} AND updated >= \"{run_jql_ts}\"")
+    updated_keys = set()
+    for issue in _fetch_paginated(
+            server, user, token, updated_jql, "key"):
+        updated_keys.add(issue["key"])
+    print(f"Issues updated since run: {len(updated_keys)}",
+          file=sys.stderr)
+
+    # Step 4: Build snapshot — use historical descriptions for
+    # issues updated since the run, current hash for the rest
+    snapshot_issues = {}
+    lookups = 0
+    hist_changed = 0
+    done_excluded = 0
+
+    for key, data in current.items():
+        if key not in updated_keys:
+            snapshot_issues[key] = data["content_hash"]
+            continue
+
+        changelog = _fetch_changelog(server, user, token, key)
+        lookups += 1
+
+        # Skip issues that were in Done status at run time — they
+        # were out of scope and will surface as "new" on first fetch
+        if _was_done_at_time(changelog, run_dt):
+            done_excluded += 1
+            continue
+
+        hist_desc = _description_at_time(changelog, run_dt)
+        if hist_desc is None:
+            # No description changes — current is the original
+            snapshot_issues[key] = data["content_hash"]
+        else:
+            hist_hash = compute_content_hash(hist_desc)
+            snapshot_issues[key] = hist_hash
+            if hist_hash != data["content_hash"]:
+                hist_changed += 1
+
+    print(f"Changelog lookups: {lookups} "
+          f"({hist_changed} with changed description)",
+          file=sys.stderr)
+    if done_excluded:
+        print(f"Excluded {done_excluded} issues (Done at run time)",
+              file=sys.stderr)
+
+    # Step 5: Merge submitted hashes from run report
+    # Issues whose descriptions were changed by the run have historical
+    # (pre-submit) hashes in the snapshot, but Jira now has the post-submit
+    # content. Use current hashes for these so the next fetch doesn't
+    # re-flag our own changes.
+    run_report_path = os.path.join(
+        args.results_dir, run_name, "auto-fix-runs", f"{run_name}.yaml")
+    if os.path.exists(run_report_path):
+        with open(run_report_path, encoding="utf-8") as f:
+            report = yaml.safe_load(f)
+        submitted_ids = [
+            e["id"] for e in report.get("per_rfe", [])
+            if e.get("recommendation") == "submit" and e.get("auto_revised")
+        ]
+        merged = 0
+        for key in submitted_ids:
+            if key in current and key in snapshot_issues:
+                snapshot_issues[key] = current[key]["content_hash"]
+                merged += 1
+        if merged:
+            print(f"Merged {merged} submitted hashes from run report",
+                  file=sys.stderr)
+
+    # Step 6: Write snapshot
+    if args.dry_run:
+        print(f"\nDry run — would write snapshot with "
+              f"{len(snapshot_issues)} issue hashes")
+        return
+
+    snapshot_dir = (os.path.join(args.artifacts_dir, "auto-fix-runs")
+                    if args.artifacts_dir else SNAPSHOT_DIR)
+    os.makedirs(snapshot_dir, exist_ok=True)
+
+    run_ts_str = run_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    snapshot = {
+        "query_timestamp": run_ts_str,
+        "timestamp": datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"),
+        "bootstrapped_from": run_name,
+        "issues": snapshot_issues,
+    }
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    snapshot_path = os.path.join(snapshot_dir,
+                                 f"issue-snapshot-{ts}.yaml")
+    with open(snapshot_path, "w", encoding="utf-8") as f:
+        yaml.dump(snapshot, f, default_flow_style=False,
+                  sort_keys=False)
+    print(f"Wrote snapshot: {snapshot_path}")
+    print(f"Bootstrap complete. {len(snapshot_issues)} issues.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -23,6 +23,7 @@ Environment variables:
 import argparse
 import json
 import os
+import re
 import sys
 import urllib.parse
 from datetime import datetime, timezone
@@ -87,7 +88,8 @@ def _fetch_changelog(server, user, token, key):
             created_str = history.get("created", "")
             try:
                 created = datetime.fromisoformat(
-                    created_str.replace("+0000", "+00:00"))
+                    re.sub(r'([+-]\d{2})(\d{2})$', r'\1:\2',
+                           created_str))
             except (ValueError, TypeError):
                 continue
             entries.append({

--- a/scripts/check_resume.py
+++ b/scripts/check_resume.py
@@ -1,8 +1,25 @@
 #!/usr/bin/env python3
-"""Identify already-processed RFE IDs for resume support.
+"""Identify which RFE IDs need processing, accounting for resume and
+change detection.
 
-Checks which IDs have passing review files (pass=true, no error field).
-Outputs PROCESS= and SKIP= lines for shell consumption.
+Supports two modes:
+
+1. File-based (preferred): reads IDs and changed-IDs from files, writes
+   the final process list to an output file. Changed IDs always bypass
+   the resume check (their Jira content has changed, so local reviews
+   are stale). New IDs are checked for existing passing reviews.
+
+2. Positional args (legacy): accepts IDs as arguments, prints PROCESS=
+   and SKIP= lines to stdout.
+
+Usage:
+    # File-based (used by auto-fix skill)
+    python3 scripts/check_resume.py --ids-file tmp/autofix-all-ids.txt \\
+        --changed-file tmp/autofix-changed-ids.txt \\
+        --output-file tmp/autofix-process-ids.txt
+
+    # Legacy positional args
+    python3 scripts/check_resume.py RHAIRFE-1234 RHAIRFE-5678
 """
 
 import argparse
@@ -13,19 +30,34 @@ sys.path.insert(0, os.path.dirname(__file__))
 from artifact_utils import find_review_file, read_frontmatter
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Check which RFE IDs already have passing reviews")
-    parser.add_argument("ids", nargs="+", help="RFE IDs to check")
-    parser.add_argument("--artifacts-dir", default="artifacts",
-                        help="Path to artifacts directory (default: artifacts)")
-    args = parser.parse_args()
+def read_ids_from_file(path):
+    """Read IDs from a file, one per line. Returns empty list if missing."""
+    if not path or not os.path.exists(path):
+        return []
+    with open(path, encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip()]
 
+
+def check_resume(ids, changed_ids, artifacts_dir):
+    """Determine which IDs need processing.
+
+    Changed IDs always need processing (bypass resume check).
+    Other IDs are checked for existing passing reviews.
+
+    Returns (process_ids, skip_ids).
+    """
+    changed_set = set(changed_ids)
     process_ids = []
     skip_ids = []
 
-    for rfe_id in args.ids:
-        review_path = find_review_file(args.artifacts_dir, rfe_id)
+    for rfe_id in ids:
+        # Changed IDs always bypass resume — local reviews are stale
+        if rfe_id in changed_set:
+            process_ids.append(rfe_id)
+            continue
+
+        # Check for existing passing review
+        review_path = find_review_file(artifacts_dir, rfe_id)
         if review_path and os.path.exists(review_path):
             data, _ = read_frontmatter(review_path)
             if data.get("pass") is True and data.get("error") is None:
@@ -33,6 +65,51 @@ def main():
                 continue
         process_ids.append(rfe_id)
 
+    return process_ids, skip_ids
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check which RFE IDs need processing")
+    parser.add_argument("ids", nargs="*", help="RFE IDs to check (legacy)")
+    parser.add_argument("--ids-file",
+                        help="File containing all IDs (one per line)")
+    parser.add_argument("--changed-file",
+                        help="File containing changed IDs (one per line)")
+    parser.add_argument("--output-file",
+                        help="File to write process IDs to (one per line)")
+    parser.add_argument("--artifacts-dir", default="artifacts",
+                        help="Path to artifacts directory (default: artifacts)")
+    args = parser.parse_args()
+
+    # File-based mode
+    if args.ids_file:
+        all_ids = read_ids_from_file(args.ids_file)
+        changed_ids = read_ids_from_file(args.changed_file)
+        process_ids, skip_ids = check_resume(
+            all_ids, changed_ids, args.artifacts_dir)
+
+        # Write output file
+        if args.output_file:
+            os.makedirs(os.path.dirname(args.output_file) or "tmp",
+                        exist_ok=True)
+            with open(args.output_file, "w", encoding="utf-8") as f:
+                for id_ in process_ids:
+                    f.write(f"{id_}\n")
+
+        # Print counts for logging
+        changed_count = len(set(changed_ids) & set(process_ids))
+        print(f"PROCESS={len(process_ids)}")
+        print(f"SKIP={len(skip_ids)}")
+        print(f"CHANGED={changed_count}")
+        return
+
+    # Legacy positional args mode
+    if not args.ids:
+        parser.print_help()
+        sys.exit(1)
+
+    process_ids, skip_ids = check_resume(args.ids, [], args.artifacts_dir)
     print(f"PROCESS={','.join(process_ids)}")
     print(f"SKIP={','.join(skip_ids)}")
 

--- a/scripts/clone_results_repo.py
+++ b/scripts/clone_results_repo.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Sparse-clone a data repo, fetching only snapshot files.
+
+Only materializes the 'latest' symlink and issue-snapshot-*.yaml files.
+Skips reviews, tasks, originals, run reports, and HTML reports.
+
+Usage:
+    DATA_REPO_TOKEN=<token> python3 scripts/clone_results_repo.py <repo-path-or-url> [dest]
+
+Examples:
+    DATA_REPO_TOKEN=glpat-xxx python3 scripts/clone_results_repo.py redhat/rhel-ai/agentic-ci/rfe-autofixer-results
+    DATA_REPO_TOKEN=glpat-xxx python3 scripts/clone_results_repo.py https://gitlab.com/my/repo.git /tmp/data-repo
+
+If repo arg is a bare path (no ://), builds a GitLab HTTPS URL with
+the token embedded. Prints the clone destination to stdout.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import urllib.parse
+
+
+def build_clone_url(repo, token):
+    """Build an authenticated clone URL from repo spec and token.
+
+    Raises ValueError if a bare project path is given without a token.
+    """
+    if "://" not in repo and "@" not in repo:
+        if not token:
+            raise ValueError(
+                "DATA_REPO_TOKEN required for private repos")
+        return f"https://bot:{token}@gitlab.com/{repo}.git"
+    if token and repo.startswith("https://"):
+        parsed = urllib.parse.urlparse(repo)
+        return parsed._replace(
+            netloc=f"bot:{token}@{parsed.hostname}"
+            + (f":{parsed.port}" if parsed.port else "")
+        ).geturl()
+    return repo
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: clone_results_repo.py <repo-path-or-url> [dest]",
+              file=sys.stderr)
+        sys.exit(1)
+
+    repo = sys.argv[1]
+    dest = sys.argv[2] if len(sys.argv) > 2 else "/tmp/data-repo"
+    token = os.environ.get("DATA_REPO_TOKEN", "")
+    try:
+        clone_url = build_clone_url(repo, token)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
+    if os.path.exists(dest):
+        shutil.rmtree(dest)
+
+    # Sparse clone — only download blobs we check out
+    subprocess.run(
+        ["git", "clone", "--depth", "1", "--filter=blob:none",
+         "--sparse", clone_url, dest],
+        check=True, capture_output=True, text=True,
+    )
+
+    # Materialize only the symlink and snapshots
+    subprocess.run(
+        ["git", "sparse-checkout", "set", "--no-cone",
+         "/latest",
+         "/*/auto-fix-runs/issue-snapshot-*.yaml"],
+        cwd=dest, check=True, capture_output=True, text=True,
+    )
+
+    print(dest)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/clone_results_repo.py
+++ b/scripts/clone_results_repo.py
@@ -26,7 +26,10 @@ def build_clone_url(repo, token):
     """Build an authenticated clone URL from repo spec and token.
 
     Raises ValueError if a bare project path is given without a token.
+    Local absolute paths (starting with /) are passed through as-is.
     """
+    if os.path.isabs(repo):
+        return repo
     if "://" not in repo and "@" not in repo:
         if not token:
             raise ValueError(

--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -14,6 +14,7 @@ import os
 import re
 import sys
 import time
+import unicodedata
 import urllib.error
 import urllib.request
 
@@ -156,6 +157,17 @@ def add_labels(server, user, token, issue_key, labels):
     body = {
         "update": {
             "labels": [{"add": label} for label in labels]
+        }
+    }
+    path = f"/issue/{issue_key}"
+    api_call_with_retry(server, path, user, token, body=body, method="PUT")
+
+
+def remove_labels(server, user, token, issue_key, labels):
+    """Remove labels from an existing issue without affecting other labels."""
+    body = {
+        "update": {
+            "labels": [{"remove": label} for label in labels]
         }
     }
     path = f"/issue/{issue_key}"
@@ -647,5 +659,45 @@ def strip_metadata(markdown):
     cleaned = "\n".join(result)
     cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
     return cleaned.strip()
+
+
+def normalize_for_compare(text):
+    """Normalize text to ignore ADF-to-markdown conversion artifacts.
+
+    Handles: curly quotes, non-breaking spaces, carriage returns,
+    dash/arrow variants, trailing whitespace, emoji, table alignment,
+    and other Unicode normalization differences.
+    """
+    # Unicode normalize (NFC)
+    text = unicodedata.normalize("NFC", text)
+    # Carriage returns
+    text = text.replace("\r", "")
+    # Curly quotes -> straight
+    text = text.replace("\u2018", "'").replace("\u2019", "'")
+    text = text.replace("\u201c", '"').replace("\u201d", '"')
+    # Dashes: em dash -> —, en dash -> -  (normalize to ASCII)
+    text = text.replace("\u2014", "---").replace("\u2013", "--")
+    # Arrows: → -> ->
+    text = text.replace("\u2192", "->")
+    # Non-breaking space -> regular space
+    text = text.replace("\xa0", " ")
+    # Collapse multiple spaces to one (table alignment differences)
+    text = re.sub(r"  +", " ", text)
+    # Strip emoji (Unicode emoji blocks)
+    text = re.sub(
+        r"[\U0001F600-\U0001F64F\U0001F300-\U0001F5FF"
+        r"\U0001F680-\U0001F6FF\U0001F900-\U0001F9FF"
+        r"\U00002702-\U000027B0\U0000FE00-\U0000FE0F]", "", text)
+    # Normalize table separator rows (varying dash counts)
+    text = re.sub(r"-{2,}", "--", text)
+    # Strip auto-linked URLs: [url](url) -> url
+    text = re.sub(r"\[([^\]]+)\]\(\1/?\.?\)", r"\1", text)
+    # Strip zero-width characters
+    text = re.sub(r"[\u200b\u200c\u200d\u2060\ufeff]", "", text)
+    # Strip trailing whitespace per line
+    text = re.sub(r"[ \t]+$", "", text, flags=re.MULTILINE)
+    # Collapse multiple blank lines to one
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
 
 

--- a/scripts/snapshot_fetch.py
+++ b/scripts/snapshot_fetch.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Snapshot-based JQL fetch with change detection.
+
+Fetches all issues matching a JQL query, computes content hashes, and
+diffs against the previous snapshot to identify genuinely changed issues.
+Only changed issues are output for processing, avoiding redundant work.
+
+Usage:
+    python3 scripts/snapshot_fetch.py fetch "<jql>" --ids-file tmp/autofix-all-ids.txt --changed-file tmp/autofix-changed-ids.txt [--limit 100] [--data-dir <path>]
+
+Output (stdout):
+    TOTAL=<count>
+    CHANGED=<count>
+    NEW=<count>
+"""
+
+import argparse
+import glob
+import hashlib
+import os
+import sys
+import urllib.parse
+from datetime import datetime, timezone
+
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from jira_utils import (
+    require_env,
+    api_call_with_retry,
+    adf_to_markdown,
+    normalize_for_compare,
+)
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SNAPSHOT_DIR = os.path.join(SCRIPT_DIR, "..", "artifacts", "auto-fix-runs")
+
+
+def normalize_for_hash(text):
+    """Aggressively normalize text for content hashing.
+
+    Stricter than normalize_for_compare — collapses all whitespace
+    differences so that ADF conversion jitter and trivial formatting
+    edits (indentation, blank lines, tabs) don't produce false changes.
+    """
+    text = normalize_for_compare(text)
+    # Collapse all leading/trailing whitespace on each line
+    lines = [line.strip() for line in text.splitlines()]
+    # Drop empty lines entirely
+    lines = [line for line in lines if line]
+    return "\n".join(lines)
+
+
+def compute_content_hash(adf_description):
+    """Compute SHA256 of normalized description content.
+
+    Pipeline: ADF -> markdown -> normalize (aggressive) -> SHA256
+    """
+    if not adf_description:
+        return hashlib.sha256(b"").hexdigest()
+    markdown = adf_to_markdown(adf_description)
+    normalized = normalize_for_hash(markdown)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _fetch_paginated(server, user, token, jql, fields):
+    """Paginate through a JQL search, yielding issue dicts."""
+    page_size = 100
+    next_page_token = None
+
+    while True:
+        path = (f"/search/jql?jql={urllib.parse.quote(jql, safe='')}"
+                f"&maxResults={page_size}&fields={fields}")
+        if next_page_token:
+            path += f"&nextPageToken="
+            path += urllib.parse.quote(next_page_token, safe='')
+        data = api_call_with_retry(server, path, user, token)
+
+        for issue in data.get("issues", []):
+            yield issue
+
+        if data.get("isLast", True):
+            break
+        next_page_token = data.get("nextPageToken")
+        if not next_page_token:
+            break
+
+
+def fetch_all_issues(server, user, token, jql):
+    """Fetch all issues matching JQL with description and labels.
+
+    Returns an ordered dict of {key: {"content_hash": str, "labels": list}}.
+    Order matches Jira's default (created desc).
+    """
+    issues = {}
+    for issue in _fetch_paginated(
+            server, user, token, jql, "key,description,labels"):
+        key = issue["key"]
+        fields = issue.get("fields", {})
+        description = fields.get("description")
+        labels = fields.get("labels", [])
+        content_hash = compute_content_hash(description)
+        issues[key] = {
+            "content_hash": content_hash,
+            "labels": labels,
+        }
+    return issues
+
+
+def find_previous_snapshot():
+    """Find the most recent valid promoted snapshot.
+
+    Walks backwards through issue-snapshot-*.yaml files sorted by name
+    (which sorts by timestamp since names use YYYYMMDD-HHMMSS format).
+    """
+    pattern = os.path.join(SNAPSHOT_DIR, "issue-snapshot-*.yaml")
+    files = sorted(glob.glob(pattern), reverse=True)
+
+    for f in files:
+        try:
+            with open(f, encoding="utf-8") as fh:
+                data = yaml.safe_load(fh)
+            if data and isinstance(data.get("issues"), dict):
+                return f, data
+        except Exception:
+            continue
+    return None, None
+
+
+def load_snapshot_from_dir(data_dir):
+    """Find the previous snapshot in a local data directory.
+
+    Follows the 'latest' symlink to find the most recent run, then
+    walks backwards through run directories looking for a snapshot
+    in auto-fix-runs/.
+
+    Returns snapshot_data dict or None.
+    """
+    if not os.path.isdir(data_dir):
+        print(f"Data repo path not found: {data_dir}", file=sys.stderr)
+        return None
+
+    # Follow 'latest' symlink to find the most recent run
+    latest_link = os.path.join(data_dir, "latest")
+    if os.path.islink(latest_link):
+        latest_target = os.readlink(latest_link)
+        print(f"Data repo latest: {latest_target}", file=sys.stderr)
+    else:
+        print("Data repo: no 'latest' symlink, scanning directories",
+              file=sys.stderr)
+        latest_target = None
+
+    # Collect run directories sorted newest-first
+    run_dirs = []
+    for name in sorted(os.listdir(data_dir), reverse=True):
+        if name.startswith(".") or name == "latest":
+            continue
+        path = os.path.join(data_dir, name)
+        if os.path.isdir(path):
+            run_dirs.append(name)
+
+    if latest_target and latest_target in [os.path.basename(d)
+                                           for d in run_dirs]:
+        # Put the symlink target first, then the rest newest-first
+        run_dirs.remove(latest_target)
+        run_dirs.insert(0, latest_target)
+
+    # Walk backwards through runs looking for a snapshot
+    for run_name in run_dirs:
+        run_path = os.path.join(data_dir, run_name)
+        snap_dir = os.path.join(run_path, "auto-fix-runs")
+        if not os.path.isdir(snap_dir):
+            continue
+        pattern = os.path.join(snap_dir, "issue-snapshot-*.yaml")
+        snap_files = sorted(glob.glob(pattern), reverse=True)
+        for sf in snap_files:
+            try:
+                with open(sf, encoding="utf-8") as fh:
+                    data = yaml.safe_load(fh)
+                if data and isinstance(data.get("issues"), dict):
+                    print(f"Data repo snapshot: {run_name}/"
+                          f"{os.path.basename(sf)} "
+                          f"({len(data['issues'])} issues)",
+                          file=sys.stderr)
+                    return data
+            except Exception:
+                continue
+
+    print("Data repo: no valid snapshot found", file=sys.stderr)
+    return None
+
+
+def diff_snapshots(current_issues, previous_data):
+    """Compare current fetch against previous snapshot.
+
+    Returns (changed_keys, new_keys) preserving Jira's fetch order.
+    - changed: hash differs from previous snapshot
+    - new: not in previous snapshot at all
+    """
+    if previous_data is None:
+        # First run — all issues are "new"
+        return [], list(current_issues.keys())
+
+    prev_issues = previous_data.get("issues", {})
+    changed = []
+    new = []
+
+    for key, data in current_issues.items():
+        current_hash = data["content_hash"]
+
+        if key not in prev_issues:
+            new.append(key)
+            continue
+
+        if current_hash != prev_issues[key]:
+            changed.append(key)
+
+    return changed, new
+
+
+def write_id_file(path, ids):
+    """Write IDs to a file, one per line."""
+    os.makedirs(os.path.dirname(path) or "tmp", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for id_ in ids:
+            f.write(f"{id_}\n")
+
+
+def update_snapshot_hashes(hashes, snapshot_dir=None):
+    """Update the latest snapshot with post-submit content hashes.
+
+    Called by submit.py after Jira writes so the next fetch sees
+    the post-submit state and doesn't re-flag our own changes.
+    """
+    snap_dir = snapshot_dir or SNAPSHOT_DIR
+    pattern = os.path.join(snap_dir, "issue-snapshot-*.yaml")
+    files = sorted(glob.glob(pattern), reverse=True)
+
+    for f in files:
+        try:
+            with open(f, encoding="utf-8") as fh:
+                data = yaml.safe_load(fh)
+            if data and isinstance(data.get("issues"), dict):
+                data["issues"].update(hashes)
+                with open(f, "w", encoding="utf-8") as fh:
+                    yaml.dump(data, fh, default_flow_style=False,
+                              sort_keys=False)
+                return f
+        except Exception:
+            continue
+    return None
+
+
+def cmd_fetch(args):
+    """Fetch all issues, diff against previous snapshot, write ID files."""
+    server, user, token = require_env()
+    if not all([server, user, token]):
+        print("Error: JIRA_SERVER, JIRA_USER, and JIRA_TOKEN required",
+              file=sys.stderr)
+        sys.exit(1)
+
+    # Load previous snapshot
+    prev_path, prev_data = find_previous_snapshot()
+
+    # If no local snapshot, try the data directory
+    if prev_data is None and args.data_dir:
+        prev_data = load_snapshot_from_dir(args.data_dir)
+
+    if prev_path:
+        prev_count = len(prev_data.get("issues", {}))
+        print(f"Previous snapshot: {prev_path} ({prev_count} issues)",
+              file=sys.stderr)
+    elif prev_data:
+        prev_count = len(prev_data.get("issues", {}))
+        print(f"Previous snapshot: from data dir ({prev_count} issues)",
+              file=sys.stderr)
+    else:
+        print("Previous snapshot: none (first run)", file=sys.stderr)
+
+    # Hard filters only
+    jql = (f"({args.jql}) AND statusCategory != Done "
+           f"AND labels not in (rfe-creator-ignore)")
+    print(f"JQL={jql}", file=sys.stderr)
+
+    query_timestamp = datetime.now(timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ")
+
+    # Fetch all matching issues
+    current = fetch_all_issues(server, user, token, jql)
+    print(f"Fetched {len(current)} issues", file=sys.stderr)
+
+    # Write snapshot directly to artifacts
+    os.makedirs(SNAPSHOT_DIR, exist_ok=True)
+    snapshot = {
+        "query_timestamp": query_timestamp,
+        "timestamp": datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"),
+        "issues": {k: v["content_hash"] for k, v in current.items()},
+    }
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out_path = os.path.join(SNAPSHOT_DIR, f"issue-snapshot-{ts}.yaml")
+    with open(out_path, "w", encoding="utf-8") as f:
+        yaml.dump(snapshot, f, default_flow_style=False, sort_keys=False)
+
+    # Diff
+    changed, new = diff_snapshots(current, prev_data)
+
+    # Maintain Jira's original order across both sets
+    changed_set = set(changed)
+    new_set = set(new)
+    all_ids = [k for k in current.keys() if k in changed_set or k in new_set]
+
+    # Apply limit
+    limit = args.limit or len(all_ids)
+    all_ids = all_ids[:limit]
+
+    # Re-split into changed/new after limit
+    out_changed = [k for k in all_ids if k in changed_set]
+    out_new = [k for k in all_ids if k in new_set]
+
+    # Write ID files for downstream scripts
+    write_id_file(args.ids_file, all_ids)
+    write_id_file(args.changed_file, out_changed)
+
+    # Output counts only — IDs are in files
+    print(f"TOTAL={len(all_ids)}")
+    print(f"CHANGED={len(out_changed)}")
+    print(f"NEW={len(out_new)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    fetch_p = sub.add_parser(
+        "fetch", help="Fetch issues and diff against previous snapshot")
+    fetch_p.add_argument("jql", help="JQL query string")
+    fetch_p.add_argument("--limit", type=int, default=None,
+                         help="Max number of changed keys to output")
+    fetch_p.add_argument("--ids-file", required=True,
+                         help="Output file for all IDs to process")
+    fetch_p.add_argument("--changed-file", required=True,
+                         help="Output file for changed-only IDs")
+    fetch_p.add_argument("--data-dir",
+                         help="Local directory with previous run results")
+
+    args = parser.parse_args()
+    if args.command == "fetch":
+        cmd_fetch(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -30,13 +30,18 @@ from jira_utils import (
     create_issue,
     update_issue,
     add_labels,
+    remove_labels,
     add_comment,
     get_issue,
     adf_to_markdown,
     strip_metadata,
     markdown_to_adf,
+    normalize_for_compare,
 )
-from check_conflicts import _normalize_for_compare
+
+_normalize_for_compare = normalize_for_compare
+
+from snapshot_fetch import compute_content_hash, update_snapshot_hashes
 
 from artifact_utils import (
     read_frontmatter,
@@ -224,10 +229,18 @@ def main():
             attn_reason = review_data.get("needs_attention_reason")
 
         if rec in ("reject", "autorevise_reject"):
+            # Check if rubric-pass label needs to be removed (RFE was
+            # previously passing but no longer does after re-review)
+            remove = []
+            if (is_existing
+                    and "rfe-creator-autofix-rubric-pass" in original_labels):
+                remove.append("rfe-creator-autofix-rubric-pass")
             plan.append({
                 "rfe_id": rfe_id, "title": title,
                 "is_existing": is_existing, "priority": priority, "size": size,
-                "action": "SKIP", "labels": [], "skip_reason": "rejected",
+                "action": "Remove labels" if remove else "SKIP",
+                "labels": [], "remove_labels": remove,
+                "skip_reason": None if remove else "rejected",
                 "task_path": task_path,
                 "attn_reason": None, "original_labels": original_labels,
             })
@@ -257,9 +270,12 @@ def main():
                             "is_existing": is_existing, "priority": priority,
                             "size": size,
                             "action": "SKIP", "labels": [],
+                            "remove_labels": [],
                             "skip_reason": "Jira conflict — description "
                                            "modified since fetch",
                             "task_path": task_path,
+                            "attn_reason": None,
+                            "original_labels": original_labels,
                         })
                         continue
                 except Exception as e:
@@ -289,7 +305,7 @@ def main():
                         "is_existing": is_existing, "priority": priority,
                         "size": size,
                         "action": "Label only" if no_change_labels else "SKIP",
-                        "labels": no_change_labels,
+                        "labels": no_change_labels, "remove_labels": [],
                         "skip_reason": None if no_change_labels else "no changes",
                         "task_path": task_path,
                         "attn_reason": attn_reason,
@@ -312,8 +328,8 @@ def main():
         plan.append({
             "rfe_id": rfe_id, "title": title,
             "is_existing": is_existing, "priority": priority, "size": size,
-            "action": action, "labels": labels, "skip_reason": None,
-            "task_path": task_path,
+            "action": action, "labels": labels, "remove_labels": [],
+            "skip_reason": None, "task_path": task_path,
             "attn_reason": attn_reason, "original_labels": original_labels,
         })
 
@@ -328,16 +344,29 @@ def main():
               f"{entry['priority']:<10} {entry['action']:<20}")
         if entry["labels"]:
             print(f"{'':>10} Labels: {', '.join(entry['labels'])}")
+        if entry.get("remove_labels"):
+            print(f"{'':>10} Remove: {', '.join(entry['remove_labels'])}")
         if entry["skip_reason"]:
             print(f"{'':>10} Reason: {entry['skip_reason']}")
     print()
 
     # Execute
     results = {}  # rfe_id -> assigned jira key
+    submitted_hashes = {}  # assigned_key -> content_hash
     for entry in plan:
         rfe_id = entry["rfe_id"]
         if entry["skip_reason"]:
             print(f"  {rfe_id}: Skipping — {entry['skip_reason']}")
+            continue
+
+        if entry["action"] == "Remove labels":
+            remove = entry["remove_labels"]
+            if args.dry_run:
+                print(f"  {rfe_id}: Would remove labels: "
+                      f"{', '.join(remove)}")
+            else:
+                remove_labels(server, user, token, rfe_id, remove)
+                print(f"  {rfe_id}: Removed labels: {', '.join(remove)}")
             continue
 
         if entry["action"] == "Label only":
@@ -372,6 +401,7 @@ def main():
                 if labels:
                     add_labels(server, user, token, rfe_id, labels)
                     print(f"           Labels: {', '.join(labels)}")
+                submitted_hashes[rfe_id] = compute_content_hash(description_adf)
             results[rfe_id] = rfe_id
         else:
             # Create new ticket
@@ -387,6 +417,7 @@ def main():
                 if labels:
                     print(f"           Labels: {', '.join(labels)}")
                 results[rfe_id] = new_key
+                submitted_hashes[new_key] = compute_content_hash(description_adf)
 
         # Post removed-context Jira comment if applicable
         yaml_path = find_removed_context_yaml(args.artifacts_dir, rfe_id)
@@ -428,6 +459,18 @@ def main():
             update_frontmatter(entry["task_path"],
                                {"status": "Submitted"},
                                "rfe-task")
+
+    # Update snapshot with post-submit hashes so the next fetch
+    # doesn't re-flag our own changes
+    if submitted_hashes and not args.dry_run:
+        snap_dir = os.path.join(args.artifacts_dir, "auto-fix-runs")
+        updated = update_snapshot_hashes(submitted_hashes, snap_dir)
+        if updated:
+            print(f"  Updated snapshot with {len(submitted_hashes)} "
+                  f"post-submit hashes: {updated}")
+        else:
+            print("  Warning: no snapshot found to update",
+                  file=sys.stderr)
 
     # Rebuild index
     rebuild_index(args.artifacts_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,132 @@
+"""Shared test fixtures — jira-emulator server for integration tests."""
+import base64
+import json
+import os
+import socket
+import threading
+import time
+import urllib.request
+
+import pytest
+
+
+def _find_free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _jira_request(base_url, method, path, body=None):
+    """Make a request to the jira-emulator."""
+    url = f"{base_url}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    creds = base64.b64encode(b"admin:admin").decode()
+    headers = {
+        "Authorization": f"Basic {creds}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req) as resp:
+        if resp.status == 204:
+            return None
+        body_bytes = resp.read()
+        return json.loads(body_bytes) if body_bytes else None
+
+
+@pytest.fixture(scope="session")
+def jira_emu():
+    """Start a jira-emulator server for the test session.
+
+    Returns the base URL (e.g. http://127.0.0.1:PORT).
+    The server runs in a daemon thread and is shut down when
+    the session ends.
+    """
+    port = _find_free_port()
+
+    os.environ["DATABASE_URL"] = "sqlite+aiosqlite://"
+    os.environ["AUTH_MODE"] = "none"
+    os.environ["SEED_DATA"] = "true"
+
+    # Import inside the fixture so env vars are set first
+    from jira_emulator.config import get_settings
+    get_settings.cache_clear()
+    from jira_emulator.database import reset_engine
+    reset_engine()
+    from jira_emulator.app import create_app
+    import uvicorn
+
+    app = create_app()
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    # Wait for server readiness
+    base_url = f"http://127.0.0.1:{port}"
+    for _ in range(100):
+        try:
+            urllib.request.urlopen(f"{base_url}/")
+            break
+        except Exception:
+            time.sleep(0.05)
+
+    yield base_url
+    server.should_exit = True
+
+
+@pytest.fixture
+def jira(jira_emu):
+    """Per-test fixture: resets emulator state and provides helpers.
+
+    Usage:
+        def test_foo(jira):
+            jira.create("RHAIRFE-1", "Summary", "Description text")
+            # ... run code under test against jira.url ...
+    """
+    # Reset all data before each test
+    req = urllib.request.Request(
+        f"{jira_emu}/api/admin/reset", method="POST", data=b"")
+    urllib.request.urlopen(req)
+
+    class JiraHelper:
+        url = jira_emu
+
+        @staticmethod
+        def create(key, summary, description, labels=None):
+            """Import an issue with a specific key."""
+            issue = {
+                "key": key,
+                "summary": summary,
+                "project": key.split("-")[0],
+                "issue_type": "Feature Request",
+                "description": description,
+            }
+            if labels:
+                issue["labels"] = labels
+            _jira_request(jira_emu, "POST", "/api/admin/import",
+                          {"issues": [issue]})
+
+        @staticmethod
+        def get(key):
+            """GET an issue, return parsed JSON."""
+            return _jira_request(jira_emu, "GET",
+                                 f"/rest/api/3/issue/{key}")
+
+        @staticmethod
+        def search(jql, fields="key,description,labels"):
+            """JQL search, return list of issues."""
+            from urllib.parse import quote
+            path = (f"/rest/api/3/search/jql"
+                    f"?jql={quote(jql, safe='')}&fields={fields}")
+            data = _jira_request(jira_emu, "GET", path)
+            return data.get("issues", [])
+
+        @staticmethod
+        def request(method, path, body=None):
+            """Make an arbitrary API request to the emulator."""
+            return _jira_request(jira_emu, method, path, body)
+
+    return JiraHelper()

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Tests for scripts/bootstrap_snapshot.py."""
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import threading
+import urllib.parse
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..",
+                      "scripts", "bootstrap_snapshot.py")
+
+from snapshot_fetch import normalize_for_hash
+from bootstrap_snapshot import (
+    find_latest_run_timestamp,
+    get_description_at_time,
+    _parse_adf,
+)
+
+
+def _write(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def _md_hash(text):
+    """Compute the expected hash for markdown content."""
+    normalized = normalize_for_hash(text)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _text_to_adf(text):
+    return {
+        "type": "doc", "version": 1,
+        "content": [{"type": "paragraph", "content": [
+            {"type": "text", "text": text}
+        ]}],
+    }
+
+
+# ── Unit Tests ────────────────────────────────────────────────────────────────
+
+class TestFindLatestRunTimestamp:
+    def test_follows_latest_symlink(self, tmp_path):
+        (tmp_path / "20260401-120000").mkdir()
+        (tmp_path / "20260402-080000").mkdir()
+        os.symlink("20260401-120000", str(tmp_path / "latest"))
+
+        name, dt = find_latest_run_timestamp(str(tmp_path))
+        assert name == "20260401-120000"
+        assert dt.year == 2026
+        assert dt.month == 4
+        assert dt.day == 1
+
+    def test_newest_dir_without_symlink(self, tmp_path):
+        (tmp_path / "20260401-120000").mkdir()
+        (tmp_path / "20260402-080000").mkdir()
+
+        name, dt = find_latest_run_timestamp(str(tmp_path))
+        assert name == "20260402-080000"
+
+    def test_empty_dir_returns_none(self, tmp_path):
+        name, dt = find_latest_run_timestamp(str(tmp_path))
+        assert name is None
+        assert dt is None
+
+    def test_skips_non_timestamp_dirs(self, tmp_path):
+        (tmp_path / "not-a-timestamp").mkdir()
+        (tmp_path / "20260401-120000").mkdir()
+
+        name, dt = find_latest_run_timestamp(str(tmp_path))
+        assert name == "20260401-120000"
+
+
+class TestParseAdf:
+    def test_none_returns_none(self):
+        assert _parse_adf(None) is None
+
+    def test_dict_passthrough(self):
+        adf = {"type": "doc", "version": 1, "content": []}
+        assert _parse_adf(adf) == adf
+
+    def test_json_string_parsed(self):
+        adf = {"type": "doc", "version": 1, "content": []}
+        assert _parse_adf(json.dumps(adf)) == adf
+
+    def test_invalid_json_returns_none(self):
+        assert _parse_adf("not json") is None
+
+    def test_non_dict_json_returns_none(self):
+        assert _parse_adf(json.dumps([1, 2, 3])) is None
+
+
+# ── Mock Jira Server ─────────────────────────────────────────────────────────
+
+class JiraHandler(BaseHTTPRequestHandler):
+    """Mock Jira that serves search results and changelogs."""
+
+    def do_GET(self):
+        decoded = urllib.parse.unquote(self.path)
+
+        if "/search/jql" in decoded:
+            self._handle_search(decoded)
+        elif "/changelog" in decoded:
+            self._handle_changelog(decoded)
+        else:
+            self._json(404, {"error": "not found"})
+
+    def _handle_search(self, path):
+        fields = ""
+        if "fields=" in path:
+            fields = path.split("fields=")[1].split("&")[0]
+
+        issues = []
+        for key, desc in self.server.issues.items():
+            if fields == "key":
+                issues.append({"key": key})
+            else:
+                adf = _text_to_adf(desc) if desc else None
+                issues.append({
+                    "key": key,
+                    "fields": {"description": adf, "labels": []},
+                })
+        self._json(200, {"issues": issues, "isLast": True})
+
+    def _handle_changelog(self, path):
+        # Extract issue key from path like /issue/RHAIRFE-1234/changelog
+        parts = path.split("/issue/")[1].split("/changelog")[0]
+        key = parts.split("?")[0]
+
+        histories = self.server.changelogs.get(key, [])
+        self._json(200, {
+            "values": histories,
+            "total": len(histories),
+        })
+
+    def _json(self, status, data):
+        body = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.fixture
+def mock_jira():
+    server = HTTPServer(("127.0.0.1", 0), JiraHandler)
+    server.issues = {}
+    server.changelogs = {}
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    yield url, server
+    server.shutdown()
+
+
+def _make_results_dir(tmp_path, run_names, latest=None):
+    """Create a results directory with run dirs."""
+    results = str(tmp_path / "results")
+    os.makedirs(results)
+    for name in run_names:
+        os.makedirs(os.path.join(results, name))
+    if latest:
+        os.symlink(latest, os.path.join(results, "latest"))
+    return results
+
+
+# ── Integration Tests ─────────────────────────────────────────────────────────
+
+class TestBootstrapIntegration:
+    def test_dry_run(self, tmp_path, mock_jira):
+        """Dry run prints plan without writing files."""
+        url, server = mock_jira
+        server.issues = {
+            "RHAIRFE-1234": "Description 1.",
+            "RHAIRFE-5678": "Description 2.",
+        }
+        results = _make_results_dir(
+            tmp_path, ["20260401-120000"], latest="20260401-120000")
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT, "--dry-run",
+             "--results-dir", results,
+             "--artifacts-dir", art_dir,
+             "project = RHAIRFE"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+        assert "Dry run" in r.stdout
+        assert "2 issue hashes" in r.stdout
+
+        # No files written
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        assert not os.path.exists(snapshot_dir)
+
+    def test_creates_snapshot_with_current_hashes(self, tmp_path, mock_jira):
+        """Issues not updated since run use current Jira hashes."""
+        url, server = mock_jira
+        server.issues = {
+            "RHAIRFE-1234": "Current description.",
+            "RHAIRFE-5678": "Another description.",
+        }
+        # No issues match "updated since run" query (mock returns all
+        # for any query, so we set the run time to now — the JQL filter
+        # for updated >= will still match all, but changelogs are empty
+        # so current hashes are used)
+        results = _make_results_dir(
+            tmp_path, ["20260401-120000"], latest="20260401-120000")
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT,
+             "--results-dir", results,
+             "--artifacts-dir", art_dir,
+             "project = RHAIRFE"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        snapshots = [f for f in os.listdir(snapshot_dir)
+                     if f.startswith("issue-snapshot-")]
+        assert len(snapshots) == 1
+
+        with open(os.path.join(snapshot_dir, snapshots[0])) as f:
+            snap = yaml.safe_load(f)
+
+        assert len(snap["issues"]) == 2
+        expected_1234 = _md_hash("Current description.")
+        assert snap["issues"]["RHAIRFE-1234"] == expected_1234
+
+    def test_run_timestamp_used(self, tmp_path, mock_jira):
+        """Snapshot query_timestamp comes from the run directory name."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Content."}
+        results = _make_results_dir(
+            tmp_path, ["20260401-120000"], latest="20260401-120000")
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT,
+             "--results-dir", results,
+             "--artifacts-dir", art_dir,
+             "project = RHAIRFE"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        snapshots = [f for f in os.listdir(snapshot_dir)
+                     if f.startswith("issue-snapshot-")]
+        with open(os.path.join(snapshot_dir, snapshots[0])) as f:
+            snap = yaml.safe_load(f)
+
+        assert snap["query_timestamp"] == "2026-04-01T12:00:00Z"
+        assert snap["bootstrapped_from"] == "20260401-120000"
+
+    def test_historical_description_via_changelog(self, tmp_path, mock_jira):
+        """Issue updated since run gets historical hash from changelog."""
+        url, server = mock_jira
+        # Current description (after someone edited it)
+        server.issues = {"RHAIRFE-1": "Edited after run."}
+        # Changelog shows description was changed AFTER the run
+        server.changelogs["RHAIRFE-1"] = [{
+            "created": "2026-04-02T10:00:00.000+0000",
+            "items": [{
+                "field": "description",
+                "from": json.dumps(_text_to_adf("Original at run time.")),
+                "to": json.dumps(_text_to_adf("Edited after run.")),
+            }],
+        }]
+        results = _make_results_dir(
+            tmp_path, ["20260401-120000"], latest="20260401-120000")
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT,
+             "--results-dir", results,
+             "--artifacts-dir", art_dir,
+             "project = RHAIRFE"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        snapshots = [f for f in os.listdir(snapshot_dir)
+                     if f.startswith("issue-snapshot-")]
+        with open(os.path.join(snapshot_dir, snapshots[0])) as f:
+            snap = yaml.safe_load(f)
+
+        # Should use the HISTORICAL hash (from before the edit)
+        historical_hash = _md_hash("Original at run time.")
+        current_hash = _md_hash("Edited after run.")
+        assert snap["issues"]["RHAIRFE-1"] == historical_hash
+        assert snap["issues"]["RHAIRFE-1"] != current_hash
+
+    def test_only_snapshot_written(self, tmp_path, mock_jira):
+        """Bootstrap writes only an issue-snapshot file, nothing else."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Content."}
+        results = _make_results_dir(
+            tmp_path, ["20260401-120000"], latest="20260401-120000")
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+        subprocess.run(
+            [sys.executable, SCRIPT,
+             "--results-dir", results,
+             "--artifacts-dir", art_dir,
+             "project = RHAIRFE"],
+            capture_output=True, text=True, env=env,
+        )
+
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        files = os.listdir(snapshot_dir)
+        assert all(f.startswith("issue-snapshot-") for f in files)
+
+    def test_reopened_issue_excluded(self, tmp_path, mock_jira):
+        """Issue in Done status at run time is excluded from snapshot."""
+        url, server = mock_jira
+        server.issues = {
+            "RHAIRFE-1": "Normal issue.",
+            "RHAIRFE-2": "Was closed, now reopened.",
+        }
+        # RHAIRFE-2 was Closed at run time, reopened after
+        server.changelogs["RHAIRFE-2"] = [{
+            "created": "2026-04-02T10:00:00.000+0000",
+            "items": [{
+                "field": "status",
+                "fromString": "Closed",
+                "toString": "New",
+            }],
+        }]
+        results = _make_results_dir(
+            tmp_path, ["20260401-120000"], latest="20260401-120000")
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT,
+             "--results-dir", results,
+             "--artifacts-dir", art_dir,
+             "project = RHAIRFE"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        snapshots = [f for f in os.listdir(snapshot_dir)
+                     if f.startswith("issue-snapshot-")]
+        with open(os.path.join(snapshot_dir, snapshots[0])) as f:
+            snap = yaml.safe_load(f)
+
+        assert "RHAIRFE-1" in snap["issues"]
+        assert "RHAIRFE-2" not in snap["issues"]
+        assert len(snap["issues"]) == 1

--- a/tests/test_check_resume.py
+++ b/tests/test_check_resume.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_resume.py — resume checking with changed-ID bypass
+and file-based I/O."""
+import os
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts",
+                      "check_resume.py")
+
+from check_resume import check_resume, read_ids_from_file
+
+
+def _write(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+
+
+PASSING_REVIEW = """\
+---
+rfe_id: {rfe_id}
+score: 9
+pass: true
+recommendation: submit
+feasibility: feasible
+auto_revised: false
+needs_attention: false
+error: null
+scores:
+  what: 2
+  why: 2
+  open_to_how: 2
+  not_a_task: 2
+  right_sized: 1
+---
+
+Looks good.
+"""
+
+FAILING_REVIEW = """\
+---
+rfe_id: {rfe_id}
+score: 3
+pass: false
+recommendation: reject
+feasibility: feasible
+auto_revised: false
+needs_attention: false
+error: null
+scores:
+  what: 0
+  why: 1
+  open_to_how: 1
+  not_a_task: 1
+  right_sized: 0
+---
+
+Needs work.
+"""
+
+ERROR_REVIEW = """\
+---
+rfe_id: {rfe_id}
+score: 0
+pass: false
+recommendation: reject
+feasibility: unknown
+auto_revised: false
+needs_attention: false
+error: "fetch_failed"
+scores:
+  what: 0
+  why: 0
+  open_to_how: 0
+  not_a_task: 0
+  right_sized: 0
+---
+
+Error during processing.
+"""
+
+
+@pytest.fixture
+def art_dir(tmp_path):
+    """Create a minimal artifacts directory."""
+    os.makedirs(tmp_path / "rfe-reviews")
+    orig = os.getcwd()
+    os.chdir(tmp_path)
+    yield str(tmp_path)
+    os.chdir(orig)
+
+
+class TestCheckResumeFunction:
+    def test_no_reviews_all_process(self, art_dir):
+        """IDs with no review files → all need processing."""
+        process, skip = check_resume(
+            ["RHAIRFE-1", "RHAIRFE-2"], [], art_dir)
+        assert process == ["RHAIRFE-1", "RHAIRFE-2"]
+        assert skip == []
+
+    def test_passing_review_skipped(self, art_dir):
+        """ID with passing review → skipped."""
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1-review.md",
+               PASSING_REVIEW.format(rfe_id="RHAIRFE-1"))
+        process, skip = check_resume(["RHAIRFE-1"], [], art_dir)
+        assert process == []
+        assert skip == ["RHAIRFE-1"]
+
+    def test_failing_review_processed(self, art_dir):
+        """ID with failing review → needs processing."""
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1-review.md",
+               FAILING_REVIEW.format(rfe_id="RHAIRFE-1"))
+        process, skip = check_resume(["RHAIRFE-1"], [], art_dir)
+        assert process == ["RHAIRFE-1"]
+        assert skip == []
+
+    def test_error_review_processed(self, art_dir):
+        """ID with error in review → needs processing."""
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1-review.md",
+               ERROR_REVIEW.format(rfe_id="RHAIRFE-1"))
+        process, skip = check_resume(["RHAIRFE-1"], [], art_dir)
+        assert process == ["RHAIRFE-1"]
+        assert skip == []
+
+    def test_changed_id_bypasses_passing_review(self, art_dir):
+        """Changed ID with passing review → still processed (bypass)."""
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1-review.md",
+               PASSING_REVIEW.format(rfe_id="RHAIRFE-1"))
+        process, skip = check_resume(
+            ["RHAIRFE-1"], ["RHAIRFE-1"], art_dir)
+        assert process == ["RHAIRFE-1"]
+        assert skip == []
+
+    def test_mixed_changed_and_new(self, art_dir):
+        """Mix of changed and unchanged IDs with various review states."""
+        # RHAIRFE-1: changed, has passing review → process (bypass)
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1-review.md",
+               PASSING_REVIEW.format(rfe_id="RHAIRFE-1"))
+        # RHAIRFE-2: not changed, has passing review → skip
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-2-review.md",
+               PASSING_REVIEW.format(rfe_id="RHAIRFE-2"))
+        # RHAIRFE-3: not changed, no review → process
+        # RHAIRFE-4: changed, no review → process
+
+        ids = ["RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3", "RHAIRFE-4"]
+        changed = ["RHAIRFE-1", "RHAIRFE-4"]
+        process, skip = check_resume(ids, changed, art_dir)
+        assert process == ["RHAIRFE-1", "RHAIRFE-3", "RHAIRFE-4"]
+        assert skip == ["RHAIRFE-2"]
+
+    def test_preserves_input_order(self, art_dir):
+        """Output preserves the order of input IDs."""
+        process, skip = check_resume(
+            ["RHAIRFE-3", "RHAIRFE-1", "RHAIRFE-2"], [], art_dir)
+        assert process == ["RHAIRFE-3", "RHAIRFE-1", "RHAIRFE-2"]
+
+
+class TestReadIdsFromFile:
+    def test_reads_ids(self, tmp_path):
+        path = str(tmp_path / "ids.txt")
+        with open(path, "w") as f:
+            f.write("RHAIRFE-1\nRHAIRFE-2\nRHAIRFE-3\n")
+        assert read_ids_from_file(path) == [
+            "RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"]
+
+    def test_missing_file_returns_empty(self):
+        assert read_ids_from_file("/nonexistent/file.txt") == []
+
+    def test_none_path_returns_empty(self):
+        assert read_ids_from_file(None) == []
+
+    def test_skips_blank_lines(self, tmp_path):
+        path = str(tmp_path / "ids.txt")
+        with open(path, "w") as f:
+            f.write("RHAIRFE-1\n\nRHAIRFE-2\n\n")
+        assert read_ids_from_file(path) == ["RHAIRFE-1", "RHAIRFE-2"]
+
+
+class TestFileBasedMode:
+    """Integration tests using subprocess to validate file-based CLI."""
+
+    def test_writes_output_file(self, art_dir, tmp_path):
+        """--output-file receives the filtered process IDs."""
+        ids_file = str(tmp_path / "all.txt")
+        changed_file = str(tmp_path / "changed.txt")
+        output_file = str(tmp_path / "process.txt")
+
+        with open(ids_file, "w") as f:
+            f.write("RHAIRFE-1\nRHAIRFE-2\n")
+        with open(changed_file, "w") as f:
+            f.write("")
+
+        result = subprocess.run(
+            ["python3", SCRIPT,
+             "--ids-file", ids_file,
+             "--changed-file", changed_file,
+             "--output-file", output_file,
+             "--artifacts-dir", art_dir],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        with open(output_file) as f:
+            ids = [l.strip() for l in f if l.strip()]
+        assert ids == ["RHAIRFE-1", "RHAIRFE-2"]
+
+    def test_changed_ids_bypass_resume(self, art_dir, tmp_path):
+        """Changed IDs bypass passing reviews in file-based mode."""
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1-review.md",
+               PASSING_REVIEW.format(rfe_id="RHAIRFE-1"))
+
+        ids_file = str(tmp_path / "all.txt")
+        changed_file = str(tmp_path / "changed.txt")
+        output_file = str(tmp_path / "process.txt")
+
+        with open(ids_file, "w") as f:
+            f.write("RHAIRFE-1\n")
+        with open(changed_file, "w") as f:
+            f.write("RHAIRFE-1\n")
+
+        result = subprocess.run(
+            ["python3", SCRIPT,
+             "--ids-file", ids_file,
+             "--changed-file", changed_file,
+             "--output-file", output_file,
+             "--artifacts-dir", art_dir],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "PROCESS=1" in result.stdout
+        assert "SKIP=0" in result.stdout
+        with open(output_file) as f:
+            ids = [l.strip() for l in f if l.strip()]
+        assert ids == ["RHAIRFE-1"]
+
+    def test_stdout_counts(self, art_dir, tmp_path):
+        """File-based mode prints PROCESS=, SKIP=, CHANGED= counts."""
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-2-review.md",
+               PASSING_REVIEW.format(rfe_id="RHAIRFE-2"))
+
+        ids_file = str(tmp_path / "all.txt")
+        changed_file = str(tmp_path / "changed.txt")
+        output_file = str(tmp_path / "process.txt")
+
+        with open(ids_file, "w") as f:
+            f.write("RHAIRFE-1\nRHAIRFE-2\nRHAIRFE-3\n")
+        with open(changed_file, "w") as f:
+            f.write("RHAIRFE-3\n")
+
+        result = subprocess.run(
+            ["python3", SCRIPT,
+             "--ids-file", ids_file,
+             "--changed-file", changed_file,
+             "--output-file", output_file,
+             "--artifacts-dir", art_dir],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "PROCESS=2" in result.stdout
+        assert "SKIP=1" in result.stdout
+        assert "CHANGED=1" in result.stdout

--- a/tests/test_clone_results_repo.py
+++ b/tests/test_clone_results_repo.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Tests for scripts/clone_results_repo.py — URL building logic."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from clone_results_repo import build_clone_url
+
+
+class TestBuildCloneUrl:
+    def test_bare_path_with_token(self):
+        """Bare project path + token → authenticated GitLab URL."""
+        url = build_clone_url("org/group/repo", "glpat-xxx")
+        assert url == "https://bot:glpat-xxx@gitlab.com/org/group/repo.git"
+
+    def test_bare_path_no_token_raises(self):
+        """Bare project path without token → ValueError."""
+        with pytest.raises(ValueError, match="DATA_REPO_TOKEN required"):
+            build_clone_url("org/group/repo", "")
+
+    def test_https_url_with_token(self):
+        """Full HTTPS URL + token → token injected."""
+        url = build_clone_url(
+            "https://gitlab.com/org/repo.git", "glpat-xxx")
+        assert url == "https://bot:glpat-xxx@gitlab.com/org/repo.git"
+
+    def test_https_url_no_token_passthrough(self):
+        """Full HTTPS URL without token → unchanged."""
+        orig = "https://gitlab.com/org/repo.git"
+        assert build_clone_url(orig, "") == orig
+
+    def test_ssh_url_passthrough(self):
+        """SSH URL → unchanged regardless of token."""
+        orig = "git@gitlab.com:org/repo.git"
+        assert build_clone_url(orig, "glpat-xxx") == orig
+
+    def test_https_url_with_port(self):
+        """HTTPS URL with port → port preserved after token injection."""
+        url = build_clone_url(
+            "https://gitlab.example.com:8443/org/repo.git", "tok")
+        assert "bot:tok@gitlab.example.com:8443" in url

--- a/tests/test_clone_results_repo.py
+++ b/tests/test_clone_results_repo.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
-"""Tests for scripts/clone_results_repo.py — URL building logic."""
+"""Tests for scripts/clone_results_repo.py — URL building and sparse checkout."""
 import os
+import subprocess
 import sys
 
 import pytest
+import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..",
+                      "scripts", "clone_results_repo.py")
 
 from clone_results_repo import build_clone_url
 
@@ -42,3 +47,137 @@ class TestBuildCloneUrl:
         url = build_clone_url(
             "https://gitlab.example.com:8443/org/repo.git", "tok")
         assert "bot:tok@gitlab.example.com:8443" in url
+
+    def test_absolute_path_passthrough(self):
+        """Local absolute path → unchanged, no token required."""
+        path = "/tmp/my-local-repo"
+        assert build_clone_url(path, "") == path
+
+    def test_absolute_path_ignores_token(self):
+        """Local absolute path with token → path unchanged."""
+        path = "/tmp/my-local-repo"
+        assert build_clone_url(path, "glpat-xxx") == path
+
+
+# ── Sparse Checkout Integration ─────────────────────────────────────────────
+
+def _init_source_repo(path):
+    """Create a bare-like git repo simulating the results data repo."""
+    os.makedirs(path, exist_ok=True)
+    subprocess.run(["git", "init", path], check=True, capture_output=True)
+    subprocess.run(["git", "-C", path, "config", "user.email", "test@test"],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-C", path, "config", "user.name", "test"],
+                   check=True, capture_output=True)
+    return path
+
+
+def _commit_file(repo, relpath, content="placeholder"):
+    """Write a file and commit it."""
+    full = os.path.join(repo, relpath)
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, "w") as f:
+        f.write(content)
+    subprocess.run(["git", "-C", repo, "add", relpath],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-C", repo, "commit", "-m", f"add {relpath}"],
+                   check=True, capture_output=True)
+
+
+class TestSparseCheckout:
+    """Verify clone_results_repo.py sparse-checkout patterns work.
+
+    Creates a local git repo with the same structure as the data repo,
+    clones it with the script, and asserts only snapshot files and the
+    latest symlink are materialized.
+    """
+
+    def test_only_snapshots_and_latest_materialized(self, tmp_path):
+        """Sparse checkout materializes snapshots and latest, skips rest."""
+        src = _init_source_repo(str(tmp_path / "source"))
+
+        # Populate source repo with a realistic structure
+        snap_content = yaml.dump({
+            "query_timestamp": "2026-04-01T00:00:00Z",
+            "timestamp": "2026-04-01T00:00:01Z",
+            "issues": {"RHAIRFE-1": "abc123"},
+        })
+        _commit_file(src, "20260401-120000/auto-fix-runs/"
+                     "issue-snapshot-20260401-120000.yaml", snap_content)
+        _commit_file(src, "20260401-120000/auto-fix-runs/"
+                     "20260401-120000.yaml", "run report data")
+        _commit_file(src, "20260401-120000/rfe-tasks/RHAIRFE-1.md",
+                     "task content")
+        _commit_file(src, "20260401-120000/rfe-reviews/RHAIRFE-1-review.md",
+                     "review content")
+        _commit_file(src, "20260401-120000/rfe-originals/RHAIRFE-1.md",
+                     "original content")
+
+        # Create the latest symlink (committed as a file in git)
+        latest_path = os.path.join(src, "latest")
+        os.symlink("20260401-120000", latest_path)
+        subprocess.run(["git", "-C", src, "add", "latest"],
+                       check=True, capture_output=True)
+        subprocess.run(["git", "-C", src, "commit", "-m", "add latest"],
+                       check=True, capture_output=True)
+
+        # Clone with the script
+        dest = str(tmp_path / "clone")
+        r = subprocess.run(
+            [sys.executable, SCRIPT, src, dest],
+            capture_output=True, text=True,
+            env={**os.environ, "DATA_REPO_TOKEN": ""},
+        )
+        assert r.returncode == 0, r.stderr
+
+        # Snapshot file should exist
+        snap_file = os.path.join(
+            dest, "20260401-120000", "auto-fix-runs",
+            "issue-snapshot-20260401-120000.yaml")
+        assert os.path.exists(snap_file)
+        with open(snap_file) as f:
+            data = yaml.safe_load(f)
+        assert data["issues"]["RHAIRFE-1"] == "abc123"
+
+        # latest symlink should exist
+        assert os.path.exists(os.path.join(dest, "latest"))
+
+        # Files outside the sparse patterns should NOT be materialized
+        assert not os.path.exists(os.path.join(
+            dest, "20260401-120000", "rfe-tasks", "RHAIRFE-1.md"))
+        assert not os.path.exists(os.path.join(
+            dest, "20260401-120000", "rfe-reviews",
+            "RHAIRFE-1-review.md"))
+        assert not os.path.exists(os.path.join(
+            dest, "20260401-120000", "rfe-originals", "RHAIRFE-1.md"))
+
+    def test_run_report_not_materialized(self, tmp_path):
+        """Run report YAML in auto-fix-runs/ is excluded (not a snapshot)."""
+        src = _init_source_repo(str(tmp_path / "source"))
+
+        snap_content = yaml.dump({
+            "query_timestamp": "2026-04-01T00:00:00Z",
+            "timestamp": "2026-04-01T00:00:01Z",
+            "issues": {},
+        })
+        _commit_file(src, "20260401-120000/auto-fix-runs/"
+                     "issue-snapshot-20260401-120000.yaml", snap_content)
+        _commit_file(src, "20260401-120000/auto-fix-runs/"
+                     "20260401-120000.yaml", "run report")
+
+        dest = str(tmp_path / "clone")
+        r = subprocess.run(
+            [sys.executable, SCRIPT, src, dest],
+            capture_output=True, text=True,
+            env={**os.environ, "DATA_REPO_TOKEN": ""},
+        )
+        assert r.returncode == 0, r.stderr
+
+        # Snapshot: yes
+        assert os.path.exists(os.path.join(
+            dest, "20260401-120000", "auto-fix-runs",
+            "issue-snapshot-20260401-120000.yaml"))
+        # Run report: no
+        assert not os.path.exists(os.path.join(
+            dest, "20260401-120000", "auto-fix-runs",
+            "20260401-120000.yaml"))

--- a/tests/test_snapshot_fetch.py
+++ b/tests/test_snapshot_fetch.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Tests for scripts/snapshot_fetch.py — content hashing, snapshot diffing,
+ID file writing, and snapshot loading from results directories."""
+import hashlib
+import os
+import sys
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from snapshot_fetch import (
+    compute_content_hash,
+    diff_snapshots,
+    load_snapshot_from_dir,
+    write_id_file,
+)
+
+
+class TestComputeContentHash:
+    def test_none_input(self):
+        """None/empty ADF → hash of empty bytes."""
+        expected = hashlib.sha256(b"").hexdigest()
+        assert compute_content_hash(None) == expected
+
+    def test_empty_dict(self):
+        """Empty ADF doc → hash of empty bytes."""
+        expected = hashlib.sha256(b"").hexdigest()
+        assert compute_content_hash({}) == expected
+
+    def test_simple_adf(self):
+        """Basic ADF paragraph → deterministic hash."""
+        adf = {
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {"type": "paragraph", "content": [
+                    {"type": "text", "text": "Hello world"}
+                ]}
+            ]
+        }
+        h = compute_content_hash(adf)
+        assert isinstance(h, str)
+        assert len(h) == 64  # SHA256 hex
+
+    def test_same_content_same_hash(self):
+        """Identical ADF content → identical hash."""
+        adf = {
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {"type": "paragraph", "content": [
+                    {"type": "text", "text": "Test content"}
+                ]}
+            ]
+        }
+        assert compute_content_hash(adf) == compute_content_hash(adf)
+
+    def test_different_content_different_hash(self):
+        """Different ADF content → different hash."""
+        adf1 = {
+            "type": "doc", "version": 1,
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "Version A"}
+            ]}]
+        }
+        adf2 = {
+            "type": "doc", "version": 1,
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "Version B"}
+            ]}]
+        }
+        assert compute_content_hash(adf1) != compute_content_hash(adf2)
+
+    def test_normalization_collapses_whitespace(self):
+        """Curly quotes and extra spaces normalize to the same hash."""
+        adf_straight = {
+            "type": "doc", "version": 1,
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "It's a \"test\""}
+            ]}]
+        }
+        adf_curly = {
+            "type": "doc", "version": 1,
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text",
+                 "text": "It\u2019s a \u201ctest\u201d"}
+            ]}]
+        }
+        assert compute_content_hash(adf_straight) == \
+            compute_content_hash(adf_curly)
+
+    def test_whitespace_only_changes_same_hash(self):
+        """Extra blank lines, indentation, and tabs produce the same hash."""
+        adf_clean = {
+            "type": "doc", "version": 1,
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "Line one\nLine two\nLine three"}
+            ]}]
+        }
+        adf_messy = {
+            "type": "doc", "version": 1,
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text",
+                 "text": "  Line one\n\n\n\tLine two  \n\n  Line three  "}
+            ]}]
+        }
+        assert compute_content_hash(adf_clean) == \
+            compute_content_hash(adf_messy)
+
+
+class TestDiffSnapshots:
+    def test_first_run_all_new(self):
+        """No previous snapshot → all issues are new."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa", "labels": []},
+            "RHAIRFE-2": {"content_hash": "bbb", "labels": []},
+        }
+        changed, new = diff_snapshots(current, None)
+        assert changed == []
+        assert new == ["RHAIRFE-1", "RHAIRFE-2"]
+
+    def test_unchanged_issues_excluded(self):
+        """Issues with same hash → not in changed or new."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa", "labels": []},
+            "RHAIRFE-2": {"content_hash": "bbb", "labels": []},
+        }
+        previous = {"issues": {"RHAIRFE-1": "aaa", "RHAIRFE-2": "bbb"}}
+        changed, new = diff_snapshots(current, previous)
+        assert changed == []
+        assert new == []
+
+    def test_changed_issue_detected(self):
+        """Issue with different hash → in changed list."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa-new", "labels": []},
+            "RHAIRFE-2": {"content_hash": "bbb", "labels": []},
+        }
+        previous = {"issues": {"RHAIRFE-1": "aaa", "RHAIRFE-2": "bbb"}}
+        changed, new = diff_snapshots(current, previous)
+        assert changed == ["RHAIRFE-1"]
+        assert new == []
+
+    def test_new_issue_detected(self):
+        """Issue not in previous snapshot → in new list."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa", "labels": []},
+            "RHAIRFE-3": {"content_hash": "ccc", "labels": []},
+        }
+        previous = {"issues": {"RHAIRFE-1": "aaa"}}
+        changed, new = diff_snapshots(current, previous)
+        assert changed == []
+        assert new == ["RHAIRFE-3"]
+
+    def test_preserves_jira_order(self):
+        """Output preserves insertion order from current dict."""
+        current = {
+            "RHAIRFE-3": {"content_hash": "ccc", "labels": []},
+            "RHAIRFE-1": {"content_hash": "aaa-new", "labels": []},
+            "RHAIRFE-2": {"content_hash": "bbb", "labels": []},
+        }
+        previous = {"issues": {"RHAIRFE-1": "aaa", "RHAIRFE-2": "bbb"}}
+        changed, new = diff_snapshots(current, previous)
+        assert new == ["RHAIRFE-3"]
+        assert changed == ["RHAIRFE-1"]
+
+    def test_mixed_changed_new_unchanged(self):
+        """Mix of changed, new, and unchanged issues."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa-new", "labels": []},
+            "RHAIRFE-2": {"content_hash": "bbb", "labels": []},
+            "RHAIRFE-3": {"content_hash": "ccc", "labels": []},
+            "RHAIRFE-4": {"content_hash": "ddd", "labels": []},
+        }
+        previous = {
+            "issues": {
+                "RHAIRFE-1": "aaa",
+                "RHAIRFE-2": "bbb",
+                "RHAIRFE-3": "ccc-old",
+            }
+        }
+        changed, new = diff_snapshots(current, previous)
+        assert changed == ["RHAIRFE-1", "RHAIRFE-3"]
+        assert new == ["RHAIRFE-4"]
+
+
+def _make_results_dir(tmp_path, runs):
+    """Create a directory mimicking the results directory structure.
+
+    runs: list of dicts with keys: name, snapshot (dict or None),
+          latest (bool).
+    Returns the repo path.
+    """
+    repo = str(tmp_path / "data-repo")
+    os.makedirs(repo)
+
+    latest_name = None
+    for run in runs:
+        name = run["name"]
+        snap_dir = os.path.join(repo, name, "auto-fix-runs")
+        os.makedirs(snap_dir, exist_ok=True)
+
+        if run.get("snapshot"):
+            snap_path = os.path.join(snap_dir,
+                                     f"issue-snapshot-{name}.yaml")
+            with open(snap_path, "w") as f:
+                yaml.dump(run["snapshot"], f)
+
+        if run.get("latest"):
+            latest_name = name
+
+    if latest_name:
+        os.symlink(latest_name, os.path.join(repo, "latest"))
+
+    return repo
+
+
+class TestLoadSnapshotFromDir:
+    def test_follows_latest_symlink(self, tmp_path):
+        """Finds snapshot via latest symlink."""
+        snapshot = {"issues": {"RHAIRFE-1": "aaa"}}
+        repo = _make_results_dir(tmp_path, [
+            {"name": "20260401-120000", "snapshot": snapshot,
+             "latest": True},
+        ])
+
+        data = load_snapshot_from_dir(repo)
+        assert data is not None
+        assert data["issues"] == {"RHAIRFE-1": "aaa"}
+
+    def test_walks_backwards_for_snapshot(self, tmp_path):
+        """Latest run has no snapshot → walks to older run."""
+        old_snapshot = {"issues": {"RHAIRFE-1": "aaa"}}
+        repo = _make_results_dir(tmp_path, [
+            {"name": "20260401-120000", "snapshot": old_snapshot},
+            {"name": "20260402-120000", "snapshot": None,
+             "latest": True},
+        ])
+
+        data = load_snapshot_from_dir(repo)
+        assert data is not None
+        assert data["issues"] == {"RHAIRFE-1": "aaa"}
+
+    def test_no_symlink_uses_newest_dir(self, tmp_path):
+        """No latest symlink → uses newest directory by name."""
+        snap_old = {"issues": {"RHAIRFE-1": "aaa"}}
+        snap_new = {"issues": {"RHAIRFE-1": "bbb", "RHAIRFE-2": "ccc"}}
+        repo = _make_results_dir(tmp_path, [
+            {"name": "20260401-120000", "snapshot": snap_old},
+            {"name": "20260402-120000", "snapshot": snap_new},
+        ])
+
+        data = load_snapshot_from_dir(repo)
+        assert data is not None
+        assert data["issues"] == {"RHAIRFE-1": "bbb",
+                                  "RHAIRFE-2": "ccc"}
+
+    def test_empty_repo_returns_none(self, tmp_path):
+        """No run directories → returns None."""
+        repo = str(tmp_path / "empty-repo")
+        os.makedirs(repo)
+
+        data = load_snapshot_from_dir(repo)
+        assert data is None
+
+    def test_missing_path_returns_none(self, tmp_path):
+        """Non-existent path → returns None."""
+        data = load_snapshot_from_dir(str(tmp_path / "no-such-dir"))
+        assert data is None
+
+
+class TestWriteIdFile:
+    def test_writes_ids_one_per_line(self, tmp_path):
+        path = str(tmp_path / "ids.txt")
+        write_id_file(path, ["RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"])
+        with open(path) as f:
+            lines = f.read().splitlines()
+        assert lines == ["RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"]
+
+    def test_creates_parent_dirs(self, tmp_path):
+        path = str(tmp_path / "sub" / "dir" / "ids.txt")
+        write_id_file(path, ["RHAIRFE-1"])
+        assert os.path.exists(path)
+
+    def test_empty_list_creates_empty_file(self, tmp_path):
+        path = str(tmp_path / "empty.txt")
+        write_id_file(path, [])
+        with open(path) as f:
+            assert f.read() == ""

--- a/tests/test_snapshot_fetch_integration.py
+++ b/tests/test_snapshot_fetch_integration.py
@@ -1,24 +1,25 @@
 #!/usr/bin/env python3
 """Integration tests for snapshot_fetch.py — cmd_fetch exercised
-end-to-end against a mock Jira HTTP server.
+end-to-end against a jira-emulator server.
 
 Covers the full pipeline: first fetch, incremental fetch with change
 detection, snapshot update, and data-dir fallback.
 """
 import io
-import json
 import os
+import subprocess
 import sys
 import threading
-import urllib.parse
 from contextlib import redirect_stdout
-from http.server import HTTPServer, BaseHTTPRequestHandler
 from types import SimpleNamespace
 
 import pytest
 import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+CLONE_SCRIPT = os.path.join(os.path.dirname(__file__), "..",
+                            "scripts", "clone_results_repo.py")
 
 import snapshot_fetch
 from snapshot_fetch import cmd_fetch, compute_content_hash, update_snapshot_hashes
@@ -45,54 +46,7 @@ def _text_to_adf(text):
     }
 
 
-# ── Mock Jira Server ─────────────────────────────────────────────────────────
-
-class JiraHandler(BaseHTTPRequestHandler):
-    """Mock Jira that serves search results.
-
-    server.issues: dict of {key: description} — all current issues
-    """
-
-    def do_GET(self):
-        if "/search/jql" not in self.path:
-            self._json(404, {"error": "not found"})
-            return
-
-        issues = []
-        for key, desc in self.server.issues.items():
-            adf = _text_to_adf(desc) if desc else None
-            issues.append({
-                "key": key,
-                "fields": {"description": adf, "labels": []},
-            })
-
-        self._json(200, {"issues": issues, "isLast": True})
-
-    def _json(self, status, data):
-        body = json.dumps(data).encode()
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def log_message(self, format, *args):
-        pass
-
-
 # ── Fixtures ─────────────────────────────────────────────────────────────────
-
-@pytest.fixture
-def mock_jira():
-    server = HTTPServer(("127.0.0.1", 0), JiraHandler)
-    server.issues = {}
-    url = f"http://127.0.0.1:{server.server_address[1]}"
-    thread = threading.Thread(target=server.serve_forever)
-    thread.daemon = True
-    thread.start()
-    yield url, server
-    server.shutdown()
-
 
 @pytest.fixture
 def work_dirs(tmp_path, monkeypatch):
@@ -138,22 +92,18 @@ def _seed_snapshot(work_dirs, issues, query_ts="2026-04-01T00:00:00Z"):
 
 def _jira_env(monkeypatch, url):
     monkeypatch.setenv("JIRA_SERVER", url)
-    monkeypatch.setenv("JIRA_USER", "test@example.com")
-    monkeypatch.setenv("JIRA_TOKEN", "test-token")
+    monkeypatch.setenv("JIRA_USER", "admin")
+    monkeypatch.setenv("JIRA_TOKEN", "admin")
 
 
 # ── cmd_fetch: First Run ─────────────────────────────────────────────────────
 
 class TestCmdFetchFirstRun:
-    def test_all_issues_are_new(self, work_dirs, mock_jira, monkeypatch,
-                                tmp_path):
+    def test_all_issues_are_new(self, work_dirs, jira, monkeypatch, tmp_path):
         """First run (no snapshot) → all issues NEW, correct stdout."""
-        url, server = mock_jira
-        server.issues = {
-            "RHAIRFE-1": "Description one.",
-            "RHAIRFE-2": "Description two.",
-        }
-        _jira_env(monkeypatch, url)
+        jira.create("RHAIRFE-1", "Issue one", "Description one.")
+        jira.create("RHAIRFE-2", "Issue two", "Description two.")
+        _jira_env(monkeypatch, jira.url)
         args = _fetch_args(tmp_path)
 
         stdout = _run_fetch(args)
@@ -164,12 +114,10 @@ class TestCmdFetchFirstRun:
         assert set(_read_ids(args.ids_file)) == {"RHAIRFE-1", "RHAIRFE-2"}
         assert _read_ids(args.changed_file) == []
 
-    def test_snapshot_written(self, work_dirs, mock_jira, monkeypatch,
-                              tmp_path):
+    def test_snapshot_written(self, work_dirs, jira, monkeypatch, tmp_path):
         """Fetch writes snapshot directly to artifacts with hashes."""
-        url, server = mock_jira
-        server.issues = {"RHAIRFE-1": "Content."}
-        _jira_env(monkeypatch, url)
+        jira.create("RHAIRFE-1", "Issue one", "Content.")
+        _jira_env(monkeypatch, jira.url)
         args = _fetch_args(tmp_path)
 
         _run_fetch(args)
@@ -187,26 +135,22 @@ class TestCmdFetchFirstRun:
 # ── cmd_fetch: Incremental Run ───────────────────────────────────────────────
 
 class TestCmdFetchIncremental:
-    def test_unchanged_excluded(self, work_dirs, mock_jira, monkeypatch,
-                                tmp_path):
+    def test_unchanged_excluded(self, work_dirs, jira, monkeypatch, tmp_path):
         """Issue with same hash → not in output IDs."""
-        url, server = mock_jira
+        jira.create("RHAIRFE-1", "Issue one", "Same content.")
         same_hash = compute_content_hash(_text_to_adf("Same content."))
         _seed_snapshot(work_dirs, {"RHAIRFE-1": same_hash})
-        server.issues = {"RHAIRFE-1": "Same content."}
-        _jira_env(monkeypatch, url)
+        _jira_env(monkeypatch, jira.url)
 
         stdout = _run_fetch(_fetch_args(tmp_path))
 
         assert "TOTAL=0" in stdout
 
-    def test_changed_detected(self, work_dirs, mock_jira, monkeypatch,
-                              tmp_path):
+    def test_changed_detected(self, work_dirs, jira, monkeypatch, tmp_path):
         """Issue with different hash → in changed file."""
-        url, server = mock_jira
+        jira.create("RHAIRFE-1", "Issue one", "New content.")
         _seed_snapshot(work_dirs, {"RHAIRFE-1": "old-hash"})
-        server.issues = {"RHAIRFE-1": "New content."}
-        _jira_env(monkeypatch, url)
+        _jira_env(monkeypatch, jira.url)
 
         args = _fetch_args(tmp_path)
         stdout = _run_fetch(args)
@@ -217,16 +161,13 @@ class TestCmdFetchIncremental:
         assert _read_ids(args.ids_file) == ["RHAIRFE-1"]
         assert _read_ids(args.changed_file) == ["RHAIRFE-1"]
 
-    def test_new_detected(self, work_dirs, mock_jira, monkeypatch, tmp_path):
+    def test_new_detected(self, work_dirs, jira, monkeypatch, tmp_path):
         """Issue not in previous snapshot → new."""
-        url, server = mock_jira
+        jira.create("RHAIRFE-1", "Issue one", "Existing.")
+        jira.create("RHAIRFE-2", "Issue two", "Brand new.")
         existing_hash = compute_content_hash(_text_to_adf("Existing."))
         _seed_snapshot(work_dirs, {"RHAIRFE-1": existing_hash})
-        server.issues = {
-            "RHAIRFE-1": "Existing.",
-            "RHAIRFE-2": "Brand new.",
-        }
-        _jira_env(monkeypatch, url)
+        _jira_env(monkeypatch, jira.url)
 
         args = _fetch_args(tmp_path)
         stdout = _run_fetch(args)
@@ -235,17 +176,13 @@ class TestCmdFetchIncremental:
         assert "NEW=1" in stdout
         assert _read_ids(args.ids_file) == ["RHAIRFE-2"]
 
-    def test_limit_caps_output(self, work_dirs, mock_jira, monkeypatch,
-                               tmp_path):
+    def test_limit_caps_output(self, work_dirs, jira, monkeypatch, tmp_path):
         """--limit caps the number of output IDs."""
-        url, server = mock_jira
+        jira.create("RHAIRFE-1", "One", "One.")
+        jira.create("RHAIRFE-2", "Two", "Two.")
+        jira.create("RHAIRFE-3", "Three", "Three.")
         _seed_snapshot(work_dirs, {})
-        server.issues = {
-            "RHAIRFE-1": "One.",
-            "RHAIRFE-2": "Two.",
-            "RHAIRFE-3": "Three.",
-        }
-        _jira_env(monkeypatch, url)
+        _jira_env(monkeypatch, jira.url)
 
         args = _fetch_args(tmp_path, limit=2)
         stdout = _run_fetch(args)
@@ -277,14 +214,13 @@ class TestCmdFetchWithDataDir:
         os.symlink("20260401-120000", os.path.join(data_dir, "latest"))
         return data_dir
 
-    def test_falls_back_to_data_dir(self, work_dirs, mock_jira, monkeypatch,
+    def test_falls_back_to_data_dir(self, work_dirs, jira, monkeypatch,
                                     tmp_path):
         """No local snapshot → uses data-dir snapshot for diffing."""
-        url, server = mock_jira
+        jira.create("RHAIRFE-1", "Issue one", "Changed content.")
         data_dir = self._make_data_dir(tmp_path,
                                        {"RHAIRFE-1": "old-hash"})
-        server.issues = {"RHAIRFE-1": "Changed content."}
-        _jira_env(monkeypatch, url)
+        _jira_env(monkeypatch, jira.url)
 
         args = _fetch_args(tmp_path, data_dir=data_dir)
         stdout = _run_fetch(args)
@@ -303,15 +239,12 @@ class TestMultiRunPipeline:
     unless a user changes the description in Jira.
     """
 
-    def test_steady_state_skips_unchanged(self, work_dirs, mock_jira,
+    def test_steady_state_skips_unchanged(self, work_dirs, jira,
                                           monkeypatch, tmp_path):
         """Run 1 processes everything. Run 2 sees nothing to do."""
-        url, server = mock_jira
-        server.issues = {
-            "RHAIRFE-1": "Description one.",
-            "RHAIRFE-2": "Description two.",
-        }
-        _jira_env(monkeypatch, url)
+        jira.create("RHAIRFE-1", "Issue one", "Description one.")
+        jira.create("RHAIRFE-2", "Issue two", "Description two.")
+        _jira_env(monkeypatch, jira.url)
 
         # Run 1: first fetch — all new
         stdout1 = _run_fetch(_fetch_args(tmp_path))
@@ -322,16 +255,13 @@ class TestMultiRunPipeline:
         stdout2 = _run_fetch(_fetch_args(tmp_path))
         assert "TOTAL=0" in stdout2
 
-    def test_user_edits_after_submit(self, work_dirs, mock_jira,
+    def test_user_edits_after_submit(self, work_dirs, jira,
                                      monkeypatch, tmp_path):
         """Run 1: fetch + submit. Run 2: user edits → re-process.
         Run 3: nothing changed → skip."""
-        url, server = mock_jira
-        server.issues = {
-            "RHAIRFE-1": "Original description.",
-            "RHAIRFE-2": "Another description.",
-        }
-        _jira_env(monkeypatch, url)
+        jira.create("RHAIRFE-1", "Issue one", "Original description.")
+        jira.create("RHAIRFE-2", "Issue two", "Another description.")
+        _jira_env(monkeypatch, jira.url)
 
         # Run 1: fetch all
         _run_fetch(_fetch_args(tmp_path))
@@ -341,10 +271,14 @@ class TestMultiRunPipeline:
             _text_to_adf("Auto-revised description."))
         update_snapshot_hashes(
             {"RHAIRFE-1": revised_hash}, work_dirs.snapshot_dir)
-        server.issues["RHAIRFE-1"] = "Auto-revised description."
+        # Simulate Jira now has the revised description
+        jira.request( "PUT", "/rest/api/3/issue/RHAIRFE-1",
+                      {"fields": {"description": "Auto-revised description."}})
 
         # Between runs: user edits RHAIRFE-1 in Jira
-        server.issues["RHAIRFE-1"] = "User rewrote this after our fix."
+        jira.request( "PUT", "/rest/api/3/issue/RHAIRFE-1",
+                      {"fields": {"description":
+                                  "User rewrote this after our fix."}})
 
         # Run 2: detects user's edit, skips RHAIRFE-2
         args2 = _fetch_args(tmp_path)
@@ -358,13 +292,12 @@ class TestMultiRunPipeline:
         stdout3 = _run_fetch(_fetch_args(tmp_path))
         assert "TOTAL=0" in stdout3
 
-    def test_submit_without_user_edit(self, work_dirs, mock_jira,
+    def test_submit_without_user_edit(self, work_dirs, jira,
                                       monkeypatch, tmp_path):
         """Run 1: fetch + submit. Run 2: no user edits → skip our own
         changes."""
-        url, server = mock_jira
-        server.issues = {"RHAIRFE-1": "Original."}
-        _jira_env(monkeypatch, url)
+        jira.create("RHAIRFE-1", "Issue one", "Original.")
+        _jira_env(monkeypatch, jira.url)
 
         # Run 1: fetch
         _run_fetch(_fetch_args(tmp_path))
@@ -374,36 +307,39 @@ class TestMultiRunPipeline:
             _text_to_adf("We revised this."))
         update_snapshot_hashes(
             {"RHAIRFE-1": revised_hash}, work_dirs.snapshot_dir)
-        server.issues["RHAIRFE-1"] = "We revised this."
+        # Simulate Jira now has our revision
+        jira.request( "PUT", "/rest/api/3/issue/RHAIRFE-1",
+                      {"fields": {"description": "We revised this."}})
 
         # Run 2: our own change is in the snapshot — skip
         stdout2 = _run_fetch(_fetch_args(tmp_path))
         assert "TOTAL=0" in stdout2
 
-    def test_new_issue_created_by_submit(self, work_dirs, mock_jira,
+    def test_new_issue_created_by_submit(self, work_dirs, jira,
                                          monkeypatch, tmp_path):
         """Run 1: fetch + create new issue. Run 2: new issue not
         re-flagged. Run 3: user edits the new issue → detected."""
-        url, server = mock_jira
-        server.issues = {"RHAIRFE-1": "Existing."}
-        _jira_env(monkeypatch, url)
+        jira.create("RHAIRFE-1", "Existing", "Existing.")
+        _jira_env(monkeypatch, jira.url)
 
         # Run 1: fetch
         _run_fetch(_fetch_args(tmp_path))
 
         # Run 1: submit creates RHAIRFE-2, updates snapshot
+        jira.create("RHAIRFE-2", "We created this", "We created this.")
         new_hash = compute_content_hash(
             _text_to_adf("We created this."))
         update_snapshot_hashes(
             {"RHAIRFE-2": new_hash}, work_dirs.snapshot_dir)
-        server.issues["RHAIRFE-2"] = "We created this."
 
         # Run 2: our new issue is already in the snapshot — skip
         stdout2 = _run_fetch(_fetch_args(tmp_path))
         assert "TOTAL=0" in stdout2
 
         # Between runs: user edits the new issue
-        server.issues["RHAIRFE-2"] = "User improved our new issue."
+        jira.request( "PUT", "/rest/api/3/issue/RHAIRFE-2",
+                      {"fields": {"description":
+                                  "User improved our new issue."}})
 
         # Run 3: detects the edit
         args3 = _fetch_args(tmp_path)
@@ -412,36 +348,38 @@ class TestMultiRunPipeline:
         assert "CHANGED=1" in stdout3
         assert _read_ids(args3.ids_file) == ["RHAIRFE-2"]
 
-    def test_issue_leaves_scope(self, work_dirs, mock_jira,
+    def test_issue_leaves_scope(self, work_dirs, jira,
                                 monkeypatch, tmp_path):
         """Issue closed between runs → silently dropped, not flagged."""
-        url, server = mock_jira
-        server.issues = {
-            "RHAIRFE-1": "Open issue.",
-            "RHAIRFE-2": "Another open issue.",
-        }
-        _jira_env(monkeypatch, url)
+        jira.create("RHAIRFE-1", "Open issue", "Open issue.")
+        jira.create("RHAIRFE-2", "Another", "Another open issue.")
+        _jira_env(monkeypatch, jira.url)
 
         # Run 1
         stdout1 = _run_fetch(_fetch_args(tmp_path))
         assert "TOTAL=2" in stdout1
 
-        # Between runs: RHAIRFE-2 gets closed (no longer in JQL results)
-        del server.issues["RHAIRFE-2"]
+        # Between runs: RHAIRFE-2 gets closed (transitions to Done)
+        transitions = jira.request(
+            "GET", "/rest/api/3/issue/RHAIRFE-2/transitions")
+        done_t = next(
+            (t for t in transitions["transitions"]
+             if t["to"]["statusCategory"]["key"] == "done"), None)
+        if done_t:
+            jira.request( "POST",
+                          "/rest/api/3/issue/RHAIRFE-2/transitions",
+                          {"transition": {"id": done_t["id"]}})
 
         # Run 2: RHAIRFE-2 gone, RHAIRFE-1 unchanged — nothing to do
         stdout2 = _run_fetch(_fetch_args(tmp_path))
         assert "TOTAL=0" in stdout2
 
-    def test_mixed_activity_across_runs(self, work_dirs, mock_jira,
+    def test_mixed_activity_across_runs(self, work_dirs, jira,
                                         monkeypatch, tmp_path):
         """Multiple runs with a mix of edits, new issues, and closures."""
-        url, server = mock_jira
-        server.issues = {
-            "RHAIRFE-1": "Issue one.",
-            "RHAIRFE-2": "Issue two.",
-        }
-        _jira_env(monkeypatch, url)
+        jira.create("RHAIRFE-1", "Issue one", "Issue one.")
+        jira.create("RHAIRFE-2", "Issue two", "Issue two.")
+        _jira_env(monkeypatch, jira.url)
 
         # Run 1: first fetch — all new
         stdout1 = _run_fetch(_fetch_args(tmp_path))
@@ -453,11 +391,14 @@ class TestMultiRunPipeline:
             _text_to_adf("Revised issue one."))
         update_snapshot_hashes(
             {"RHAIRFE-1": revised_hash}, work_dirs.snapshot_dir)
-        server.issues["RHAIRFE-1"] = "Revised issue one."
+        jira.request( "PUT", "/rest/api/3/issue/RHAIRFE-1",
+                      {"fields": {"description": "Revised issue one."}})
 
         # Between runs: user edits RHAIRFE-2, new RHAIRFE-3 filed
-        server.issues["RHAIRFE-2"] = "User rewrote issue two."
-        server.issues["RHAIRFE-3"] = "Brand new issue three."
+        jira.request( "PUT", "/rest/api/3/issue/RHAIRFE-2",
+                      {"fields": {"description":
+                                  "User rewrote issue two."}})
+        jira.create("RHAIRFE-3", "Issue three", "Brand new issue three.")
 
         # Run 2: RHAIRFE-1 skip (our change), RHAIRFE-2 changed,
         #         RHAIRFE-3 new
@@ -472,8 +413,111 @@ class TestMultiRunPipeline:
         assert "RHAIRFE-1" not in ids2
 
         # Between runs: RHAIRFE-2 closed, nothing else changes
-        del server.issues["RHAIRFE-2"]
+        transitions = jira.request(
+            "GET", "/rest/api/3/issue/RHAIRFE-2/transitions")
+        done_t = next(
+            (t for t in transitions["transitions"]
+             if t["to"]["statusCategory"]["key"] == "done"), None)
+        if done_t:
+            jira.request( "POST",
+                          "/rest/api/3/issue/RHAIRFE-2/transitions",
+                          {"transition": {"id": done_t["id"]}})
 
         # Run 3: RHAIRFE-2 gone, rest unchanged — nothing to do
         stdout3 = _run_fetch(_fetch_args(tmp_path))
         assert "TOTAL=0" in stdout3
+
+
+# ── End-to-End: Clone → Fetch with --data-dir ──────────────────────────────
+
+def _init_git_repo(path):
+    """Init a git repo for use as a data source."""
+    os.makedirs(path, exist_ok=True)
+    subprocess.run(["git", "init", path], check=True, capture_output=True)
+    subprocess.run(["git", "-C", path, "config", "user.email", "test@test"],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-C", path, "config", "user.name", "test"],
+                   check=True, capture_output=True)
+
+
+def _git_add_commit(repo, relpath, content, msg):
+    """Write a file, git add, git commit."""
+    full = os.path.join(repo, relpath)
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, "w") as f:
+        f.write(content)
+    subprocess.run(["git", "-C", repo, "add", relpath],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-C", repo, "commit", "-m", msg],
+                   check=True, capture_output=True)
+
+
+class TestCloneThenFetch:
+    """End-to-end: clone a data repo, then use it as --data-dir for fetch.
+
+    Verifies that clone_results_repo.py sparse checkout produces a layout
+    that snapshot_fetch.py can read, and that incremental diffing works
+    across the full pipeline.
+    """
+
+    def test_clone_provides_baseline_for_incremental_fetch(
+            self, jira, monkeypatch, tmp_path):
+        """Clone data repo → fetch with --data-dir → unchanged skipped."""
+        _jira_env(monkeypatch, jira.url)
+
+        # Build a source git repo with a previous snapshot
+        src = str(tmp_path / "source")
+        _init_git_repo(src)
+
+        existing_hash = compute_content_hash(
+            _text_to_adf("Already processed."))
+        snap = yaml.dump({
+            "query_timestamp": "2026-04-01T00:00:00Z",
+            "timestamp": "2026-04-01T00:00:01Z",
+            "issues": {
+                "RHAIRFE-1": existing_hash,
+                "RHAIRFE-2": "old-hash-will-differ",
+            },
+        })
+        _git_add_commit(src,
+                        "20260401-120000/auto-fix-runs/"
+                        "issue-snapshot-20260401-120000.yaml",
+                        snap, "add snapshot")
+        # Add the latest symlink
+        os.symlink("20260401-120000", os.path.join(src, "latest"))
+        subprocess.run(["git", "-C", src, "add", "latest"],
+                       check=True, capture_output=True)
+        subprocess.run(["git", "-C", src, "commit", "-m", "add latest"],
+                       check=True, capture_output=True)
+
+        # Clone it with clone_results_repo.py
+        clone_dest = str(tmp_path / "cloned")
+        r = subprocess.run(
+            [sys.executable, CLONE_SCRIPT, src, clone_dest],
+            capture_output=True, text=True,
+            env={**os.environ, "DATA_REPO_TOKEN": ""},
+        )
+        assert r.returncode == 0, r.stderr
+
+        # Jira has the same issues — RHAIRFE-1 unchanged, RHAIRFE-2 changed
+        jira.create("RHAIRFE-1", "Already processed", "Already processed.")
+        jira.create("RHAIRFE-2", "Edited", "User edited this since last run.")
+        jira.create("RHAIRFE-3", "Brand new", "Brand new issue.")
+
+        # Fetch with --data-dir pointing at clone
+        snap_dir = str(tmp_path / "artifacts" / "auto-fix-runs")
+        os.makedirs(snap_dir)
+        monkeypatch.setattr(snapshot_fetch, "SNAPSHOT_DIR", snap_dir)
+        args = _fetch_args(tmp_path, data_dir=clone_dest)
+        stdout = _run_fetch(args)
+
+        # RHAIRFE-1: unchanged → skipped
+        # RHAIRFE-2: hash differs → changed
+        # RHAIRFE-3: new
+        assert "TOTAL=2" in stdout
+        assert "CHANGED=1" in stdout
+        assert "NEW=1" in stdout
+        ids = _read_ids(args.ids_file)
+        assert "RHAIRFE-1" not in ids
+        assert "RHAIRFE-2" in ids
+        assert "RHAIRFE-3" in ids

--- a/tests/test_snapshot_fetch_integration.py
+++ b/tests/test_snapshot_fetch_integration.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""Integration tests for snapshot_fetch.py — cmd_fetch exercised
+end-to-end against a mock Jira HTTP server.
+
+Covers the full pipeline: first fetch, incremental fetch with change
+detection, snapshot update, and data-dir fallback.
+"""
+import io
+import json
+import os
+import sys
+import threading
+import urllib.parse
+from contextlib import redirect_stdout
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import snapshot_fetch
+from snapshot_fetch import cmd_fetch, compute_content_hash, update_snapshot_hashes
+
+
+def _write(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def _read_ids(path):
+    """Read ID file, return list of non-blank lines."""
+    with open(path) as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def _text_to_adf(text):
+    return {
+        "type": "doc", "version": 1,
+        "content": [{"type": "paragraph", "content": [
+            {"type": "text", "text": text}
+        ]}],
+    }
+
+
+# ── Mock Jira Server ─────────────────────────────────────────────────────────
+
+class JiraHandler(BaseHTTPRequestHandler):
+    """Mock Jira that serves search results.
+
+    server.issues: dict of {key: description} — all current issues
+    """
+
+    def do_GET(self):
+        if "/search/jql" not in self.path:
+            self._json(404, {"error": "not found"})
+            return
+
+        issues = []
+        for key, desc in self.server.issues.items():
+            adf = _text_to_adf(desc) if desc else None
+            issues.append({
+                "key": key,
+                "fields": {"description": adf, "labels": []},
+            })
+
+        self._json(200, {"issues": issues, "isLast": True})
+
+    def _json(self, status, data):
+        body = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def mock_jira():
+    server = HTTPServer(("127.0.0.1", 0), JiraHandler)
+    server.issues = {}
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    yield url, server
+    server.shutdown()
+
+
+@pytest.fixture
+def work_dirs(tmp_path, monkeypatch):
+    """Redirect snapshot_fetch module-level paths to temp directories."""
+    snap_dir = str(tmp_path / "artifacts" / "auto-fix-runs")
+    os.makedirs(snap_dir)
+    monkeypatch.setattr(snapshot_fetch, "SNAPSHOT_DIR", snap_dir)
+    return SimpleNamespace(
+        snapshot_dir=snap_dir,
+    )
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _fetch_args(tmp_path, jql="project = RHAIRFE", limit=None, data_dir=None):
+    return SimpleNamespace(
+        jql=jql, limit=limit, data_dir=data_dir,
+        ids_file=str(tmp_path / "ids.txt"),
+        changed_file=str(tmp_path / "changed.txt"),
+    )
+
+
+def _run_fetch(args):
+    """Run cmd_fetch, capturing stdout. Returns stdout string."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        cmd_fetch(args)
+    return buf.getvalue()
+
+
+def _seed_snapshot(work_dirs, issues, query_ts="2026-04-01T00:00:00Z"):
+    """Write a previous snapshot."""
+    snap = {
+        "query_timestamp": query_ts,
+        "timestamp": "2026-04-01T00:00:01Z",
+        "issues": issues,
+    }
+    path = os.path.join(work_dirs.snapshot_dir,
+                        "issue-snapshot-20260401-000000.yaml")
+    with open(path, "w") as f:
+        yaml.dump(snap, f, default_flow_style=False, sort_keys=False)
+
+
+def _jira_env(monkeypatch, url):
+    monkeypatch.setenv("JIRA_SERVER", url)
+    monkeypatch.setenv("JIRA_USER", "test@example.com")
+    monkeypatch.setenv("JIRA_TOKEN", "test-token")
+
+
+# ── cmd_fetch: First Run ─────────────────────────────────────────────────────
+
+class TestCmdFetchFirstRun:
+    def test_all_issues_are_new(self, work_dirs, mock_jira, monkeypatch,
+                                tmp_path):
+        """First run (no snapshot) → all issues NEW, correct stdout."""
+        url, server = mock_jira
+        server.issues = {
+            "RHAIRFE-1": "Description one.",
+            "RHAIRFE-2": "Description two.",
+        }
+        _jira_env(monkeypatch, url)
+        args = _fetch_args(tmp_path)
+
+        stdout = _run_fetch(args)
+
+        assert "TOTAL=2" in stdout
+        assert "CHANGED=0" in stdout
+        assert "NEW=2" in stdout
+        assert set(_read_ids(args.ids_file)) == {"RHAIRFE-1", "RHAIRFE-2"}
+        assert _read_ids(args.changed_file) == []
+
+    def test_snapshot_written(self, work_dirs, mock_jira, monkeypatch,
+                              tmp_path):
+        """Fetch writes snapshot directly to artifacts with hashes."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Content."}
+        _jira_env(monkeypatch, url)
+        args = _fetch_args(tmp_path)
+
+        _run_fetch(args)
+
+        snaps = [f for f in os.listdir(work_dirs.snapshot_dir)
+                 if f.startswith("issue-snapshot-")]
+        assert len(snaps) == 1
+        with open(os.path.join(work_dirs.snapshot_dir, snaps[0])) as f:
+            snap = yaml.safe_load(f)
+        assert "RHAIRFE-1" in snap["issues"]
+        assert "query_timestamp" in snap
+        assert len(snap["issues"]["RHAIRFE-1"]) == 64
+
+
+# ── cmd_fetch: Incremental Run ───────────────────────────────────────────────
+
+class TestCmdFetchIncremental:
+    def test_unchanged_excluded(self, work_dirs, mock_jira, monkeypatch,
+                                tmp_path):
+        """Issue with same hash → not in output IDs."""
+        url, server = mock_jira
+        same_hash = compute_content_hash(_text_to_adf("Same content."))
+        _seed_snapshot(work_dirs, {"RHAIRFE-1": same_hash})
+        server.issues = {"RHAIRFE-1": "Same content."}
+        _jira_env(monkeypatch, url)
+
+        stdout = _run_fetch(_fetch_args(tmp_path))
+
+        assert "TOTAL=0" in stdout
+
+    def test_changed_detected(self, work_dirs, mock_jira, monkeypatch,
+                              tmp_path):
+        """Issue with different hash → in changed file."""
+        url, server = mock_jira
+        _seed_snapshot(work_dirs, {"RHAIRFE-1": "old-hash"})
+        server.issues = {"RHAIRFE-1": "New content."}
+        _jira_env(monkeypatch, url)
+
+        args = _fetch_args(tmp_path)
+        stdout = _run_fetch(args)
+
+        assert "TOTAL=1" in stdout
+        assert "CHANGED=1" in stdout
+        assert "NEW=0" in stdout
+        assert _read_ids(args.ids_file) == ["RHAIRFE-1"]
+        assert _read_ids(args.changed_file) == ["RHAIRFE-1"]
+
+    def test_new_detected(self, work_dirs, mock_jira, monkeypatch, tmp_path):
+        """Issue not in previous snapshot → new."""
+        url, server = mock_jira
+        existing_hash = compute_content_hash(_text_to_adf("Existing."))
+        _seed_snapshot(work_dirs, {"RHAIRFE-1": existing_hash})
+        server.issues = {
+            "RHAIRFE-1": "Existing.",
+            "RHAIRFE-2": "Brand new.",
+        }
+        _jira_env(monkeypatch, url)
+
+        args = _fetch_args(tmp_path)
+        stdout = _run_fetch(args)
+
+        assert "TOTAL=1" in stdout
+        assert "NEW=1" in stdout
+        assert _read_ids(args.ids_file) == ["RHAIRFE-2"]
+
+    def test_limit_caps_output(self, work_dirs, mock_jira, monkeypatch,
+                               tmp_path):
+        """--limit caps the number of output IDs."""
+        url, server = mock_jira
+        _seed_snapshot(work_dirs, {})
+        server.issues = {
+            "RHAIRFE-1": "One.",
+            "RHAIRFE-2": "Two.",
+            "RHAIRFE-3": "Three.",
+        }
+        _jira_env(monkeypatch, url)
+
+        args = _fetch_args(tmp_path, limit=2)
+        stdout = _run_fetch(args)
+
+        assert "TOTAL=2" in stdout
+        assert len(_read_ids(args.ids_file)) == 2
+
+
+# ── cmd_fetch with --data-dir ────────────────────────────────────────────────
+
+class TestCmdFetchWithDataDir:
+    def _make_data_dir(self, tmp_path, snapshot_issues):
+        """Create a data-dir structure with one run."""
+        data_dir = str(tmp_path / "data-repo")
+        run_dir = os.path.join(data_dir, "20260401-120000",
+                               "auto-fix-runs")
+        os.makedirs(run_dir)
+
+        snap = {
+            "query_timestamp": "2026-04-01T00:00:00Z",
+            "timestamp": "2026-04-01T00:00:01Z",
+            "issues": snapshot_issues,
+        }
+        snap_path = os.path.join(run_dir,
+                                 "issue-snapshot-20260401-120000.yaml")
+        with open(snap_path, "w") as f:
+            yaml.dump(snap, f)
+
+        os.symlink("20260401-120000", os.path.join(data_dir, "latest"))
+        return data_dir
+
+    def test_falls_back_to_data_dir(self, work_dirs, mock_jira, monkeypatch,
+                                    tmp_path):
+        """No local snapshot → uses data-dir snapshot for diffing."""
+        url, server = mock_jira
+        data_dir = self._make_data_dir(tmp_path,
+                                       {"RHAIRFE-1": "old-hash"})
+        server.issues = {"RHAIRFE-1": "Changed content."}
+        _jira_env(monkeypatch, url)
+
+        args = _fetch_args(tmp_path, data_dir=data_dir)
+        stdout = _run_fetch(args)
+
+        assert "CHANGED=1" in stdout
+        assert _read_ids(args.ids_file) == ["RHAIRFE-1"]
+
+
+# ── Multi-Run Pipeline ──────────────────────────────────────────────────────
+
+class TestMultiRunPipeline:
+    """Simulate realistic multi-run CI cycles.
+
+    Each test exercises the full flow: fetch → (simulate submit) → fetch,
+    modeling the snapshot as a cache that skips already-processed issues
+    unless a user changes the description in Jira.
+    """
+
+    def test_steady_state_skips_unchanged(self, work_dirs, mock_jira,
+                                          monkeypatch, tmp_path):
+        """Run 1 processes everything. Run 2 sees nothing to do."""
+        url, server = mock_jira
+        server.issues = {
+            "RHAIRFE-1": "Description one.",
+            "RHAIRFE-2": "Description two.",
+        }
+        _jira_env(monkeypatch, url)
+
+        # Run 1: first fetch — all new
+        stdout1 = _run_fetch(_fetch_args(tmp_path))
+        assert "TOTAL=2" in stdout1
+        assert "NEW=2" in stdout1
+
+        # Run 2: nothing changed — nothing to process
+        stdout2 = _run_fetch(_fetch_args(tmp_path))
+        assert "TOTAL=0" in stdout2
+
+    def test_user_edits_after_submit(self, work_dirs, mock_jira,
+                                     monkeypatch, tmp_path):
+        """Run 1: fetch + submit. Run 2: user edits → re-process.
+        Run 3: nothing changed → skip."""
+        url, server = mock_jira
+        server.issues = {
+            "RHAIRFE-1": "Original description.",
+            "RHAIRFE-2": "Another description.",
+        }
+        _jira_env(monkeypatch, url)
+
+        # Run 1: fetch all
+        _run_fetch(_fetch_args(tmp_path))
+
+        # Run 1: submit revises RHAIRFE-1, updates snapshot
+        revised_hash = compute_content_hash(
+            _text_to_adf("Auto-revised description."))
+        update_snapshot_hashes(
+            {"RHAIRFE-1": revised_hash}, work_dirs.snapshot_dir)
+        server.issues["RHAIRFE-1"] = "Auto-revised description."
+
+        # Between runs: user edits RHAIRFE-1 in Jira
+        server.issues["RHAIRFE-1"] = "User rewrote this after our fix."
+
+        # Run 2: detects user's edit, skips RHAIRFE-2
+        args2 = _fetch_args(tmp_path)
+        stdout2 = _run_fetch(args2)
+        assert "TOTAL=1" in stdout2
+        assert "CHANGED=1" in stdout2
+        assert _read_ids(args2.ids_file) == ["RHAIRFE-1"]
+        assert _read_ids(args2.changed_file) == ["RHAIRFE-1"]
+
+        # Run 3: nothing changed — nothing to process
+        stdout3 = _run_fetch(_fetch_args(tmp_path))
+        assert "TOTAL=0" in stdout3
+
+    def test_submit_without_user_edit(self, work_dirs, mock_jira,
+                                      monkeypatch, tmp_path):
+        """Run 1: fetch + submit. Run 2: no user edits → skip our own
+        changes."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Original."}
+        _jira_env(monkeypatch, url)
+
+        # Run 1: fetch
+        _run_fetch(_fetch_args(tmp_path))
+
+        # Run 1: submit revises RHAIRFE-1, updates snapshot
+        revised_hash = compute_content_hash(
+            _text_to_adf("We revised this."))
+        update_snapshot_hashes(
+            {"RHAIRFE-1": revised_hash}, work_dirs.snapshot_dir)
+        server.issues["RHAIRFE-1"] = "We revised this."
+
+        # Run 2: our own change is in the snapshot — skip
+        stdout2 = _run_fetch(_fetch_args(tmp_path))
+        assert "TOTAL=0" in stdout2
+
+    def test_new_issue_created_by_submit(self, work_dirs, mock_jira,
+                                         monkeypatch, tmp_path):
+        """Run 1: fetch + create new issue. Run 2: new issue not
+        re-flagged. Run 3: user edits the new issue → detected."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Existing."}
+        _jira_env(monkeypatch, url)
+
+        # Run 1: fetch
+        _run_fetch(_fetch_args(tmp_path))
+
+        # Run 1: submit creates RHAIRFE-2, updates snapshot
+        new_hash = compute_content_hash(
+            _text_to_adf("We created this."))
+        update_snapshot_hashes(
+            {"RHAIRFE-2": new_hash}, work_dirs.snapshot_dir)
+        server.issues["RHAIRFE-2"] = "We created this."
+
+        # Run 2: our new issue is already in the snapshot — skip
+        stdout2 = _run_fetch(_fetch_args(tmp_path))
+        assert "TOTAL=0" in stdout2
+
+        # Between runs: user edits the new issue
+        server.issues["RHAIRFE-2"] = "User improved our new issue."
+
+        # Run 3: detects the edit
+        args3 = _fetch_args(tmp_path)
+        stdout3 = _run_fetch(args3)
+        assert "TOTAL=1" in stdout3
+        assert "CHANGED=1" in stdout3
+        assert _read_ids(args3.ids_file) == ["RHAIRFE-2"]
+
+    def test_issue_leaves_scope(self, work_dirs, mock_jira,
+                                monkeypatch, tmp_path):
+        """Issue closed between runs → silently dropped, not flagged."""
+        url, server = mock_jira
+        server.issues = {
+            "RHAIRFE-1": "Open issue.",
+            "RHAIRFE-2": "Another open issue.",
+        }
+        _jira_env(monkeypatch, url)
+
+        # Run 1
+        stdout1 = _run_fetch(_fetch_args(tmp_path))
+        assert "TOTAL=2" in stdout1
+
+        # Between runs: RHAIRFE-2 gets closed (no longer in JQL results)
+        del server.issues["RHAIRFE-2"]
+
+        # Run 2: RHAIRFE-2 gone, RHAIRFE-1 unchanged — nothing to do
+        stdout2 = _run_fetch(_fetch_args(tmp_path))
+        assert "TOTAL=0" in stdout2
+
+    def test_mixed_activity_across_runs(self, work_dirs, mock_jira,
+                                        monkeypatch, tmp_path):
+        """Multiple runs with a mix of edits, new issues, and closures."""
+        url, server = mock_jira
+        server.issues = {
+            "RHAIRFE-1": "Issue one.",
+            "RHAIRFE-2": "Issue two.",
+        }
+        _jira_env(monkeypatch, url)
+
+        # Run 1: first fetch — all new
+        stdout1 = _run_fetch(_fetch_args(tmp_path))
+        assert "TOTAL=2" in stdout1
+        assert "NEW=2" in stdout1
+
+        # Run 1: submit revises RHAIRFE-1
+        revised_hash = compute_content_hash(
+            _text_to_adf("Revised issue one."))
+        update_snapshot_hashes(
+            {"RHAIRFE-1": revised_hash}, work_dirs.snapshot_dir)
+        server.issues["RHAIRFE-1"] = "Revised issue one."
+
+        # Between runs: user edits RHAIRFE-2, new RHAIRFE-3 filed
+        server.issues["RHAIRFE-2"] = "User rewrote issue two."
+        server.issues["RHAIRFE-3"] = "Brand new issue three."
+
+        # Run 2: RHAIRFE-1 skip (our change), RHAIRFE-2 changed,
+        #         RHAIRFE-3 new
+        args2 = _fetch_args(tmp_path)
+        stdout2 = _run_fetch(args2)
+        assert "TOTAL=2" in stdout2
+        assert "CHANGED=1" in stdout2
+        assert "NEW=1" in stdout2
+        ids2 = _read_ids(args2.ids_file)
+        assert "RHAIRFE-2" in ids2
+        assert "RHAIRFE-3" in ids2
+        assert "RHAIRFE-1" not in ids2
+
+        # Between runs: RHAIRFE-2 closed, nothing else changes
+        del server.issues["RHAIRFE-2"]
+
+        # Run 3: RHAIRFE-2 gone, rest unchanged — nothing to do
+        stdout3 = _run_fetch(_fetch_args(tmp_path))
+        assert "TOTAL=0" in stdout3

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -70,6 +70,27 @@ scores:
 Looks good.
 """
 
+REJECT_REVIEW_FM = """\
+---
+rfe_id: {rfe_id}
+score: 3
+pass: false
+recommendation: reject
+feasibility: feasible
+auto_revised: false
+needs_attention: false
+scores:
+  what: 0
+  why: 1
+  open_to_how: 1
+  not_a_task: 1
+  right_sized: 0
+---
+
+## Assessor Feedback
+Does not meet rubric.
+"""
+
 
 @pytest.fixture
 def art_dir(tmp_path):
@@ -189,3 +210,85 @@ class TestAutoRevisedLabel:
         stdout, _, rc = _run_submit(art_dir)
         assert rc == 0
         assert "rfe-creator-auto-revised" not in stdout
+
+
+class TestRemoveLabels:
+    """Tests for stale label removal on rejected RFEs."""
+
+    def _task_with_labels(self, rfe_id, labels):
+        """Task frontmatter with original_labels set."""
+        labels_yaml = "\n".join(f"- {l}" for l in labels) if labels else "[]"
+        return (f"---\nrfe_id: {rfe_id}\ntitle: Test RFE\n"
+                f"priority: Major\nstatus: Ready\n"
+                f"original_labels:\n{labels_yaml}\n---\n\n"
+                f"## Problem\n\nContent here.\n")
+
+    def test_rejected_with_rubric_pass_removes_label(self, art_dir):
+        """Rejected RFE that had rubric-pass → Remove labels action."""
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               self._task_with_labels("RHAIRFE-1234",
+                                      ["rfe-creator-autofix-rubric-pass"]))
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
+
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert "Remove labels" in stdout
+        assert "rfe-creator-autofix-rubric-pass" in stdout
+        assert "Would remove labels" in stdout
+
+    def test_rejected_without_rubric_pass_skips(self, art_dir):
+        """Rejected RFE without rubric-pass → plain SKIP."""
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               TASK_FM.format(rfe_id="RHAIRFE-1234"))
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
+
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert "SKIP" in stdout
+        assert "rejected" in stdout
+        assert "Remove labels" not in stdout
+
+    def test_rejected_new_rfe_skips(self, art_dir):
+        """Rejected new RFE (RFE-NNN) → SKIP, no label removal."""
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
+               REJECT_REVIEW_FM.format(rfe_id="RFE-001"))
+
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert "SKIP" in stdout
+        assert "Remove labels" not in stdout
+
+    def test_autorevise_reject_removes_rubric_pass(self, art_dir):
+        """autorevise_reject with rubric-pass → Remove labels."""
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               self._task_with_labels("RHAIRFE-1234",
+                                      ["rfe-creator-autofix-rubric-pass"]))
+        review = REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234").replace(
+            "recommendation: reject", "recommendation: autorevise_reject")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md", review)
+
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert "Remove labels" in stdout
+        assert "Would remove labels" in stdout
+
+
+class TestSnapshotUpdate:
+    """Tests for snapshot update after submission."""
+
+    def test_dry_run_does_not_update_snapshot(self, art_dir):
+        """Dry-run does not update snapshot."""
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
+               REVIEW_FM.format(rfe_id="RFE-001", auto_revised="false"))
+
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        # Dry run should NOT create any snapshot files
+        snap_dir = os.path.join(art_dir, "auto-fix-runs")
+        assert not os.path.exists(snap_dir)

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""Integration tests for submit.py using a mock Jira HTTP server.
+
+Unlike test_submit.py (which only tests --dry-run plan building), these tests
+run the full execution path against a local HTTP server that records requests
+and returns plausible Jira API responses.
+"""
+import json
+import os
+import subprocess
+import sys
+import threading
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+import pytest
+import yaml
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "submit.py")
+
+# Counter for generated Jira keys
+_next_key = [2000]
+
+
+def _write(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def _read_frontmatter(path):
+    """Read YAML frontmatter from a file."""
+    with open(path) as f:
+        content = f.read()
+    if not content.startswith("---"):
+        return {}
+    end = content.index("---", 3)
+    return yaml.safe_load(content[3:end])
+
+
+def _text_to_adf(text):
+    """Build a minimal ADF doc from plain text."""
+    return {
+        "type": "doc", "version": 1,
+        "content": [{"type": "paragraph", "content": [
+            {"type": "text", "text": text}
+        ]}],
+    }
+
+
+class JiraHandler(BaseHTTPRequestHandler):
+    """Mock Jira REST API handler that records requests."""
+
+    def do_GET(self):
+        self._record("GET")
+
+        # GET /issue/KEY?fields=description — conflict check
+        if "/rest/api/3/issue/" in self.path and "fields=" in self.path:
+            key = self.path.split("/rest/api/3/issue/")[1].split("?")[0]
+            desc_md = self.server.original_descriptions.get(key)
+            adf = _text_to_adf(desc_md) if desc_md is not None else None
+            self._json(200, {"key": key, "fields": {"description": adf}})
+            return
+
+        self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        body = self._record("POST")
+
+        # POST /issue — create
+        if self.path == "/rest/api/3/issue":
+            key = f"RHAIRFE-{_next_key[0]}"
+            _next_key[0] += 1
+            self._json(201, {"key": key, "id": "99999"})
+            return
+
+        # POST /issue/KEY/comment
+        if "/comment" in self.path:
+            self._json(201, {"id": "10001"})
+            return
+
+        self._json(404, {"error": "not found"})
+
+    def do_PUT(self):
+        self._record("PUT")
+
+        if "/rest/api/3/issue/" in self.path:
+            self.send_response(204)
+            self.end_headers()
+            return
+
+        self._json(404, {"error": "not found"})
+
+    def _record(self, method):
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length)) if length else None
+        self.server.requests.append({
+            "method": method, "path": self.path, "body": body,
+        })
+        return body
+
+    def _json(self, status, data):
+        body = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.fixture
+def mock_jira():
+    """Start a mock Jira server, yield (url, server), then shut down."""
+    server = HTTPServer(("127.0.0.1", 0), JiraHandler)
+    server.requests = []
+    server.original_descriptions = {}
+    url = f"http://127.0.0.1:{server.server_address[1]}"
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    yield url, server
+    server.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def reset_key_counter():
+    """Reset the mock key counter between tests."""
+    _next_key[0] = 2000
+    yield
+
+
+@pytest.fixture
+def art_dir(tmp_path):
+    """Create a minimal artifacts directory."""
+    for d in ["rfe-tasks", "rfe-reviews", "rfe-originals"]:
+        os.makedirs(tmp_path / d)
+    orig = os.getcwd()
+    os.chdir(tmp_path)
+    yield str(tmp_path)
+    os.chdir(orig)
+
+
+def _run_submit(artifacts_dir, server_url):
+    """Run submit.py (non-dry-run) against the mock server."""
+    env = {
+        **os.environ,
+        "JIRA_SERVER": server_url,
+        "JIRA_USER": "test@example.com",
+        "JIRA_TOKEN": "test-token",
+    }
+    return subprocess.run(
+        ["python3", SCRIPT, "--artifacts-dir", artifacts_dir],
+        capture_output=True, text=True, env=env,
+    )
+
+
+def _filter_requests(server, method=None, path_contains=None):
+    """Filter recorded requests."""
+    reqs = server.requests
+    if method:
+        reqs = [r for r in reqs if r["method"] == method]
+    if path_contains:
+        reqs = [r for r in reqs if path_contains in r["path"]]
+    return reqs
+
+
+# ── Templates ────────────────────────────────────────────────────────────────
+
+TASK_FM = """\
+---
+rfe_id: {rfe_id}
+title: Test RFE
+priority: Major
+status: Ready
+---
+
+## Problem Statement
+
+Users need better logging for compliance audits.
+
+## Acceptance Criteria
+
+- Audit logs capture all inference requests
+"""
+
+REVIEW_FM = """\
+---
+rfe_id: {rfe_id}
+score: 9
+pass: true
+recommendation: submit
+feasibility: feasible
+auto_revised: {auto_revised}
+needs_attention: {needs_attention}
+{extra_fields}scores:
+  what: 2
+  why: 2
+  open_to_how: 2
+  not_a_task: 2
+  right_sized: 1
+---
+
+## Assessor Feedback
+Looks good.
+"""
+
+REJECT_REVIEW_FM = """\
+---
+rfe_id: {rfe_id}
+score: 3
+pass: false
+recommendation: reject
+feasibility: feasible
+auto_revised: false
+needs_attention: false
+scores:
+  what: 0
+  why: 1
+  open_to_how: 1
+  not_a_task: 1
+  right_sized: 0
+---
+
+## Assessor Feedback
+Does not meet rubric.
+"""
+
+
+def _review(rfe_id, auto_revised="false", needs_attention="false",
+            extra_fields=""):
+    return REVIEW_FM.format(rfe_id=rfe_id, auto_revised=auto_revised,
+                            needs_attention=needs_attention,
+                            extra_fields=extra_fields)
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+class TestCreateNewRFE:
+    def test_posts_correct_fields(self, art_dir, mock_jira):
+        """New RFE → POST /issue with correct project, type, priority."""
+        url, server = mock_jira
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
+               _review("RFE-001"))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+
+        creates = [r for r in _filter_requests(server, "POST", "/issue")
+                   if "/comment" not in r["path"]]
+        assert len(creates) == 1
+        fields = creates[0]["body"]["fields"]
+        assert fields["project"]["key"] == "RHAIRFE"
+        assert fields["issuetype"]["name"] == "Feature Request"
+        assert fields["summary"] == "Test RFE"
+        assert fields["priority"]["name"] == "Major"
+
+    def test_includes_labels(self, art_dir, mock_jira):
+        """New RFE → labels include auto-created and rubric-pass."""
+        url, server = mock_jira
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
+               _review("RFE-001"))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+
+        creates = [r for r in _filter_requests(server, "POST", "/issue")
+                   if "/comment" not in r["path"]]
+        labels = creates[0]["body"]["fields"]["labels"]
+        assert "rfe-creator-auto-created" in labels
+        assert "rfe-creator-autofix-rubric-pass" in labels
+
+    def test_renames_files(self, art_dir, mock_jira):
+        """New RFE → RFE-001.md renamed to RHAIRFE-2000.md."""
+        url, server = mock_jira
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
+               _review("RFE-001"))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+
+        assert not os.path.exists(f"{art_dir}/rfe-tasks/RFE-001.md")
+        assert os.path.exists(f"{art_dir}/rfe-tasks/RHAIRFE-2000.md")
+        fm = _read_frontmatter(f"{art_dir}/rfe-tasks/RHAIRFE-2000.md")
+        assert fm["rfe_id"] == "RHAIRFE-2000"
+
+
+class TestUpdateExistingRFE:
+    def _setup_existing(self, art_dir, server, original, revised):
+        server.original_descriptions["RHAIRFE-1234"] = original
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", original)
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n---\n{revised}")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               _review("RHAIRFE-1234", auto_revised="true"))
+
+    def test_puts_description(self, art_dir, mock_jira):
+        """Existing RFE with changes → PUT with description."""
+        url, server = mock_jira
+        self._setup_existing(art_dir, server, "Original.", "Revised.")
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+        assert "Updated" in r.stdout
+
+        puts = _filter_requests(server, "PUT", "/issue/RHAIRFE-1234")
+        field_puts = [p for p in puts if p["body"] and "fields" in p["body"]]
+        assert len(field_puts) == 1
+        assert "description" in field_puts[0]["body"]["fields"]
+
+    def test_adds_labels_separately(self, art_dir, mock_jira):
+        """Update → labels added via separate PUT with update.labels."""
+        url, server = mock_jira
+        self._setup_existing(art_dir, server, "Original.", "Revised.")
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+
+        puts = _filter_requests(server, "PUT", "/issue/RHAIRFE-1234")
+        label_puts = [p for p in puts if p["body"]
+                      and "update" in p["body"]
+                      and "labels" in p["body"].get("update", {})]
+        assert len(label_puts) == 1
+        added = [op["add"] for op in label_puts[0]["body"]["update"]["labels"]
+                 if "add" in op]
+        assert "rfe-creator-auto-revised" in added
+        assert "rfe-creator-autofix-rubric-pass" in added
+
+    def test_sets_status_submitted(self, art_dir, mock_jira):
+        """Existing RFE after update → frontmatter status = Submitted."""
+        url, server = mock_jira
+        self._setup_existing(art_dir, server, "Original.", "Revised.")
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+
+        fm = _read_frontmatter(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md")
+        assert fm["status"] == "Submitted"
+
+
+class TestLabelOnly:
+    def test_no_description_put(self, art_dir, mock_jira):
+        """Unchanged content → label PUT only, no fields PUT."""
+        url, server = mock_jira
+        body = "Same content.\n"
+        server.original_descriptions["RHAIRFE-1234"] = body
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", body)
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n---\n{body}")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               _review("RHAIRFE-1234"))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+
+        puts = _filter_requests(server, "PUT", "/issue/RHAIRFE-1234")
+        field_puts = [p for p in puts if p["body"] and "fields" in p["body"]]
+        label_puts = [p for p in puts if p["body"] and "update" in p["body"]]
+        assert len(field_puts) == 0
+        assert len(label_puts) == 1
+
+
+class TestRemoveLabels:
+    def test_sends_remove_operation(self, art_dir, mock_jira):
+        """Rejected RFE with stale rubric-pass → PUT with remove op."""
+        url, server = mock_jira
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n"
+               f"original_labels:\n- rfe-creator-autofix-rubric-pass\n"
+               f"---\n\n## Problem\n\nContent.\n")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+        assert "Removed labels" in r.stdout
+
+        puts = _filter_requests(server, "PUT", "/issue/RHAIRFE-1234")
+        assert len(puts) == 1
+        label_ops = puts[0]["body"]["update"]["labels"]
+        removed = [op["remove"] for op in label_ops if "remove" in op]
+        assert "rfe-creator-autofix-rubric-pass" in removed
+
+    def test_no_api_call_on_plain_reject(self, art_dir, mock_jira):
+        """Rejected RFE without rubric-pass → no PUT at all."""
+        url, server = mock_jira
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               TASK_FM.format(rfe_id="RHAIRFE-1234"))
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+
+        non_get = [r for r in server.requests if r["method"] != "GET"]
+        assert len(non_get) == 0
+
+    def test_does_not_update_frontmatter_status(self, art_dir, mock_jira):
+        """Remove labels must NOT set status to Submitted."""
+        url, server = mock_jira
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n"
+               f"original_labels:\n- rfe-creator-autofix-rubric-pass\n"
+               f"---\n\n## Problem\n\nContent.\n")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+
+        fm = _read_frontmatter(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md")
+        assert fm["status"] == "Ready"  # NOT "Submitted"
+
+    def test_not_in_snapshot_update(self, art_dir, mock_jira):
+        """Remove labels must NOT update the snapshot."""
+        url, server = mock_jira
+        # Seed a snapshot
+        snap_dir = os.path.join(art_dir, "auto-fix-runs")
+        os.makedirs(snap_dir, exist_ok=True)
+        snap = {"query_timestamp": "2026-04-01T00:00:00Z",
+                "timestamp": "2026-04-01T00:00:01Z",
+                "issues": {"RHAIRFE-1234": "original-hash"}}
+        snap_path = os.path.join(snap_dir,
+                                 "issue-snapshot-20260401-000000.yaml")
+        with open(snap_path, "w") as f:
+            yaml.dump(snap, f)
+
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n"
+               f"original_labels:\n- rfe-creator-autofix-rubric-pass\n"
+               f"---\n\n## Problem\n\nContent.\n")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+
+        # Snapshot should be unchanged (no submitted hashes)
+        with open(snap_path) as f:
+            data = yaml.safe_load(f)
+        assert data["issues"]["RHAIRFE-1234"] == "original-hash"
+
+
+class TestConflictDetection:
+    def test_conflict_prevents_update(self, art_dir, mock_jira):
+        """Jira description differs from original → skip, no PUT."""
+        url, server = mock_jira
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", "Original.")
+        server.original_descriptions["RHAIRFE-1234"] = "Edited by someone."
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n---\nOur revision.")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               _review("RHAIRFE-1234", auto_revised="true"))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+        assert "Skipping" in r.stdout
+
+        puts = _filter_requests(server, "PUT")
+        assert len(puts) == 0
+
+
+class TestCommentPosting:
+    def test_removed_context_comment(self, art_dir, mock_jira):
+        """RFE with removed-context YAML → POST comment."""
+        url, server = mock_jira
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
+               _review("RFE-001"))
+        rc_yaml = {"blocks": [{
+            "type": "genuine",
+            "heading": "Implementation Notes",
+            "content": "Use gRPC for the service mesh.",
+        }]}
+        _write(f"{art_dir}/rfe-tasks/RFE-001-removed-context.yaml",
+               yaml.dump(rc_yaml))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+        assert "Posted removed-context comment" in r.stdout
+
+        comments = _filter_requests(server, "POST", "/comment")
+        assert len(comments) >= 1
+        assert "body" in comments[0]["body"]
+
+    def test_needs_attention_comment(self, art_dir, mock_jira):
+        """RFE with needs_attention → POST comment with reason."""
+        url, server = mock_jira
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
+               _review("RFE-001", needs_attention="true",
+                       extra_fields="needs_attention_reason: Unclear scope\n"))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+        assert "needs-attention comment" in r.stdout
+
+        comments = _filter_requests(server, "POST", "/comment")
+        assert len(comments) >= 1
+
+
+class TestSnapshotUpdate:
+    def _seed_snapshot(self, art_dir, issues):
+        """Write a snapshot so submit.py can update it."""
+        snap_dir = os.path.join(art_dir, "auto-fix-runs")
+        os.makedirs(snap_dir, exist_ok=True)
+        snap = {
+            "query_timestamp": "2026-04-01T00:00:00Z",
+            "timestamp": "2026-04-01T00:00:01Z",
+            "issues": issues,
+        }
+        path = os.path.join(snap_dir,
+                            "issue-snapshot-20260401-000000.yaml")
+        with open(path, "w") as f:
+            yaml.dump(snap, f, default_flow_style=False, sort_keys=False)
+        return path
+
+    def test_snapshot_updated_on_create(self, art_dir, mock_jira):
+        """Create → snapshot updated with new issue hash."""
+        url, server = mock_jira
+        snap_path = self._seed_snapshot(art_dir, {"RHAIRFE-1": "existing"})
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
+               _review("RFE-001"))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+
+        with open(snap_path) as f:
+            data = yaml.safe_load(f)
+        assert "RHAIRFE-2000" in data["issues"]
+        assert isinstance(data["issues"]["RHAIRFE-2000"], str)
+        assert len(data["issues"]["RHAIRFE-2000"]) == 64  # SHA256 hex
+        # Original issue still present
+        assert data["issues"]["RHAIRFE-1"] == "existing"
+
+    def test_snapshot_updated_on_update(self, art_dir, mock_jira):
+        """Update → snapshot updated with revised hash."""
+        url, server = mock_jira
+        snap_path = self._seed_snapshot(art_dir,
+                                        {"RHAIRFE-1234": "old-hash"})
+        server.original_descriptions["RHAIRFE-1234"] = "Original."
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", "Original.")
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n---\nRevised.")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               _review("RHAIRFE-1234"))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+
+        with open(snap_path) as f:
+            data = yaml.safe_load(f)
+        assert "RHAIRFE-1234" in data["issues"]
+        assert len(data["issues"]["RHAIRFE-1234"]) == 64
+        assert data["issues"]["RHAIRFE-1234"] != "old-hash"
+
+    def test_no_update_when_all_skipped(self, art_dir, mock_jira):
+        """All RFEs rejected/skipped → snapshot unchanged."""
+        url, server = mock_jira
+        snap_path = self._seed_snapshot(art_dir,
+                                        {"RHAIRFE-1234": "existing"})
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               TASK_FM.format(rfe_id="RHAIRFE-1234"))
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
+
+        r = _run_submit(art_dir, url)
+        assert r.returncode == 0, r.stderr
+
+        with open(snap_path) as f:
+            data = yaml.safe_load(f)
+        # Snapshot untouched — still just the original issue
+        assert data["issues"] == {"RHAIRFE-1234": "existing"}

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -1,24 +1,18 @@
 #!/usr/bin/env python3
-"""Integration tests for submit.py using a mock Jira HTTP server.
+"""Integration tests for submit.py using a jira-emulator server.
 
-Unlike test_submit.py (which only tests --dry-run plan building), these tests
-run the full execution path against a local HTTP server that records requests
-and returns plausible Jira API responses.
+Runs the full execution path against a real HTTP server that tracks
+issue state, changelogs, labels, and comments.
 """
 import json
 import os
 import subprocess
 import sys
-import threading
-from http.server import HTTPServer, BaseHTTPRequestHandler
 
 import pytest
 import yaml
 
 SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "submit.py")
-
-# Counter for generated Jira keys
-_next_key = [2000]
 
 
 def _write(path, content):
@@ -37,99 +31,7 @@ def _read_frontmatter(path):
     return yaml.safe_load(content[3:end])
 
 
-def _text_to_adf(text):
-    """Build a minimal ADF doc from plain text."""
-    return {
-        "type": "doc", "version": 1,
-        "content": [{"type": "paragraph", "content": [
-            {"type": "text", "text": text}
-        ]}],
-    }
-
-
-class JiraHandler(BaseHTTPRequestHandler):
-    """Mock Jira REST API handler that records requests."""
-
-    def do_GET(self):
-        self._record("GET")
-
-        # GET /issue/KEY?fields=description — conflict check
-        if "/rest/api/3/issue/" in self.path and "fields=" in self.path:
-            key = self.path.split("/rest/api/3/issue/")[1].split("?")[0]
-            desc_md = self.server.original_descriptions.get(key)
-            adf = _text_to_adf(desc_md) if desc_md is not None else None
-            self._json(200, {"key": key, "fields": {"description": adf}})
-            return
-
-        self._json(404, {"error": "not found"})
-
-    def do_POST(self):
-        body = self._record("POST")
-
-        # POST /issue — create
-        if self.path == "/rest/api/3/issue":
-            key = f"RHAIRFE-{_next_key[0]}"
-            _next_key[0] += 1
-            self._json(201, {"key": key, "id": "99999"})
-            return
-
-        # POST /issue/KEY/comment
-        if "/comment" in self.path:
-            self._json(201, {"id": "10001"})
-            return
-
-        self._json(404, {"error": "not found"})
-
-    def do_PUT(self):
-        self._record("PUT")
-
-        if "/rest/api/3/issue/" in self.path:
-            self.send_response(204)
-            self.end_headers()
-            return
-
-        self._json(404, {"error": "not found"})
-
-    def _record(self, method):
-        length = int(self.headers.get("Content-Length", 0))
-        body = json.loads(self.rfile.read(length)) if length else None
-        self.server.requests.append({
-            "method": method, "path": self.path, "body": body,
-        })
-        return body
-
-    def _json(self, status, data):
-        body = json.dumps(data).encode()
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def log_message(self, format, *args):
-        pass
-
-
-@pytest.fixture
-def mock_jira():
-    """Start a mock Jira server, yield (url, server), then shut down."""
-    server = HTTPServer(("127.0.0.1", 0), JiraHandler)
-    server.requests = []
-    server.original_descriptions = {}
-    url = f"http://127.0.0.1:{server.server_address[1]}"
-    thread = threading.Thread(target=server.serve_forever)
-    thread.daemon = True
-    thread.start()
-    yield url, server
-    server.shutdown()
-
-
-@pytest.fixture(autouse=True)
-def reset_key_counter():
-    """Reset the mock key counter between tests."""
-    _next_key[0] = 2000
-    yield
-
+# ── Fixtures ────────────────────────────────────────────────────────────────
 
 @pytest.fixture
 def art_dir(tmp_path):
@@ -143,27 +45,17 @@ def art_dir(tmp_path):
 
 
 def _run_submit(artifacts_dir, server_url):
-    """Run submit.py (non-dry-run) against the mock server."""
+    """Run submit.py (non-dry-run) against the jira-emulator."""
     env = {
         **os.environ,
         "JIRA_SERVER": server_url,
-        "JIRA_USER": "test@example.com",
-        "JIRA_TOKEN": "test-token",
+        "JIRA_USER": "admin",
+        "JIRA_TOKEN": "admin",
     }
     return subprocess.run(
-        ["python3", SCRIPT, "--artifacts-dir", artifacts_dir],
+        [sys.executable, SCRIPT, "--artifacts-dir", artifacts_dir],
         capture_output=True, text=True, env=env,
     )
-
-
-def _filter_requests(server, method=None, path_contains=None):
-    """Filter recorded requests."""
-    reqs = server.requests
-    if method:
-        reqs = [r for r in reqs if r["method"] == method]
-    if path_contains:
-        reqs = [r for r in reqs if path_contains in r["path"]]
-    return reqs
 
 
 # ── Templates ────────────────────────────────────────────────────────────────
@@ -238,63 +130,62 @@ def _review(rfe_id, auto_revised="false", needs_attention="false",
 # ── Tests ────────────────────────────────────────────────────────────────────
 
 class TestCreateNewRFE:
-    def test_posts_correct_fields(self, art_dir, mock_jira):
-        """New RFE → POST /issue with correct project, type, priority."""
-        url, server = mock_jira
+    def test_posts_correct_fields(self, art_dir, jira):
+        """New RFE → issue created in Jira with correct fields."""
         _write(f"{art_dir}/rfe-tasks/RFE-001.md",
                TASK_FM.format(rfe_id="RFE-001"))
         _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
                _review("RFE-001"))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
-        creates = [r for r in _filter_requests(server, "POST", "/issue")
-                   if "/comment" not in r["path"]]
-        assert len(creates) == 1
-        fields = creates[0]["body"]["fields"]
-        assert fields["project"]["key"] == "RHAIRFE"
-        assert fields["issuetype"]["name"] == "Feature Request"
-        assert fields["summary"] == "Test RFE"
-        assert fields["priority"]["name"] == "Major"
+        # Find the created issue key from stdout
+        issues = jira.search("project = RHAIRFE")
+        assert len(issues) == 1
+        key = issues[0]["key"]
+        issue = jira.get(key)
+        assert issue["fields"]["summary"] == "Test RFE"
+        assert issue["fields"]["priority"]["name"] == "Major"
 
-    def test_includes_labels(self, art_dir, mock_jira):
+    def test_includes_labels(self, art_dir, jira):
         """New RFE → labels include auto-created and rubric-pass."""
-        url, server = mock_jira
         _write(f"{art_dir}/rfe-tasks/RFE-001.md",
                TASK_FM.format(rfe_id="RFE-001"))
         _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
                _review("RFE-001"))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
-        creates = [r for r in _filter_requests(server, "POST", "/issue")
-                   if "/comment" not in r["path"]]
-        labels = creates[0]["body"]["fields"]["labels"]
+        issues = jira.search("project = RHAIRFE")
+        issue = jira.get(issues[0]["key"])
+        labels = issue["fields"]["labels"]
         assert "rfe-creator-auto-created" in labels
         assert "rfe-creator-autofix-rubric-pass" in labels
 
-    def test_renames_files(self, art_dir, mock_jira):
-        """New RFE → RFE-001.md renamed to RHAIRFE-2000.md."""
-        url, server = mock_jira
+    def test_renames_files(self, art_dir, jira):
+        """New RFE → RFE-001.md renamed to RHAIRFE-N.md."""
         _write(f"{art_dir}/rfe-tasks/RFE-001.md",
                TASK_FM.format(rfe_id="RFE-001"))
         _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
                _review("RFE-001"))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
+        # RFE-001.md should be renamed to the Jira key
         assert not os.path.exists(f"{art_dir}/rfe-tasks/RFE-001.md")
-        assert os.path.exists(f"{art_dir}/rfe-tasks/RHAIRFE-2000.md")
-        fm = _read_frontmatter(f"{art_dir}/rfe-tasks/RHAIRFE-2000.md")
-        assert fm["rfe_id"] == "RHAIRFE-2000"
+        issues = jira.search("project = RHAIRFE")
+        key = issues[0]["key"]
+        assert os.path.exists(f"{art_dir}/rfe-tasks/{key}.md")
+        fm = _read_frontmatter(f"{art_dir}/rfe-tasks/{key}.md")
+        assert fm["rfe_id"] == key
 
 
 class TestUpdateExistingRFE:
-    def _setup_existing(self, art_dir, server, original, revised):
-        server.original_descriptions["RHAIRFE-1234"] = original
+    def _setup_existing(self, art_dir, jira, original, revised):
+        jira.create("RHAIRFE-1234", "Test RFE", original)
         _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", original)
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
                f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
@@ -302,44 +193,47 @@ class TestUpdateExistingRFE:
         _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
                _review("RHAIRFE-1234", auto_revised="true"))
 
-    def test_puts_description(self, art_dir, mock_jira):
-        """Existing RFE with changes → PUT with description."""
-        url, server = mock_jira
-        self._setup_existing(art_dir, server, "Original.", "Revised.")
+    def test_puts_description(self, art_dir, jira):
+        """Existing RFE with changes → description updated in Jira."""
+        self._setup_existing(art_dir, jira, "Original.", "Revised.")
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
         assert "Updated" in r.stdout
 
-        puts = _filter_requests(server, "PUT", "/issue/RHAIRFE-1234")
-        field_puts = [p for p in puts if p["body"] and "fields" in p["body"]]
-        assert len(field_puts) == 1
-        assert "description" in field_puts[0]["body"]["fields"]
+        # Verify description was updated
+        issue = jira.get("RHAIRFE-1234")
+        desc = issue["fields"]["description"]
+        # Description is stored as ADF by the emulator via v3
+        if isinstance(desc, dict):
+            # Extract text from ADF
+            texts = []
+            for node in desc.get("content", []):
+                for child in node.get("content", []):
+                    if child.get("type") == "text":
+                        texts.append(child["text"])
+            desc_text = " ".join(texts)
+        else:
+            desc_text = desc
+        assert "Revised" in desc_text or "Problem Statement" in desc_text
 
-    def test_adds_labels_separately(self, art_dir, mock_jira):
-        """Update → labels added via separate PUT with update.labels."""
-        url, server = mock_jira
-        self._setup_existing(art_dir, server, "Original.", "Revised.")
+    def test_adds_labels_separately(self, art_dir, jira):
+        """Update → labels added to the issue."""
+        self._setup_existing(art_dir, jira, "Original.", "Revised.")
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
-        puts = _filter_requests(server, "PUT", "/issue/RHAIRFE-1234")
-        label_puts = [p for p in puts if p["body"]
-                      and "update" in p["body"]
-                      and "labels" in p["body"].get("update", {})]
-        assert len(label_puts) == 1
-        added = [op["add"] for op in label_puts[0]["body"]["update"]["labels"]
-                 if "add" in op]
-        assert "rfe-creator-auto-revised" in added
-        assert "rfe-creator-autofix-rubric-pass" in added
+        issue = jira.get("RHAIRFE-1234")
+        labels = issue["fields"]["labels"]
+        assert "rfe-creator-auto-revised" in labels
+        assert "rfe-creator-autofix-rubric-pass" in labels
 
-    def test_sets_status_submitted(self, art_dir, mock_jira):
+    def test_sets_status_submitted(self, art_dir, jira):
         """Existing RFE after update → frontmatter status = Submitted."""
-        url, server = mock_jira
-        self._setup_existing(art_dir, server, "Original.", "Revised.")
+        self._setup_existing(art_dir, jira, "Original.", "Revised.")
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
         fm = _read_frontmatter(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md")
@@ -347,11 +241,10 @@ class TestUpdateExistingRFE:
 
 
 class TestLabelOnly:
-    def test_no_description_put(self, art_dir, mock_jira):
-        """Unchanged content → label PUT only, no fields PUT."""
-        url, server = mock_jira
+    def test_no_description_put(self, art_dir, jira):
+        """Unchanged content → label added, description not changed."""
         body = "Same content.\n"
-        server.original_descriptions["RHAIRFE-1234"] = body
+        jira.create("RHAIRFE-1234", "Test RFE", body)
         _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", body)
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
                f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
@@ -359,20 +252,27 @@ class TestLabelOnly:
         _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
                _review("RHAIRFE-1234"))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
-        puts = _filter_requests(server, "PUT", "/issue/RHAIRFE-1234")
-        field_puts = [p for p in puts if p["body"] and "fields" in p["body"]]
-        label_puts = [p for p in puts if p["body"] and "update" in p["body"]]
-        assert len(field_puts) == 0
-        assert len(label_puts) == 1
+        # Labels should be added
+        issue = jira.get("RHAIRFE-1234")
+        assert "rfe-creator-autofix-rubric-pass" in issue["fields"]["labels"]
+
+        # Check changelog — should have label change but no description change
+        desc_changes = []
+        for h in issue.get("changelog", {}).get("histories", []):
+            for item in h.get("items", []):
+                if item["field"] == "description":
+                    desc_changes.append(item)
+        assert len(desc_changes) == 0
 
 
 class TestRemoveLabels:
-    def test_sends_remove_operation(self, art_dir, mock_jira):
-        """Rejected RFE with stale rubric-pass → PUT with remove op."""
-        url, server = mock_jira
+    def test_sends_remove_operation(self, art_dir, jira):
+        """Rejected RFE with stale rubric-pass → label removed."""
+        jira.create("RHAIRFE-1234", "Test RFE", "Content.",
+                    labels=["rfe-creator-autofix-rubric-pass"])
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
                f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
                f"priority: Major\nstatus: Ready\n"
@@ -381,33 +281,35 @@ class TestRemoveLabels:
         _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
                REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
         assert "Removed labels" in r.stdout
 
-        puts = _filter_requests(server, "PUT", "/issue/RHAIRFE-1234")
-        assert len(puts) == 1
-        label_ops = puts[0]["body"]["update"]["labels"]
-        removed = [op["remove"] for op in label_ops if "remove" in op]
-        assert "rfe-creator-autofix-rubric-pass" in removed
+        # Verify label was removed
+        issue = jira.get("RHAIRFE-1234")
+        assert "rfe-creator-autofix-rubric-pass" not in \
+            issue["fields"]["labels"]
 
-    def test_no_api_call_on_plain_reject(self, art_dir, mock_jira):
-        """Rejected RFE without rubric-pass → no PUT at all."""
-        url, server = mock_jira
+    def test_no_api_call_on_plain_reject(self, art_dir, jira):
+        """Rejected RFE without rubric-pass → issue unchanged."""
+        jira.create("RHAIRFE-1234", "Test RFE", "Content.")
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
                TASK_FM.format(rfe_id="RHAIRFE-1234"))
         _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
                REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
-        non_get = [r for r in server.requests if r["method"] != "GET"]
-        assert len(non_get) == 0
+        # Issue should have no changes (empty changelog)
+        issue = jira.get("RHAIRFE-1234")
+        histories = issue.get("changelog", {}).get("histories", [])
+        assert len(histories) == 0
 
-    def test_does_not_update_frontmatter_status(self, art_dir, mock_jira):
+    def test_does_not_update_frontmatter_status(self, art_dir, jira):
         """Remove labels must NOT set status to Submitted."""
-        url, server = mock_jira
+        jira.create("RHAIRFE-1234", "Test RFE", "Content.",
+                    labels=["rfe-creator-autofix-rubric-pass"])
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
                f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
                f"priority: Major\nstatus: Ready\n"
@@ -416,15 +318,14 @@ class TestRemoveLabels:
         _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
                REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
         fm = _read_frontmatter(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md")
         assert fm["status"] == "Ready"  # NOT "Submitted"
 
-    def test_not_in_snapshot_update(self, art_dir, mock_jira):
+    def test_not_in_snapshot_update(self, art_dir, jira):
         """Remove labels must NOT update the snapshot."""
-        url, server = mock_jira
         # Seed a snapshot
         snap_dir = os.path.join(art_dir, "auto-fix-runs")
         os.makedirs(snap_dir, exist_ok=True)
@@ -436,6 +337,8 @@ class TestRemoveLabels:
         with open(snap_path, "w") as f:
             yaml.dump(snap, f)
 
+        jira.create("RHAIRFE-1234", "Test RFE", "Content.",
+                    labels=["rfe-creator-autofix-rubric-pass"])
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
                f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
                f"priority: Major\nstatus: Ready\n"
@@ -444,7 +347,7 @@ class TestRemoveLabels:
         _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
                REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
         # Snapshot should be unchanged (no submitted hashes)
@@ -454,29 +357,38 @@ class TestRemoveLabels:
 
 
 class TestConflictDetection:
-    def test_conflict_prevents_update(self, art_dir, mock_jira):
+    def test_conflict_prevents_update(self, art_dir, jira):
         """Jira description differs from original → skip, no PUT."""
-        url, server = mock_jira
+        jira.create("RHAIRFE-1234", "Test RFE", "Edited by someone.")
         _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", "Original.")
-        server.original_descriptions["RHAIRFE-1234"] = "Edited by someone."
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
                f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
                f"priority: Major\nstatus: Ready\n---\nOur revision.")
         _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
                _review("RHAIRFE-1234", auto_revised="true"))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
         assert "Skipping" in r.stdout
 
-        puts = _filter_requests(server, "PUT")
-        assert len(puts) == 0
+        # Verify description was NOT changed
+        issue = jira.get("RHAIRFE-1234")
+        desc = issue["fields"]["description"]
+        if isinstance(desc, dict):
+            texts = []
+            for node in desc.get("content", []):
+                for child in node.get("content", []):
+                    if child.get("type") == "text":
+                        texts.append(child["text"])
+            desc_text = " ".join(texts)
+        else:
+            desc_text = desc
+        assert "Edited by someone" in desc_text
 
 
 class TestCommentPosting:
-    def test_removed_context_comment(self, art_dir, mock_jira):
-        """RFE with removed-context YAML → POST comment."""
-        url, server = mock_jira
+    def test_removed_context_comment(self, art_dir, jira):
+        """RFE with removed-context YAML → comment posted."""
         _write(f"{art_dir}/rfe-tasks/RFE-001.md",
                TASK_FM.format(rfe_id="RFE-001"))
         _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
@@ -489,29 +401,34 @@ class TestCommentPosting:
         _write(f"{art_dir}/rfe-tasks/RFE-001-removed-context.yaml",
                yaml.dump(rc_yaml))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
         assert "Posted removed-context comment" in r.stdout
 
-        comments = _filter_requests(server, "POST", "/comment")
-        assert len(comments) >= 1
-        assert "body" in comments[0]["body"]
+        # Find the created issue and check its comments
+        issues = jira.search("project = RHAIRFE")
+        key = issues[0]["key"]
+        comments = jira.request(
+            "GET", f"/rest/api/3/issue/{key}/comment")
+        assert comments["total"] >= 1
 
-    def test_needs_attention_comment(self, art_dir, mock_jira):
-        """RFE with needs_attention → POST comment with reason."""
-        url, server = mock_jira
+    def test_needs_attention_comment(self, art_dir, jira):
+        """RFE with needs_attention → comment posted."""
         _write(f"{art_dir}/rfe-tasks/RFE-001.md",
                TASK_FM.format(rfe_id="RFE-001"))
         _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
                _review("RFE-001", needs_attention="true",
                        extra_fields="needs_attention_reason: Unclear scope\n"))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
         assert "needs-attention comment" in r.stdout
 
-        comments = _filter_requests(server, "POST", "/comment")
-        assert len(comments) >= 1
+        issues = jira.search("project = RHAIRFE")
+        key = issues[0]["key"]
+        comments = jira.request(
+            "GET", f"/rest/api/3/issue/{key}/comment")
+        assert comments["total"] >= 1
 
 
 class TestSnapshotUpdate:
@@ -530,32 +447,33 @@ class TestSnapshotUpdate:
             yaml.dump(snap, f, default_flow_style=False, sort_keys=False)
         return path
 
-    def test_snapshot_updated_on_create(self, art_dir, mock_jira):
+    def test_snapshot_updated_on_create(self, art_dir, jira):
         """Create → snapshot updated with new issue hash."""
-        url, server = mock_jira
-        snap_path = self._seed_snapshot(art_dir, {"RHAIRFE-1": "existing"})
+        snap_path = self._seed_snapshot(art_dir, {"RHAIRFE-9000": "existing"})
         _write(f"{art_dir}/rfe-tasks/RFE-001.md",
                TASK_FM.format(rfe_id="RFE-001"))
         _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
                _review("RFE-001"))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
         with open(snap_path) as f:
             data = yaml.safe_load(f)
-        assert "RHAIRFE-2000" in data["issues"]
-        assert isinstance(data["issues"]["RHAIRFE-2000"], str)
-        assert len(data["issues"]["RHAIRFE-2000"]) == 64  # SHA256 hex
-        # Original issue still present
-        assert data["issues"]["RHAIRFE-1"] == "existing"
+        # Find the created key
+        issues = jira.search("project = RHAIRFE")
+        key = issues[0]["key"]
+        assert key in data["issues"]
+        assert isinstance(data["issues"][key], str)
+        assert len(data["issues"][key]) == 64  # SHA256 hex
+        # Other issues in snapshot still present
+        assert data["issues"]["RHAIRFE-9000"] == "existing"
 
-    def test_snapshot_updated_on_update(self, art_dir, mock_jira):
+    def test_snapshot_updated_on_update(self, art_dir, jira):
         """Update → snapshot updated with revised hash."""
-        url, server = mock_jira
         snap_path = self._seed_snapshot(art_dir,
                                         {"RHAIRFE-1234": "old-hash"})
-        server.original_descriptions["RHAIRFE-1234"] = "Original."
+        jira.create("RHAIRFE-1234", "Test RFE", "Original.")
         _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", "Original.")
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
                f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
@@ -563,7 +481,7 @@ class TestSnapshotUpdate:
         _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
                _review("RHAIRFE-1234"))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
         with open(snap_path) as f:
@@ -572,9 +490,8 @@ class TestSnapshotUpdate:
         assert len(data["issues"]["RHAIRFE-1234"]) == 64
         assert data["issues"]["RHAIRFE-1234"] != "old-hash"
 
-    def test_no_update_when_all_skipped(self, art_dir, mock_jira):
+    def test_no_update_when_all_skipped(self, art_dir, jira):
         """All RFEs rejected/skipped → snapshot unchanged."""
-        url, server = mock_jira
         snap_path = self._seed_snapshot(art_dir,
                                         {"RHAIRFE-1234": "existing"})
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
@@ -582,7 +499,7 @@ class TestSnapshotUpdate:
         _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
                REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
 
-        r = _run_submit(art_dir, url)
+        r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
         with open(snap_path) as f:


### PR DESCRIPTION
## Summary

- Adds content-hash snapshots so auto-fix only re-processes RFEs whose Jira descriptions actually changed or are new since the last run, avoiding redundant review cycles
- Introduces snapshot_fetch.py with incremental Jira updated >= filtering, scoped carry-forward with graceful degradation, and submitted-keys exclusion
- Adds clone_results_repo.py for sparse-cloning the results repo in CI (auth handled externally, Claude gets zero tokens)
- Adds bootstrap_snapshot.py to seed initial snapshots from existing review artifacts
- Extends submit.py with post-submit snapshot updates and stale rubric-pass label removal for rejected RFEs
- Upgrades check_resume.py with file-based mode that bypasses resume for changed IDs (local reviews are stale)
- Moves normalize_for_compare to jira_utils.py (shared by snapshot hashing and conflict detection)
- Updates auto-fix skill with --data-dir flag and snapshot promote step

## Test plan

- [x] 157 tests pass (test_snapshot_fetch, test_bootstrap_snapshot, test_clone_results_repo, test_check_resume, test_submit, test_submit_integration, and all existing tests)
- [x] CI integration: verify clone_results_repo.py works with sparse checkout in rfe-autofixer pipeline
- [x] End-to-end: run auto-fix with --data-dir pointing at a previous run to confirm incremental fetch skips unchanged RFEs