### PR TITLE
Prohibit HTML comments in revise agent output

### DIFF
--- a/.claude/skills/rfe.review/prompts/revise-agent.md
+++ b/.claude/skills/rfe.review/prompts/revise-agent.md
@@ -26,6 +26,8 @@ Comments file: artifacts/rfe-tasks/{ID}-comments.md (read if it exists)
 
 **Do not invent missing evidence.** If WHY is flagged for missing named customers, flag the gap — do not fabricate evidence.
 
+**Never use HTML comments (`<!-- -->`) in the task file.** HTML comments are invisible when rendered in Jira — authors will never see them. If you need to flag something for the author, set `needs_attention=true` and `needs_attention_reason` in frontmatter (Step 3), which gets posted as a visible Jira comment during submission.
+
 For each criterion the assessor flagged:
 - **Open to HOW**: Reframe flagged sections to remove prescriptive framing while preserving useful context
 - **WHY**: Strengthen with available evidence; flag gaps the author must fill


### PR DESCRIPTION
## Summary
- The revise agent was inserting `<!-- AUTHOR ACTION REQUIRED -->` HTML comments into task files to flag gaps for authors
- HTML comments are invisible when rendered in Jira — authors never see them
- Added explicit prohibition in the revise agent prompt, pointing to the correct channel: `needs_attention=true` + `needs_attention_reason` in review frontmatter, which gets posted as a visible Jira comment during submission

## Test plan
- [ ] Run `/rfe.review` on an RFE with a failing WHY criterion and verify the revise agent does not insert HTML comments
- [ ] Verify `needs_attention_reason` is set instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)