### PR TITLE
Fix bootstrap for Jira Server/DC and soft limit for snapshot fetch

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -30,7 +30,7 @@ python3 scripts/state.py init tmp/autofix-config.yaml headless=<true/false> anno
 python3 scripts/snapshot_fetch.py fetch "<query>" --ids-file tmp/autofix-all-ids.txt --changed-file tmp/autofix-changed-ids.txt [--limit N] [--data-dir "<path>"]
 ```
 
-The script prints the actual JQL to stderr. Output this to the user: `[AUTOFIX] JQL: <jql>`. The script writes all IDs to process to `tmp/autofix-all-ids.txt` and changed-only IDs to `tmp/autofix-changed-ids.txt`. Parse stdout for counts: `TOTAL=N`, `CHANGED=N`, `NEW=N`.
+The script prints the actual JQL to stderr. Output this to the user: `[AUTOFIX] JQL: <jql>`. The script writes all IDs to process to `tmp/autofix-all-ids.txt` and changed-only IDs to `tmp/autofix-changed-ids.txt`. Parse stdout for counts: `TOTAL=N`, `CHANGED=N`, `NEW=N`, `UNCHANGED=N`.
 
 **Explicit mode**: Use the provided IDs directly. Persist to disk:
 
@@ -41,7 +41,7 @@ python3 scripts/state.py write-ids tmp/autofix-changed-ids.txt
 
 If no IDs and no JQL query, stop with usage instructions.
 
-Output: `[AUTOFIX] Step 0: Parsed N IDs (C changed, W new), batch_size=M`
+Output: `[AUTOFIX] Step 0: Parsed N IDs (C changed, W new, U unchanged), batch_size=M`
 
 ## Step 1: Bootstrap Pre-flight
 

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -23,6 +23,7 @@ Environment variables:
 import argparse
 import json
 import os
+import re
 import sys
 import urllib.parse
 from datetime import datetime, timezone
@@ -30,7 +31,7 @@ from datetime import datetime, timezone
 import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from jira_utils import require_env, api_call_with_retry
+from jira_utils import require_env, api_call_with_retry, make_request
 from snapshot_fetch import (
     fetch_all_issues,
     compute_content_hash,
@@ -87,7 +88,8 @@ def _fetch_changelog(server, user, token, key):
             created_str = history.get("created", "")
             try:
                 created = datetime.fromisoformat(
-                    created_str.replace("+0000", "+00:00"))
+                    re.sub(r'([+-]\d{2})(\d{2})$', r'\1:\2',
+                           created_str))
             except (ValueError, TypeError):
                 continue
             entries.append({
@@ -105,9 +107,12 @@ def _fetch_changelog(server, user, token, key):
 
 
 def _description_at_time(changelog, target_dt):
-    """Extract the description ADF at target_dt from changelog entries.
+    """Extract the description at target_dt from changelog entries.
 
-    Returns ADF dict, or None if no description changes exist.
+    Returns ADF dict or raw text string, or None if no description
+    changes exist.  On Jira Cloud the structured content lives in
+    from/to (ADF JSON).  On Jira Server/DC those fields are None and
+    the content is in fromString/toString (wiki markup).
     """
     desc_changes = []
     for entry in changelog:
@@ -115,8 +120,8 @@ def _description_at_time(changelog, target_dt):
             if item.get("field") == "description":
                 desc_changes.append({
                     "created": entry["created"],
-                    "from": item.get("from"),
-                    "to": item.get("to"),
+                    "from": item.get("from") if item.get("from") is not None else item.get("fromString"),
+                    "to": item.get("to") if item.get("to") is not None else item.get("toString"),
                 })
 
     if not desc_changes:
@@ -199,11 +204,25 @@ def get_description_at_time(server, user, token, key, target_dt):
     return _description_at_time(changelog, target_dt)
 
 
-def _parse_adf(value):
-    """Parse a changelog value as ADF.
+def _fetch_wiki_description(server, user, token, key):
+    """Fetch current description as wiki markup via v2 API.
 
-    Changelog stores ADF as a JSON string in from/to fields.
-    Returns dict (ADF), or None.
+    Used for apples-to-apples comparison with changelog toString
+    values (which are also wiki markup on Jira Server/DC).
+    """
+    url = f"{server.rstrip('/')}/rest/api/2/issue/{urllib.parse.quote(key, safe='')}?fields=description"
+    data = make_request(url, user, token)
+    return (data.get("fields") or {}).get("description") or ""
+
+
+def _parse_adf(value):
+    """Parse a changelog description value.
+
+    On Jira Cloud, from/to contain ADF as a JSON string → returns dict.
+    On Jira Server/DC, fromString/toString contain wiki markup → returns
+    the raw string (compute_content_hash handles strings via
+    adf_to_markdown pass-through).
+    Returns None only when value is None (empty description).
     """
     if value is None:
         return None
@@ -216,6 +235,8 @@ def _parse_adf(value):
                 return parsed
         except (json.JSONDecodeError, TypeError):
             pass
+        # Wiki markup or other non-JSON text — return as-is
+        return value
     return None
 
 
@@ -289,10 +310,25 @@ def main():
         if hist_desc is None:
             # No description changes — current is the original
             snapshot_issues[key] = data["content_hash"]
-        else:
+        elif isinstance(hist_desc, dict):
+            # ADF (Jira Cloud) — hash directly comparable
             hist_hash = compute_content_hash(hist_desc)
             snapshot_issues[key] = hist_hash
             if hist_hash != data["content_hash"]:
+                hist_changed += 1
+        else:
+            # Wiki markup (Jira Server/DC) — compare wiki-to-wiki
+            # via v2 API to avoid false positives from format
+            # differences (wiki h2. vs ADF ##)
+            current_wiki = _fetch_wiki_description(
+                server, user, token, key)
+            hist_hash = compute_content_hash(hist_desc)
+            current_wiki_hash = compute_content_hash(current_wiki)
+            if hist_hash == current_wiki_hash:
+                # Description unchanged — use current ADF hash
+                snapshot_issues[key] = data["content_hash"]
+            else:
+                snapshot_issues[key] = hist_hash
                 hist_changed += 1
 
     print(f"Changelog lookups: {lookups} "

--- a/scripts/snapshot_fetch.py
+++ b/scripts/snapshot_fetch.py
@@ -308,13 +308,16 @@ def cmd_fetch(args):
     # Maintain Jira's original order across both sets
     changed_set = set(changed)
     new_set = set(new)
-    all_ids = [k for k in current.keys() if k in changed_set or k in new_set]
+    priority_ids = [k for k in current.keys()
+                    if k in changed_set or k in new_set]
+    unchanged_ids = [k for k in current.keys()
+                     if k not in changed_set and k not in new_set]
 
-    # Apply limit
-    limit = args.limit or len(all_ids)
-    all_ids = all_ids[:limit]
+    # Changed/new get priority ordering; total capped at limit
+    limit = args.limit or len(current)
+    all_ids = (priority_ids + unchanged_ids)[:limit]
 
-    # Re-split into changed/new after limit
+    # Split for downstream
     out_changed = [k for k in all_ids if k in changed_set]
     out_new = [k for k in all_ids if k in new_set]
 
@@ -323,11 +326,10 @@ def cmd_fetch(args):
     write_id_file(args.changed_file, out_changed)
 
     # Output counts only — IDs are in files
-    unchanged = len(current) - len(changed) - len(new)
     print(f"TOTAL={len(all_ids)}")
     print(f"CHANGED={len(out_changed)}")
     print(f"NEW={len(out_new)}")
-    print(f"UNCHANGED={unchanged}")
+    print(f"UNCHANGED={len(all_ids) - len(out_changed) - len(out_new)}")
 
 
 def main():

--- a/scripts/snapshot_fetch.py
+++ b/scripts/snapshot_fetch.py
@@ -323,9 +323,11 @@ def cmd_fetch(args):
     write_id_file(args.changed_file, out_changed)
 
     # Output counts only — IDs are in files
+    unchanged = len(current) - len(changed) - len(new)
     print(f"TOTAL={len(all_ids)}")
     print(f"CHANGED={len(out_changed)}")
     print(f"NEW={len(out_new)}")
+    print(f"UNCHANGED={unchanged}")
 
 
 def main():

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -22,6 +22,7 @@ from bootstrap_snapshot import (
     find_latest_run_timestamp,
     get_description_at_time,
     _parse_adf,
+    _description_at_time,
 )
 
 
@@ -92,11 +93,80 @@ class TestParseAdf:
         adf = {"type": "doc", "version": 1, "content": []}
         assert _parse_adf(json.dumps(adf)) == adf
 
-    def test_invalid_json_returns_none(self):
-        assert _parse_adf("not json") is None
+    def test_wiki_markup_returned_as_string(self):
+        wiki = "h2. Business Goal\n\nSome description text."
+        assert _parse_adf(wiki) == wiki
 
-    def test_non_dict_json_returns_none(self):
-        assert _parse_adf(json.dumps([1, 2, 3])) is None
+    def test_non_dict_json_returned_as_string(self):
+        # JSON that isn't a dict isn't ADF — returned as raw string
+        assert _parse_adf(json.dumps([1, 2, 3])) == "[1, 2, 3]"
+
+
+class TestDescriptionAtTime:
+    """Unit tests for _description_at_time with from/to and fromString/toString."""
+
+    def test_adf_from_to(self):
+        """Uses from/to when available (Jira Cloud)."""
+        from datetime import datetime, timezone
+        target = datetime(2026, 4, 1, 12, 0, tzinfo=timezone.utc)
+        changelog = [{
+            "created": datetime(2026, 4, 2, 10, 0, tzinfo=timezone.utc),
+            "items": [{
+                "field": "description",
+                "from": json.dumps(_text_to_adf("before")),
+                "to": json.dumps(_text_to_adf("after")),
+                "fromString": "before",
+                "toString": "after",
+            }],
+        }]
+        result = _description_at_time(changelog, target)
+        # Should use ADF from "from", not fromString
+        assert isinstance(result, dict)
+        assert result == _text_to_adf("before")
+
+    def test_falls_back_to_fromstring(self):
+        """Falls back to fromString/toString when from/to are None (Jira Server/DC)."""
+        from datetime import datetime, timezone
+        target = datetime(2026, 4, 1, 12, 0, tzinfo=timezone.utc)
+        changelog = [{
+            "created": datetime(2026, 4, 2, 10, 0, tzinfo=timezone.utc),
+            "items": [{
+                "field": "description",
+                "from": None,
+                "to": None,
+                "fromString": "h2. Before\n\nOriginal text.",
+                "toString": "h2. After\n\nEdited text.",
+            }],
+        }]
+        result = _description_at_time(changelog, target)
+        assert result == "h2. Before\n\nOriginal text."
+
+    def test_to_value_for_pre_target_change(self):
+        """Change before target → uses 'to' value."""
+        from datetime import datetime, timezone
+        target = datetime(2026, 4, 3, 12, 0, tzinfo=timezone.utc)
+        changelog = [{
+            "created": datetime(2026, 4, 2, 10, 0, tzinfo=timezone.utc),
+            "items": [{
+                "field": "description",
+                "from": None,
+                "to": None,
+                "fromString": "old wiki",
+                "toString": "new wiki",
+            }],
+        }]
+        result = _description_at_time(changelog, target)
+        assert result == "new wiki"
+
+    def test_no_description_changes(self):
+        """No description items → returns None."""
+        from datetime import datetime, timezone
+        target = datetime(2026, 4, 1, 12, 0, tzinfo=timezone.utc)
+        changelog = [{
+            "created": datetime(2026, 4, 2, 10, 0, tzinfo=timezone.utc),
+            "items": [{"field": "status", "fromString": "New", "toString": "Done"}],
+        }]
+        assert _description_at_time(changelog, target) is None
 
 
 # ── Mock Jira Server ─────────────────────────────────────────────────────────
@@ -111,6 +181,8 @@ class JiraHandler(BaseHTTPRequestHandler):
             self._handle_search(decoded)
         elif "/changelog" in decoded:
             self._handle_changelog(decoded)
+        elif "/rest/api/2/issue/" in decoded:
+            self._handle_v2_issue(decoded)
         else:
             self._json(404, {"error": "not found"})
 
@@ -142,6 +214,12 @@ class JiraHandler(BaseHTTPRequestHandler):
             "total": len(histories),
         })
 
+    def _handle_v2_issue(self, path):
+        # /rest/api/2/issue/RHAIRFE-1234?fields=description
+        key = path.split("/rest/api/2/issue/")[1].split("?")[0]
+        wiki = self.server.wiki_descriptions.get(key, "")
+        self._json(200, {"fields": {"description": wiki}})
+
     def _json(self, status, data):
         body = json.dumps(data).encode()
         self.send_response(status)
@@ -159,6 +237,7 @@ def mock_jira():
     server = HTTPServer(("127.0.0.1", 0), JiraHandler)
     server.issues = {}
     server.changelogs = {}
+    server.wiki_descriptions = {}
     url = f"http://127.0.0.1:{server.server_address[1]}"
     thread = threading.Thread(target=server.serve_forever)
     thread.daemon = True
@@ -336,6 +415,49 @@ class TestBootstrapIntegration:
         assert snap["issues"]["RHAIRFE-1"] == historical_hash
         assert snap["issues"]["RHAIRFE-1"] != current_hash
 
+    def test_adf_changelog_unchanged_uses_current_hash(self, tmp_path, mock_jira):
+        """ADF changelog change before run → 'to' hash matches current ADF hash."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Updated before run."}
+        # Description changed BEFORE the run — 'to' matches current
+        server.changelogs["RHAIRFE-1"] = [{
+            "created": "2026-03-30T10:00:00.000+0000",
+            "items": [{
+                "field": "description",
+                "from": json.dumps(_text_to_adf("Old version.")),
+                "to": json.dumps(_text_to_adf("Updated before run.")),
+            }],
+        }]
+        results = _make_results_dir(
+            tmp_path, ["20260401-120000"], latest="20260401-120000")
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT,
+             "--results-dir", results,
+             "--artifacts-dir", art_dir,
+             "project = RHAIRFE"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        snapshots = [f for f in os.listdir(snapshot_dir)
+                     if f.startswith("issue-snapshot-")]
+        with open(os.path.join(snapshot_dir, snapshots[0])) as f:
+            snap = yaml.safe_load(f)
+
+        # ADF 'to' hash == current ADF hash (same content, same format)
+        current_hash = _md_hash("Updated before run.")
+        assert snap["issues"]["RHAIRFE-1"] == current_hash
+
     def test_only_snapshot_written(self, tmp_path, mock_jira):
         """Bootstrap writes only an issue-snapshot file, nothing else."""
         url, server = mock_jira
@@ -362,6 +484,108 @@ class TestBootstrapIntegration:
         snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
         files = os.listdir(snapshot_dir)
         assert all(f.startswith("issue-snapshot-") for f in files)
+
+    def test_wiki_markup_fallback_changed(self, tmp_path, mock_jira):
+        """Jira Server/DC: from/to are None, falls back to fromString/toString.
+
+        When historical wiki differs from current wiki, uses historical hash.
+        """
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Edited after run."}
+        server.wiki_descriptions = {"RHAIRFE-1": "h2. Edited after run."}
+        server.changelogs["RHAIRFE-1"] = [{
+            "created": "2026-04-02T10:00:00.000+0000",
+            "items": [{
+                "field": "description",
+                "from": None,
+                "to": None,
+                "fromString": "h2. Original at run time.",
+                "toString": "h2. Edited after run.",
+            }],
+        }]
+        results = _make_results_dir(
+            tmp_path, ["20260401-120000"], latest="20260401-120000")
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT,
+             "--results-dir", results,
+             "--artifacts-dir", art_dir,
+             "project = RHAIRFE"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        snapshots = [f for f in os.listdir(snapshot_dir)
+                     if f.startswith("issue-snapshot-")]
+        with open(os.path.join(snapshot_dir, snapshots[0])) as f:
+            snap = yaml.safe_load(f)
+
+        # Should use historical wiki hash, NOT current ADF hash
+        hist_hash = _md_hash("h2. Original at run time.")
+        current_adf_hash = _md_hash("Edited after run.")
+        assert snap["issues"]["RHAIRFE-1"] == hist_hash
+        assert snap["issues"]["RHAIRFE-1"] != current_adf_hash
+
+    def test_wiki_markup_fallback_unchanged(self, tmp_path, mock_jira):
+        """Jira Server/DC: pre-run description change, wiki matches current.
+
+        When historical wiki matches current wiki via v2, uses current ADF hash
+        (avoids false positive from wiki vs ADF format difference).
+        """
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Same description."}
+        server.wiki_descriptions = {"RHAIRFE-1": "h2. Same description."}
+        # Description was changed BEFORE the run
+        server.changelogs["RHAIRFE-1"] = [{
+            "created": "2026-03-30T10:00:00.000+0000",
+            "items": [{
+                "field": "description",
+                "from": None,
+                "to": None,
+                "fromString": "h2. Old version.",
+                "toString": "h2. Same description.",
+            }],
+        }]
+        results = _make_results_dir(
+            tmp_path, ["20260401-120000"], latest="20260401-120000")
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT,
+             "--results-dir", results,
+             "--artifacts-dir", art_dir,
+             "project = RHAIRFE"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        snapshots = [f for f in os.listdir(snapshot_dir)
+                     if f.startswith("issue-snapshot-")]
+        with open(os.path.join(snapshot_dir, snapshots[0])) as f:
+            snap = yaml.safe_load(f)
+
+        # Should use current ADF hash (not wiki hash) since content is the same
+        current_adf_hash = _md_hash("Same description.")
+        wiki_hash = _md_hash("h2. Same description.")
+        assert snap["issues"]["RHAIRFE-1"] == current_adf_hash
+        assert snap["issues"]["RHAIRFE-1"] != wiki_hash
 
     def test_reopened_issue_excluded(self, tmp_path, mock_jira):
         """Issue in Done status at run time is excluded from snapshot."""

--- a/tests/test_snapshot_fetch_integration.py
+++ b/tests/test_snapshot_fetch_integration.py
@@ -135,16 +135,22 @@ class TestCmdFetchFirstRun:
 # ── cmd_fetch: Incremental Run ───────────────────────────────────────────────
 
 class TestCmdFetchIncremental:
-    def test_unchanged_excluded(self, work_dirs, jira, monkeypatch, tmp_path):
-        """Issue with same hash → not in output IDs."""
+    def test_unchanged_included_not_changed(self, work_dirs, jira,
+                                               monkeypatch, tmp_path):
+        """Issue with same hash → in output IDs but not in changed file."""
         jira.create("RHAIRFE-1", "Issue one", "Same content.")
         same_hash = compute_content_hash(_text_to_adf("Same content."))
         _seed_snapshot(work_dirs, {"RHAIRFE-1": same_hash})
         _jira_env(monkeypatch, jira.url)
 
-        stdout = _run_fetch(_fetch_args(tmp_path))
+        args = _fetch_args(tmp_path)
+        stdout = _run_fetch(args)
 
-        assert "TOTAL=0" in stdout
+        assert "TOTAL=1" in stdout
+        assert "CHANGED=0" in stdout
+        assert "UNCHANGED=1" in stdout
+        assert _read_ids(args.ids_file) == ["RHAIRFE-1"]
+        assert _read_ids(args.changed_file) == []
 
     def test_changed_detected(self, work_dirs, jira, monkeypatch, tmp_path):
         """Issue with different hash → in changed file."""
@@ -162,7 +168,7 @@ class TestCmdFetchIncremental:
         assert _read_ids(args.changed_file) == ["RHAIRFE-1"]
 
     def test_new_detected(self, work_dirs, jira, monkeypatch, tmp_path):
-        """Issue not in previous snapshot → new."""
+        """Issue not in previous snapshot → new. Unchanged fills remaining."""
         jira.create("RHAIRFE-1", "Issue one", "Existing.")
         jira.create("RHAIRFE-2", "Issue two", "Brand new.")
         existing_hash = compute_content_hash(_text_to_adf("Existing."))
@@ -172,9 +178,12 @@ class TestCmdFetchIncremental:
         args = _fetch_args(tmp_path)
         stdout = _run_fetch(args)
 
-        assert "TOTAL=1" in stdout
+        assert "TOTAL=2" in stdout
         assert "NEW=1" in stdout
-        assert _read_ids(args.ids_file) == ["RHAIRFE-2"]
+        assert "UNCHANGED=1" in stdout
+        ids = _read_ids(args.ids_file)
+        assert "RHAIRFE-2" in ids
+        assert "RHAIRFE-1" in ids
 
     def test_limit_caps_output(self, work_dirs, jira, monkeypatch, tmp_path):
         """--limit caps the number of output IDs."""
@@ -241,7 +250,7 @@ class TestMultiRunPipeline:
 
     def test_steady_state_skips_unchanged(self, work_dirs, jira,
                                           monkeypatch, tmp_path):
-        """Run 1 processes everything. Run 2 sees nothing to do."""
+        """Run 1 processes everything. Run 2 includes all but none changed."""
         jira.create("RHAIRFE-1", "Issue one", "Description one.")
         jira.create("RHAIRFE-2", "Issue two", "Description two.")
         _jira_env(monkeypatch, jira.url)
@@ -251,9 +260,13 @@ class TestMultiRunPipeline:
         assert "TOTAL=2" in stdout1
         assert "NEW=2" in stdout1
 
-        # Run 2: nothing changed — nothing to process
-        stdout2 = _run_fetch(_fetch_args(tmp_path))
-        assert "TOTAL=0" in stdout2
+        # Run 2: nothing changed — all unchanged, none in changed file
+        args2 = _fetch_args(tmp_path)
+        stdout2 = _run_fetch(args2)
+        assert "TOTAL=2" in stdout2
+        assert "CHANGED=0" in stdout2
+        assert "UNCHANGED=2" in stdout2
+        assert _read_ids(args2.changed_file) == []
 
     def test_user_edits_after_submit(self, work_dirs, jira,
                                      monkeypatch, tmp_path):
@@ -280,17 +293,18 @@ class TestMultiRunPipeline:
                       {"fields": {"description":
                                   "User rewrote this after our fix."}})
 
-        # Run 2: detects user's edit, skips RHAIRFE-2
+        # Run 2: detects user's edit, RHAIRFE-2 unchanged fills capacity
         args2 = _fetch_args(tmp_path)
         stdout2 = _run_fetch(args2)
-        assert "TOTAL=1" in stdout2
+        assert "TOTAL=2" in stdout2
         assert "CHANGED=1" in stdout2
-        assert _read_ids(args2.ids_file) == ["RHAIRFE-1"]
         assert _read_ids(args2.changed_file) == ["RHAIRFE-1"]
 
-        # Run 3: nothing changed — nothing to process
-        stdout3 = _run_fetch(_fetch_args(tmp_path))
-        assert "TOTAL=0" in stdout3
+        # Run 3: nothing changed — all unchanged
+        args3 = _fetch_args(tmp_path)
+        stdout3 = _run_fetch(args3)
+        assert "CHANGED=0" in stdout3
+        assert "UNCHANGED=2" in stdout3
 
     def test_submit_without_user_edit(self, work_dirs, jira,
                                       monkeypatch, tmp_path):
@@ -311,9 +325,12 @@ class TestMultiRunPipeline:
         jira.request( "PUT", "/rest/api/3/issue/RHAIRFE-1",
                       {"fields": {"description": "We revised this."}})
 
-        # Run 2: our own change is in the snapshot — skip
-        stdout2 = _run_fetch(_fetch_args(tmp_path))
-        assert "TOTAL=0" in stdout2
+        # Run 2: our own change is in the snapshot — unchanged
+        args2 = _fetch_args(tmp_path)
+        stdout2 = _run_fetch(args2)
+        assert "TOTAL=1" in stdout2
+        assert "CHANGED=0" in stdout2
+        assert _read_ids(args2.changed_file) == []
 
     def test_new_issue_created_by_submit(self, work_dirs, jira,
                                          monkeypatch, tmp_path):
@@ -332,21 +349,23 @@ class TestMultiRunPipeline:
         update_snapshot_hashes(
             {"RHAIRFE-2": new_hash}, work_dirs.snapshot_dir)
 
-        # Run 2: our new issue is already in the snapshot — skip
-        stdout2 = _run_fetch(_fetch_args(tmp_path))
-        assert "TOTAL=0" in stdout2
+        # Run 2: our new issue is already in the snapshot — unchanged
+        args2 = _fetch_args(tmp_path)
+        stdout2 = _run_fetch(args2)
+        assert "CHANGED=0" in stdout2
+        assert _read_ids(args2.changed_file) == []
 
         # Between runs: user edits the new issue
         jira.request( "PUT", "/rest/api/3/issue/RHAIRFE-2",
                       {"fields": {"description":
                                   "User improved our new issue."}})
 
-        # Run 3: detects the edit
+        # Run 3: detects the edit; unchanged fills remaining capacity
         args3 = _fetch_args(tmp_path)
         stdout3 = _run_fetch(args3)
-        assert "TOTAL=1" in stdout3
+        assert "TOTAL=2" in stdout3
         assert "CHANGED=1" in stdout3
-        assert _read_ids(args3.ids_file) == ["RHAIRFE-2"]
+        assert set(_read_ids(args3.ids_file)) == {"RHAIRFE-1", "RHAIRFE-2"}
 
     def test_issue_leaves_scope(self, work_dirs, jira,
                                 monkeypatch, tmp_path):
@@ -370,9 +389,12 @@ class TestMultiRunPipeline:
                           "/rest/api/3/issue/RHAIRFE-2/transitions",
                           {"transition": {"id": done_t["id"]}})
 
-        # Run 2: RHAIRFE-2 gone, RHAIRFE-1 unchanged — nothing to do
-        stdout2 = _run_fetch(_fetch_args(tmp_path))
-        assert "TOTAL=0" in stdout2
+        # Run 2: RHAIRFE-2 gone, RHAIRFE-1 unchanged but included
+        args2 = _fetch_args(tmp_path)
+        stdout2 = _run_fetch(args2)
+        assert "TOTAL=1" in stdout2
+        assert "CHANGED=0" in stdout2
+        assert _read_ids(args2.changed_file) == []
 
     def test_mixed_activity_across_runs(self, work_dirs, jira,
                                         monkeypatch, tmp_path):
@@ -400,17 +422,16 @@ class TestMultiRunPipeline:
                                   "User rewrote issue two."}})
         jira.create("RHAIRFE-3", "Issue three", "Brand new issue three.")
 
-        # Run 2: RHAIRFE-1 skip (our change), RHAIRFE-2 changed,
-        #         RHAIRFE-3 new
+        # Run 2: RHAIRFE-2 changed, RHAIRFE-3 new, RHAIRFE-1 unchanged
         args2 = _fetch_args(tmp_path)
         stdout2 = _run_fetch(args2)
-        assert "TOTAL=2" in stdout2
+        assert "TOTAL=3" in stdout2
         assert "CHANGED=1" in stdout2
         assert "NEW=1" in stdout2
-        ids2 = _read_ids(args2.ids_file)
-        assert "RHAIRFE-2" in ids2
-        assert "RHAIRFE-3" in ids2
-        assert "RHAIRFE-1" not in ids2
+        assert "UNCHANGED=1" in stdout2
+        changed2 = _read_ids(args2.changed_file)
+        assert "RHAIRFE-2" in changed2
+        assert "RHAIRFE-1" not in changed2
 
         # Between runs: RHAIRFE-2 closed, nothing else changes
         transitions = jira.request(
@@ -423,9 +444,11 @@ class TestMultiRunPipeline:
                           "/rest/api/3/issue/RHAIRFE-2/transitions",
                           {"transition": {"id": done_t["id"]}})
 
-        # Run 3: RHAIRFE-2 gone, rest unchanged — nothing to do
-        stdout3 = _run_fetch(_fetch_args(tmp_path))
-        assert "TOTAL=0" in stdout3
+        # Run 3: RHAIRFE-2 gone, rest unchanged
+        args3 = _fetch_args(tmp_path)
+        stdout3 = _run_fetch(args3)
+        assert "CHANGED=0" in stdout3
+        assert _read_ids(args3.changed_file) == []
 
 
 # ── End-to-End: Clone → Fetch with --data-dir ──────────────────────────────
@@ -511,13 +534,17 @@ class TestCloneThenFetch:
         args = _fetch_args(tmp_path, data_dir=clone_dest)
         stdout = _run_fetch(args)
 
-        # RHAIRFE-1: unchanged → skipped
+        # RHAIRFE-1: unchanged → included but not changed
         # RHAIRFE-2: hash differs → changed
         # RHAIRFE-3: new
-        assert "TOTAL=2" in stdout
+        assert "TOTAL=3" in stdout
         assert "CHANGED=1" in stdout
         assert "NEW=1" in stdout
+        assert "UNCHANGED=1" in stdout
         ids = _read_ids(args.ids_file)
-        assert "RHAIRFE-1" not in ids
+        assert "RHAIRFE-1" in ids
         assert "RHAIRFE-2" in ids
         assert "RHAIRFE-3" in ids
+        changed = _read_ids(args.changed_file)
+        assert "RHAIRFE-2" in changed
+        assert "RHAIRFE-1" not in changed


### PR DESCRIPTION
## Summary
- Fix `bootstrap_snapshot.py` to handle Jira Server/DC changelog where `from`/`to` fields are None (content in `fromString`/`toString` as wiki markup). Uses v2 API for wiki-to-wiki comparison to eliminate false positives from format differences.
- Make `--limit` a soft cap in `snapshot_fetch.py`: changed/new issues get priority ordering, unchanged fill remaining capacity up to the limit.
- Add `UNCHANGED=N` count to snapshot fetch output.

## Test plan
- [x] 22 bootstrap snapshot tests pass (including new wiki markup changed/unchanged and ADF unchanged cases)
- [x] 14 snapshot fetch integration tests pass (including soft limit cap and unchanged fill behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)