### PR TITLE
Strip all HTML comments on submit and clarify flag language

### DIFF
--- a/.claude/skills/rfe.review/prompts/revise-agent.md
+++ b/.claude/skills/rfe.review/prompts/revise-agent.md
@@ -24,13 +24,13 @@ Comments file: artifacts/rfe-tasks/{ID}-comments.md (read if it exists)
 
 **Right-sizing is a recommendation, never auto-applied.** If right_sized scored 0 or 1, do NOT remove acceptance criteria or capabilities to force a different shape.
 
-**Do not invent missing evidence.** If WHY is flagged for missing named customers, flag the gap — do not fabricate evidence.
+**Do not invent missing evidence.** If WHY is flagged for missing named customers, do not fabricate evidence — set `needs_attention=true` in Step 3 so the author is notified.
 
 **Never use HTML comments (`<!-- -->`) in the task file.** HTML comments are invisible when rendered in Jira — authors will never see them. If you need to flag something for the author, set `needs_attention=true` and `needs_attention_reason` in frontmatter (Step 3), which gets posted as a visible Jira comment during submission.
 
 For each criterion the assessor flagged:
 - **Open to HOW**: Reframe flagged sections to remove prescriptive framing while preserving useful context
-- **WHY**: Strengthen with available evidence; flag gaps the author must fill
+- **WHY**: Strengthen with available evidence; if gaps remain, set `needs_attention=true` in Step 3 so the author is notified
 - **Right-sized**: Report only — do not split or remove scope
 - **WHAT / Not a task**: Follow assessor guidance if provided
 

--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -611,14 +611,18 @@ def strip_metadata(markdown):
     - Legacy inline metadata lines (now in frontmatter):
       **Jira Key**, **Size**, **Split from**, **Priority**, **Source RFE**
     - Legacy revision notes (now in review files):
-      ### Revision Notes sections, > *Review note: ...* blockquotes,
-      <!-- REVISION NOTE: ... --> HTML comments
+      ### Revision Notes sections, > *Review note: ...* blockquotes
+    - ALL HTML comments (<!-- ... -->) — these are invisible in Jira's
+      rendered view and should never be pushed
     """
     # Strip YAML frontmatter if present
     frontmatter_match = re.match(r'^---\s*\n.*?\n---\s*\n', markdown,
                                  re.DOTALL)
     if frontmatter_match:
         markdown = markdown[frontmatter_match.end():]
+
+    # Strip all HTML comments (invisible in Jira rendered view)
+    markdown = re.sub(r'<!--.*?-->', '', markdown, flags=re.DOTALL)
 
     lines = markdown.split("\n")
     result = []
@@ -633,10 +637,6 @@ def strip_metadata(markdown):
         # Skip metadata lines (legacy inline format, now in frontmatter)
         if re.match(r'^\*\*(Jira Key|Size|Split from|Priority|'
                     r'Source RFE)\*\*:', line):
-            continue
-
-        # Skip HTML revision comments
-        if re.match(r'^\s*<!--\s*REVISION NOTE:', line):
             continue
 
         # Skip review note blockquotes


### PR DESCRIPTION
## Summary
- **jira_utils.py**: `strip_metadata()` now removes ALL HTML comments (`<!-- ... -->`) before pushing to Jira, not just `<!-- REVISION NOTE: -->`. The revise agent was generating `<!-- AUTHOR ACTION REQUIRED -->`, `<!-- TODO: -->`, and `<!-- AUTHOR ACTION NEEDED -->` variants that slipped through the narrow pattern match. 12 live Jira issues had invisible HTML comments in their descriptions (now cleaned up manually).
- **revise-agent.md**: Replaced vague "flag the gap" / "flag gaps the author must fill" language with explicit pointers to `needs_attention=true` in Step 3. The ambiguous "flag" wording is what led the agent to invent the HTML comment pattern — it interpreted "flag" as "leave a note in the file" rather than using the designated frontmatter channel.

## Test plan
- [ ] Verify `strip_metadata()` removes single-line and multi-line HTML comments
- [ ] Verify legitimate markdown content is not affected by the regex
- [ ] Run a review cycle and confirm the revise agent uses `needs_attention` instead of HTML comments for WHY gaps

Follow-up to PR #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)