### PR TITLE
Add /rfe.outcome skill for JIRA Outcome card creation

### DIFF
--- a/.claude/skills/rfe.outcome/SKILL.md
+++ b/.claude/skills/rfe.outcome/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: rfe.outcome
+description: Create a JIRA Outcome card from one or more approved RFEs. Outcomes sit above Features/RFEs in the planning hierarchy — they define the measurable business result that a cluster of features collectively delivers. Use after /rfe.create or when you have RHAIRFE keys in hand.
+user-invocable: true
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion
+---
+
+You are an Outcome card creation assistant. Your job is to translate a cluster of related RFEs into a well-formed JIRA Outcome card that defines the measurable business result those features collectively deliver.
+
+Outcome cards are NOT feature descriptions. They describe what the customer or organization can observably do — or what has measurably changed — once a set of features is complete. Features answer "what are we building?" Outcomes answer "what changes in the world when we're done?"
+
+## Step 0: Parse Arguments
+
+Parse `$ARGUMENTS` for:
+- `--rfe-keys <keys>`: Comma-separated RHAIRFE or RFE-NNN keys to pull into this outcome (e.g. `RHAIRFE-1234,RHAIRFE-1235`)
+- `--domain <domain>`: Optional domain hint (e.g. `MaaS`, `Observability`, `TrustyAI`, `Inference`, `EvalHub`) to focus the business value framing
+- `--strategic-goal <text>`: Optional strategic goal text to skip the interview question on it
+- Remaining text: free-form description of the outcome theme
+
+## Step 1: Load Source RFEs
+
+Check for available RFE data from two sources:
+
+**Source A — Local artifacts** (`artifacts/rfe-tasks/`):
+
+```bash
+python3 scripts/frontmatter.py rebuild-index --artifacts-dir artifacts
+```
+
+Then read `artifacts/rfes.md` (the index) to see available RFEs with their titles, priorities, and statuses. For each RFE that is relevant, read its markdown body.
+
+**Source B — JIRA REST API** (when `--rfe-keys` is provided or user supplies keys):
+
+```bash
+python3 scripts/fetch_issue.py RHAIRFE-NNNN \
+    --fields summary,description,priority,labels,status \
+    --markdown
+```
+
+Run this for each key. Parse the JSON stdout for `fields.summary` and `fields.description`.
+
+**If both sources exist for the same RFE**: use the local artifact (may have been edited after submission).
+
+**If no RFEs are found and no keys were provided**: ask the user to either run `/rfe.create` first or provide RHAIRFE Jira keys.
+
+## Step 2: Select Contributing RFEs
+
+If RFEs were not fully specified in arguments, present the available ones and ask the user to confirm which roll up into this outcome:
+
+```
+Available RFEs:
+| Key | Title | Priority | Status |
+|-----|-------|----------|--------|
+| RFE-001 / RHAIRFE-NNNN | ... | Major | Submitted |
+| RFE-002 | ... | Normal | Draft |
+```
+
+The user can confirm, add, or remove entries. Proceed once the contributing set is confirmed.
+
+## Step 3: Outcome Interview
+
+Ask the user (one message) only for what cannot be inferred from the RFEs:
+
+1. **What is the strategic goal this outcome supports?** (e.g., "Accelerate enterprise AI adoption", "Meet regulatory readiness for EU AI Act", "Establish RHOAI as the standard MLOps platform") — skip if `--strategic-goal` was provided
+2. **What domain or product area does this outcome belong to?** (e.g., MaaS, Observability, TrustyAI, Inference, EvalHub) — skip if `--domain` was provided or is obvious from the RFEs
+3. **What is the target timeframe?** (Quarter / Half / Year — e.g., Q3 FY26)
+4. **How will you know it's done?** Describe one or two observable signals: a customer capability, a metric shift, a regulatory milestone, or an unblocked sales motion
+
+Do NOT ask about implementation details. If the RFEs already supply clear answers to any of the above, skip those questions.
+
+## Step 4: Draft the Outcome Card
+
+Generate the Outcome card using the three-section JIRA structure.
+
+Rules before writing:
+
+- **Outcome Overview**: 2–3 sentences. Describe the tangible, measurable movement toward the strategic goal that results when all contributing features are complete. Write from the customer/operator perspective — what they can now do, not what was built. Do not list features.
+- **Success Criteria**: Observable states, not outputs. "Teams can configure domain-specific evaluation in under 30 minutes" is a criterion. "EvalHub SDK supports Evaluation Collections" is an output masquerading as a criterion. Include at least one measurable signal (adoption, time-to-value, regulatory milestone, sales unblocking).
+- **Expected Results**: Concrete impact (what), mechanism (how), timing (when). Link contributing RFEs explicitly.
+
+```markdown
+# Outcome: [Outcome Title]
+
+## Outcome Overview
+
+[2–3 sentences: What tangible, incremental, measurable movement toward the Strategic Goal
+will be achieved once all contributing Features are complete?
+Frame from the customer/operator perspective — what they can observably do or what has changed.
+Do not mention feature names or list what was built.]
+
+---
+
+## Success Criteria
+
+What must be true for this outcome to be considered delivered:
+
+- [ ] [Observable state 1 — describe what you can see or measure, not what was built]
+- [ ] [Observable state 2]
+- [ ] [Observable state 3]
+- [ ] [Observable state 4 — include at least one quantifiable or regulatory signal if applicable]
+
+---
+
+## Expected Results (What, How, When)
+
+**What**: [The specific impact — describe in terms of customer capability or business metric]
+
+**How**: [The mechanism — which features/capabilities collectively produce this result]
+
+**When**: [Target quarter/date and any milestone dependencies]
+
+**Contributing Features**:
+- [JIRA-KEY or RFE-NNN]: [Feature title] — [how it contributes to this outcome]
+- [JIRA-KEY or RFE-NNN]: [Feature title] — [how it contributes to this outcome]
+
+---
+
+## JIRA-Ready Version
+
+[Plain text suitable for direct paste into the JIRA Outcome card fields.
+No markdown headers. Use plain paragraphs for Outcome Overview.
+Use numbered lists for Success Criteria and Expected Results.
+No emoji. No bold markers.]
+```
+
+## Step 5: Quality Check
+
+Before saving, verify:
+
+- [ ] Outcome Overview describes a world-state change, not a feature completion
+- [ ] Success Criteria are observable states, not output lists
+- [ ] At least one Success Criterion is quantifiable or has a clear pass/fail signal
+- [ ] Expected Results specify what, how, and when — all three
+- [ ] Contributing Features list is complete and each entry explains its contribution (not just its title)
+- [ ] JIRA-Ready Version is clean plain text, ready to paste
+
+Flag any gaps before saving. If a criterion can't be made measurable, note it explicitly for the user to supply.
+
+## Step 6: Save Artifact
+
+Determine a slug from the outcome title (lowercase, hyphens, no special chars).
+
+Save to `artifacts/outcome-tasks/[slug]-[YYYY-MM-DD].md` with frontmatter:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/outcome-tasks/<slug>-<date>.md \
+    title="<Outcome title>" \
+    date=<YYYY-MM-DD> \
+    status=Draft \
+    timeframe="<Quarter/Half/Year>" \
+    strategic_goal="<strategic goal>" \
+    domain="<domain or null>" \
+    contributing_rfe_keys="<comma-separated keys>"
+```
+
+Create `artifacts/outcome-tasks/` if it does not exist.
+
+After saving, tell the user:
+
+- The artifact is at `artifacts/outcome-tasks/<slug>-<date>.md`
+- The JIRA-Ready Version at the bottom of the file can be pasted directly into the JIRA Outcome card
+- If they have JIRA MCP or credentials available, offer to help create the Jira item directly
+- Next step: run `/strat.create` to turn contributing RFEs into RHAISTRAT Features
+
+## What NOT to Do
+
+- Do NOT describe features or implementation in the Outcome Overview
+- Do NOT use High/Medium/Low for anything — use Jira priority values or plain timeframes
+- Do NOT invent RFE keys or titles — only use what was loaded from artifacts or fetched from Jira
+- Do NOT generate a strategy or technical HOW — that is `/strat.refine`'s job
+- Do NOT skip the JIRA-Ready Version — the user needs a clean paste-ready block
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary

- Adds a new `/rfe.outcome` skill that fills the planning gap between RFE creation and strategy refinement
- Given one or more approved RFEs (from local `artifacts/rfe-tasks/` or fetched via the JIRA REST API fallback), the skill guides the user through drafting a JIRA Outcome card — the planning tier that sits above Features/RFEs
- Generates the canonical three-section structure: **Outcome Overview**, **Success Criteria**, and **Expected Results (What, How, When)**
- Includes an explicit quality check step that enforces the outputs-vs-outcomes distinction (the most common failure mode in Outcome cards: listing features instead of observable states)
- Produces a JIRA-Ready plain-text block suitable for direct paste into the Jira Outcome card fields
- Saves artifacts to `artifacts/outcome-tasks/[slug]-[YYYY-MM-DD].md` with frontmatter via `frontmatter.py set`
- Connects forward to `/strat.create` as the natural next step

The skill follows all existing rfe-creator conventions: `$ARGUMENTS` parsing with named flags (`--rfe-keys`, `--domain`, `--strategic-goal`), `fetch_issue.py` as the Jira REST API fallback when MCP is unavailable, `frontmatter.py` for schema-validated artifact metadata, and `rebuild-index` after writing.

## Test plan

- [ ] Run `/rfe.outcome` with existing local `artifacts/rfe-tasks/` — confirm it reads the index, presents available RFEs, and produces a valid three-section card
- [ ] Run `/rfe.outcome --rfe-keys RHAIRFE-NNNN` with `JIRA_SERVER`/`JIRA_USER`/`JIRA_TOKEN` set — confirm `fetch_issue.py` is invoked and description is rendered correctly
- [ ] Run `/rfe.outcome --rfe-keys RHAIRFE-NNNN --domain MaaS --strategic-goal "..."` — confirm skips the interview questions for provided flags
- [ ] Verify artifact is saved to `artifacts/outcome-tasks/` with correct frontmatter fields
- [ ] Verify quality check flags a Success Criterion written as a feature output (not an observable state)

---

Signed-off-by: William Caban <william.caban@gmail.com>
Co-created with [Claude Code](https://claude.com/claude-code)