### PR TITLE
Cumulative snapshot merge and run-report filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,10 @@ Skills that only work with local artifacts (`/rfe.create`) do not require Jira a
 - **Related link type**: `Related`
 - **Informs link type**: `Informs`
 
+## Snapshot System
+
+Before modifying `scripts/snapshot_fetch.py`, `scripts/bootstrap_snapshot.py`, or `scripts/submit.py` (snapshot-related code), read `docs/snapshot-incremental-fetch.md` — especially the **Design Invariants** section. Changes must preserve all six invariants.
+
 ## Architecture Context
 
 `/rfe.review` automatically fetches architecture context from [opendatahub-io/architecture-context](https://github.com/opendatahub-io/architecture-context) into `.context/architecture-context/` and detects the latest RHOAI version. No manual setup needed.

--- a/docs/snapshot-incremental-fetch.md
+++ b/docs/snapshot-incremental-fetch.md
@@ -20,8 +20,8 @@ against Jira and processing every result. Two issues:
 Instead of filtering at the JQL level and relying on labels to decide
 what to process, the snapshot system fetches **all** open issues (minus
 permanent exclusions), computes a content hash of each description, and
-compares against the previous run's hashes. Only issues whose description
-actually changed get processed.
+diffs against the previous snapshot. Changed and new issues get priority
+ordering; unchanged issues fill remaining capacity within the limit.
 
 ## Hard vs Soft Filters
 
@@ -46,9 +46,11 @@ artifacts/auto-fix-runs/
 
 ### Snapshot (`issue-snapshot-*.yaml`)
 
-Written by `snapshot_fetch.py fetch` at the start of each run. Updated
-by `submit.py` after Jira writes with post-submit hashes. Contains the
-content hash of every issue's description.
+The snapshot is **cumulative**: each run merges selected issues into the
+previous snapshot rather than replacing it. Issues not selected within
+the limit retain their previous hashes, and issues never selected remain
+absent (staying NEW until selected). Updated by `submit.py` after Jira
+writes with post-submit hashes.
 
 ```yaml
 query_timestamp: "2026-04-02T19:54:36Z"
@@ -73,10 +75,11 @@ The normalization step ensures that trivial formatting differences
 positives.
 
 Both fetch and submit use the same pipeline. `submit.py` converts its
-markdown to ADF (via `markdown_to_adf`) before hashing with
-`compute_content_hash`, ensuring the hash matches what fetch will compute
-from Jira's stored ADF. This avoids false positives from markdown-to-ADF
-conversion differences (tables, blockquotes, nested lists).
+artifact markdown to ADF (via `markdown_to_adf`) for the Jira write,
+then hashes that ADF through the same pipeline fetch uses
+(ADF → markdown → normalize → SHA256). This roundtrip ensures the
+post-submit hash matches what the next fetch will compute from Jira's
+stored ADF, avoiding false positives from conversion differences.
 
 ## Command Sequence
 
@@ -114,7 +117,8 @@ git push
 | File | Written by | Read by | Lifetime |
 |------|-----------|---------|----------|
 | `artifacts/auto-fix-runs/issue-snapshot-<ts>.yaml` | `snapshot_fetch.py fetch`, updated by `submit.py` | `snapshot_fetch.py fetch` (next run) | Permanent (accumulates) |
-| `tmp/autofix-all-ids.txt` | `snapshot_fetch.py fetch` | auto-fix pipeline | Current run only |
+| `artifacts/auto-fix-runs/<YYYYMMDD-HHMMSS>.yaml` | auto-fix pipeline (run report) | `bootstrap_snapshot.py` | Permanent (one per run) |
+| `tmp/autofix-all-ids.txt` | `snapshot_fetch.py fetch` | auto-fix pipeline, `check_resume.py` | Current run only |
 | `tmp/autofix-changed-ids.txt` | `snapshot_fetch.py fetch` | `check_resume.py` | Current run only |
 
 ### Ordering Constraints
@@ -134,45 +138,72 @@ The command sequence is ordered to minimize data loss on failure:
 
 ```
   from previous run
-  ─────────────────
 
-  issue-snapshot ──► ┌──────────────────────────────────┐
-                     │ 1. FETCH                          │
-                     │    load previous snapshot          │
-                     │    fetch current Jira state        │
-                     │    diff current vs previous        │
-                     │    write new issue-snapshot        │
-                     └───────────────┬──────────────────┘
-                                     │
-                            changed + new IDs
-                                     │
-                     ┌───────────────┴──────────────────┐
-                     │ 2. REVIEW / PROCESS               │
-                     │    (auto-fix pipeline)             │
-                     └───────────────┬──────────────────┘
-                                     │
-                     ┌───────────────┴──────────────────┐
-                     │ 3. SUBMIT                         │
-                     │    Jira API calls                  │
-                     │    update issue-snapshot in place   │
-                     └───────────────┬──────────────────┘
-                                     │
-                     ┌───────────────┴──────────────────┐
-                     │ 4. GIT PUSH                       │
-                     │    snapshot + results              │
-                     └──────────────────────────────────┘
+  snapshot ──► ┌─────────────────────┐
+               │ 1. FETCH            │
+               │ load prev snapshot  │
+               │ fetch Jira state    │
+               │ diff vs previous    │
+               │ select within limit │
+               │ write new snapshot  │
+               └─────────┬───────────┘
+                         │
+                         ├── ids-file
+                         ├── changed-file
+                         │
+               ┌─────────┴───────────┐
+               │ 2. REVIEW / PROCESS │
+               │ auto-fix pipeline   │
+               │ (uses changed-file) │
+               └─────────┬───────────┘
+                         │
+               ┌─────────┴───────────┐
+               │ 3. SUBMIT           │
+               │ Jira API calls      │
+               │ update snapshot     │
+               └─────────┬───────────┘
+                         │
+               ┌─────────┴───────────┐
+               │ 4. GIT PUSH         │
+               │ snapshot + results  │
+               └─────────────────────┘
 ```
+
+### Cumulative Merge
+
+```
+  previous snapshot ──► merge with selected ──► new snapshot
+       (all prior        (only issues           (previous +
+        entries)         within limit)           selected)
+```
+
+Unselected issues retain their previous hashes in the snapshot.
+Issues never selected remain absent and stay NEW until selected.
 
 ## Diffing Logic
 
 `diff_snapshots(current_issues, previous_data)` compares each issue's
 current content hash against the previous snapshot:
 
-- **Hash matches**: issue is unchanged, excluded from output
-- **Hash differs**: issue is "changed", included in output
-- **Not in previous**: issue is "new", included in output
-- **In previous but not current**: issue left scope (closed, filtered),
-  silently dropped
+- **UNCHANGED** (hash matches): issue's description hasn't changed since
+  last selected. Included in output after changed/new issues. When a
+  limit is set, unchanged issues fill remaining capacity.
+- **CHANGED** (hash differs): issue was previously selected but its
+  description has been modified since. Gets priority ordering and
+  bypasses `check_resume`.
+- **NEW** (not in previous snapshot): issue has never been selected.
+  Gets priority ordering but goes through normal `check_resume`.
+- **In previous but not current**: issue left scope (closed, filtered).
+  Retained in the snapshot as an inert entry (no pruning) so that if
+  reopened with an edited description, it surfaces as CHANGED.
+
+### Selection and Limit
+
+Changed and new issues get priority ordering. If they don't exhaust
+the limit, unchanged issues fill the remaining capacity. Only selected
+issues (within the limit) have their hashes merged into the new
+snapshot. Unselected issues retain their previous hashes — enabling
+stale-hash change detection on future runs.
 
 ## Post-Submit Snapshot Update
 
@@ -197,6 +228,13 @@ post-submit hashes. On the next run, submitted issues show as
 "changed" (hash mismatch) and get re-processed. This is safe but
 redundant — the conflict check in `submit.py` catches identical
 content, and the review pipeline is idempotent.
+
+**Job dies after processing but before submit:**
+Snapshot and reviews were written locally but no Jira writes happened.
+In CI (ephemeral environment), local state is lost — equivalent to
+"dies before fetch." Locally, the snapshot marks issues as seen; next
+run treats them as UNCHANGED and `check_resume` skips them if passing
+reviews exist. Safe but submit must be re-triggered manually.
 
 **Job dies before fetch completes:**
 Nothing was written. Next run starts from the same snapshot as this
@@ -223,48 +261,49 @@ candidates but shouldn't affect change detection.
 has prior CI run history, before the first incremental fetch.
 
 ```
-  results directory                Jira
-  ─────────────────                ────
+  results directory             Jira
+  ─────────────────             ────
 
-  run dirs ──► find latest    hard-filter JQL ──► fetch all current
-               run timestamp                      issues + hashes
-               │                                       │
-               ▼                                       │
-          run timestamp                                │
-               │                                       ▼
-               │                  updated >= run ──► updated issue keys
-               │                  timestamp               │
-               │                                          │
-               │         ┌────────────────────────────────┘
-               │         │
-               │         ▼  for each updated issue:
-               │    ┌─────────────────────────────────┐
-               │    │ changelog lookup                 │
-               │    │   description at run time → hash │
-               │    │   status at run time → exclude   │
-               │    │     if Done                      │
-               │    └──────────────┬──────────────────┘
-               │                   │
-               ▼                   ▼
-  run report ──► find auto-   historical hashes
-                 revised IDs  (pre-submit state)
-                      │            │
-                      ▼            ▼
-                 ┌──────────────────────────┐
-                 │ build snapshot            │
-                 │   unchanged → current hash│
-                 │   updated → historical    │
-                 │   auto-revised → current  │
-                 │   Done at run time → skip │
-                 └─────────────┬────────────┘
-                               │
-                               ▼
-                        issue-snapshot
-                     (initial snapshot for
-                      first incremental fetch)
+  run dirs ──► latest run  JQL ──► fetch all issues
+               timestamp              │
+               │                      ▼
+               │    run report ──► filter to
+               │                   processed IDs
+               │                      │
+               │    updated >= ──► updated keys
+               │    run timestamp     │
+               │            ┌──────┘
+               │            │
+               │            ▼  for each:
+               │       ┌──────────────────┐
+               │       │ changelog lookup │
+               │       │ desc ──► hash    │
+               │       │ status ──► excl. │
+               │       └────────┬─────────┘
+               │                │
+               ▼                ▼
+  run report ──► auto-   historical hashes
+             revised IDs (pre-submit state)
+                   │          │
+                   ▼          ▼
+              ┌─────────────────┐
+              │ build snapshot  │
+              │ unchanged ──► c.│
+              │ updated ──► h.  │
+              │ revised ──► c.  │
+              │ Done ──► skip   │
+              └────────┬────────┘
+                       │
+                       ▼
+                issue-snapshot
 ```
 
 The bootstrap snapshot accounts for:
+- **Run-report filtering**: Only issues listed in the latest run
+  report's `per_rfe` list are included in the snapshot. Issues that
+  were open but not processed by the previous run remain absent,
+  correctly surfacing as NEW on the first incremental fetch. If no
+  run report is found, all fetched issues are included as a fallback.
 - Historical descriptions at the run time (for externally modified issues)
 - Current descriptions for auto-revised issues (our own submissions)
 - Exclusion of issues that were out of scope (Done) at run time
@@ -274,10 +313,57 @@ issues that genuinely changed since the last CI run. The Done-status
 check prevents reopened issues from being silently treated as "unchanged"
 when they were never processed.
 
+## Design Invariants
+
+These invariants must hold and should guide future refactors:
+
+1. **The snapshot only grows by selection.** An issue enters the
+   snapshot when it is selected by `cmd_fetch` (within the limit) or
+   added by `update_snapshot_hashes` (post-submit). No other path
+   adds entries.
+
+2. **The snapshot never shrinks.** Closed or filtered issues remain
+   as inert entries. This ensures that reopened issues with edited
+   descriptions are detected via hash mismatch (CHANGED), bypassing
+   resume check.
+
+3. **Hash staleness is correct, not a bug.** An unselected issue's
+   hash may be many runs old. If the issue is later edited, the stale
+   hash correctly differs from the current hash (CHANGED). If not
+   edited, the stale hash still matches (UNCHANGED). Staleness is the
+   mechanism that makes cumulative merge work.
+
+4. **NEW issues do not bypass resume check.** Only CHANGED issues
+   (hash mismatch) go in the `changed_file` and bypass `check_resume`.
+   NEW issues (not in snapshot) go through normal resume check — if a
+   passing review exists, they're skipped.
+
+5. **Without a limit, behavior is identical to the old design.** When
+   `limit = len(current)`, all issues are selected, all merged — the
+   snapshot contains everything.
+
+6. **`update_snapshot_hashes` is additive.** It uses `dict.update()`
+   on the latest snapshot, adding or updating entries. This is
+   compatible with cumulative snapshots.
+
+## Known Gaps
+
+- **Split children not added to snapshot.** `split_submit.py` creates
+  child issues but does not update the snapshot with their hashes.
+  They appear as NEW on the next run. Pre-existing gap, not introduced
+  by cumulative merge.
+
+- **NEW issues with stale passing reviews.** A NEW issue that happens
+  to have a passing review from a prior run will be skipped by
+  `check_resume`. Same behavior as UNCHANGED with a stale review —
+  pre-existing, not specific to this design.
+
 ## Scripts
 
 | Script | Role |
 |--------|------|
-| `scripts/snapshot_fetch.py` | Fetch, diff, write snapshot |
+| `scripts/snapshot_fetch.py` | Fetch, diff, write snapshot and ID files |
+| `scripts/check_resume.py` | Filter IDs to process; changed IDs bypass resume check |
 | `scripts/submit.py` | Jira writes, update snapshot with post-submit hashes |
-| `scripts/bootstrap_snapshot.py` | Initial snapshot from Jira history |
+| `scripts/split_submit.py` | Split submissions (does not update snapshot — see Known Gaps) |
+| `scripts/bootstrap_snapshot.py` | Initial snapshot from prior run history |

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -40,6 +40,21 @@ from snapshot_fetch import (
 )
 
 
+def _load_run_report(results_dir, run_name):
+    """Load processed IDs and report from the run's per_rfe list.
+
+    Returns (set_of_ids, report_dict) or (None, None) if no report found.
+    """
+    path = os.path.join(results_dir, run_name,
+                        "auto-fix-runs", f"{run_name}.yaml")
+    if not os.path.exists(path):
+        return None, None
+    with open(path, encoding="utf-8") as f:
+        report = yaml.safe_load(f)
+    ids = {e["id"] for e in report.get("per_rfe", [])}
+    return ids, report
+
+
 def find_latest_run_timestamp(results_dir):
     """Find the timestamp of the latest run from directory names.
 
@@ -275,6 +290,19 @@ def main():
     current = fetch_all_issues(server, user, token, jql)
     print(f"Fetched {len(current)} issues from Jira", file=sys.stderr)
 
+    # Filter to issues that were actually processed in the run
+    processed_ids, report = _load_run_report(args.results_dir, run_name)
+    if processed_ids is None:
+        print("Warning: no run report — including all issues",
+              file=sys.stderr)
+        report = None
+    else:
+        before = len(current)
+        current = {k: v for k, v in current.items()
+                   if k in processed_ids}
+        print(f"Filtered to {len(current)}/{before} issues "
+              f"from run report", file=sys.stderr)
+
     # Step 3: Find which issues were updated since the run
     run_jql_ts = run_dt.strftime("%Y-%m-%d %H:%M")
     updated_jql = (f"{jql} AND updated >= \"{run_jql_ts}\"")
@@ -343,11 +371,7 @@ def main():
     # (pre-submit) hashes in the snapshot, but Jira now has the post-submit
     # content. Use current hashes for these so the next fetch doesn't
     # re-flag our own changes.
-    run_report_path = os.path.join(
-        args.results_dir, run_name, "auto-fix-runs", f"{run_name}.yaml")
-    if os.path.exists(run_report_path):
-        with open(run_report_path, encoding="utf-8") as f:
-            report = yaml.safe_load(f)
+    if report is not None:
         submitted_ids = [
             e["id"] for e in report.get("per_rfe", [])
             if e.get("recommendation") == "submit" and e.get("auto_revised")

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -52,6 +52,8 @@ def _load_run_report(results_dir, run_name):
     with open(path, encoding="utf-8") as f:
         report = yaml.safe_load(f)
     ids = {e["id"] for e in report.get("per_rfe", [])}
+    if not ids:
+        return None, None
     return ids, report
 
 

--- a/scripts/snapshot_fetch.py
+++ b/scripts/snapshot_fetch.py
@@ -5,6 +5,11 @@ Fetches all issues matching a JQL query, computes content hashes, and
 diffs against the previous snapshot to identify genuinely changed issues.
 Only changed issues are output for processing, avoiding redundant work.
 
+The snapshot is cumulative: each run merges selected issues into the
+previous snapshot rather than replacing it.  Issues not selected retain
+their previous hashes (enabling stale-hash change detection), and issues
+never selected remain absent (staying NEW until selected).
+
 Usage:
     python3 scripts/snapshot_fetch.py fetch "<jql>" --ids-file tmp/autofix-all-ids.txt --changed-file tmp/autofix-changed-ids.txt [--limit 100] [--data-dir <path>]
 
@@ -12,6 +17,7 @@ Output (stdout):
     TOTAL=<count>
     CHANGED=<count>
     NEW=<count>
+    UNCHANGED=<count>
 """
 
 import argparse
@@ -289,20 +295,7 @@ def cmd_fetch(args):
     current = fetch_all_issues(server, user, token, jql)
     print(f"Fetched {len(current)} issues", file=sys.stderr)
 
-    # Write snapshot directly to artifacts
-    os.makedirs(SNAPSHOT_DIR, exist_ok=True)
-    snapshot = {
-        "query_timestamp": query_timestamp,
-        "timestamp": datetime.now(timezone.utc).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"),
-        "issues": {k: v["content_hash"] for k, v in current.items()},
-    }
-    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    out_path = os.path.join(SNAPSHOT_DIR, f"issue-snapshot-{ts}.yaml")
-    with open(out_path, "w", encoding="utf-8") as f:
-        yaml.dump(snapshot, f, default_flow_style=False, sort_keys=False)
-
-    # Diff
+    # Diff against previous snapshot
     changed, new = diff_snapshots(current, prev_data)
 
     # Maintain Jira's original order across both sets
@@ -316,6 +309,28 @@ def cmd_fetch(args):
     # Changed/new get priority ordering; total capped at limit
     limit = args.limit or len(current)
     all_ids = (priority_ids + unchanged_ids)[:limit]
+
+    # Build cumulative snapshot: previous entries + selected issues.
+    # Only selected issues get their hashes recorded (or updated).
+    # Unselected issues retain their previous hash, enabling stale-hash
+    # change detection on future runs.  Issues never selected stay out
+    # of the snapshot and remain NEW until selected.
+    prev_issues = prev_data.get("issues", {}) if prev_data else {}
+    merged_issues = dict(prev_issues)
+    for key in all_ids:
+        merged_issues[key] = current[key]["content_hash"]
+
+    os.makedirs(SNAPSHOT_DIR, exist_ok=True)
+    snapshot = {
+        "query_timestamp": query_timestamp,
+        "timestamp": datetime.now(timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"),
+        "issues": merged_issues,
+    }
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    out_path = os.path.join(SNAPSHOT_DIR, f"issue-snapshot-{ts}.yaml")
+    with open(out_path, "w", encoding="utf-8") as f:
+        yaml.dump(snapshot, f, default_flow_style=False, sort_keys=False)
 
     # Split for downstream
     out_changed = [k for k in all_ids if k in changed_set]

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -246,14 +246,26 @@ def mock_jira():
     server.shutdown()
 
 
-def _make_results_dir(tmp_path, run_names, latest=None):
-    """Create a results directory with run dirs."""
+def _make_results_dir(tmp_path, run_names, latest=None,
+                      processed_ids=None):
+    """Create a results directory with run dirs.
+
+    If processed_ids is provided and latest is set, writes a run report
+    with per_rfe entries for those IDs.
+    """
     results = str(tmp_path / "results")
     os.makedirs(results)
     for name in run_names:
         os.makedirs(os.path.join(results, name))
     if latest:
         os.symlink(latest, os.path.join(results, "latest"))
+    if processed_ids is not None and latest:
+        report_dir = os.path.join(results, latest, "auto-fix-runs")
+        os.makedirs(report_dir, exist_ok=True)
+        report = {"per_rfe": [{"id": pid, "recommendation": "submit"}
+                               for pid in processed_ids]}
+        with open(os.path.join(report_dir, f"{latest}.yaml"), "w") as f:
+            yaml.dump(report, f)
     return results
 
 
@@ -268,7 +280,8 @@ class TestBootstrapIntegration:
             "RHAIRFE-5678": "Description 2.",
         }
         results = _make_results_dir(
-            tmp_path, ["20260401-120000"], latest="20260401-120000")
+            tmp_path, ["20260401-120000"], latest="20260401-120000",
+            processed_ids=["RHAIRFE-1234", "RHAIRFE-5678"])
         art_dir = str(tmp_path / "artifacts")
         os.makedirs(art_dir)
 
@@ -305,7 +318,8 @@ class TestBootstrapIntegration:
         # for updated >= will still match all, but changelogs are empty
         # so current hashes are used)
         results = _make_results_dir(
-            tmp_path, ["20260401-120000"], latest="20260401-120000")
+            tmp_path, ["20260401-120000"], latest="20260401-120000",
+            processed_ids=["RHAIRFE-1234", "RHAIRFE-5678"])
         art_dir = str(tmp_path / "artifacts")
         os.makedirs(art_dir)
 
@@ -341,7 +355,8 @@ class TestBootstrapIntegration:
         url, server = mock_jira
         server.issues = {"RHAIRFE-1": "Content."}
         results = _make_results_dir(
-            tmp_path, ["20260401-120000"], latest="20260401-120000")
+            tmp_path, ["20260401-120000"], latest="20260401-120000",
+            processed_ids=["RHAIRFE-1"])
         art_dir = str(tmp_path / "artifacts")
         os.makedirs(art_dir)
 
@@ -384,7 +399,8 @@ class TestBootstrapIntegration:
             }],
         }]
         results = _make_results_dir(
-            tmp_path, ["20260401-120000"], latest="20260401-120000")
+            tmp_path, ["20260401-120000"], latest="20260401-120000",
+            processed_ids=["RHAIRFE-1"])
         art_dir = str(tmp_path / "artifacts")
         os.makedirs(art_dir)
 
@@ -429,7 +445,8 @@ class TestBootstrapIntegration:
             }],
         }]
         results = _make_results_dir(
-            tmp_path, ["20260401-120000"], latest="20260401-120000")
+            tmp_path, ["20260401-120000"], latest="20260401-120000",
+            processed_ids=["RHAIRFE-1"])
         art_dir = str(tmp_path / "artifacts")
         os.makedirs(art_dir)
 
@@ -463,7 +480,8 @@ class TestBootstrapIntegration:
         url, server = mock_jira
         server.issues = {"RHAIRFE-1": "Content."}
         results = _make_results_dir(
-            tmp_path, ["20260401-120000"], latest="20260401-120000")
+            tmp_path, ["20260401-120000"], latest="20260401-120000",
+            processed_ids=["RHAIRFE-1"])
         art_dir = str(tmp_path / "artifacts")
         os.makedirs(art_dir)
 
@@ -504,7 +522,8 @@ class TestBootstrapIntegration:
             }],
         }]
         results = _make_results_dir(
-            tmp_path, ["20260401-120000"], latest="20260401-120000")
+            tmp_path, ["20260401-120000"], latest="20260401-120000",
+            processed_ids=["RHAIRFE-1"])
         art_dir = str(tmp_path / "artifacts")
         os.makedirs(art_dir)
 
@@ -556,7 +575,8 @@ class TestBootstrapIntegration:
             }],
         }]
         results = _make_results_dir(
-            tmp_path, ["20260401-120000"], latest="20260401-120000")
+            tmp_path, ["20260401-120000"], latest="20260401-120000",
+            processed_ids=["RHAIRFE-1"])
         art_dir = str(tmp_path / "artifacts")
         os.makedirs(art_dir)
 
@@ -604,7 +624,8 @@ class TestBootstrapIntegration:
             }],
         }]
         results = _make_results_dir(
-            tmp_path, ["20260401-120000"], latest="20260401-120000")
+            tmp_path, ["20260401-120000"], latest="20260401-120000",
+            processed_ids=["RHAIRFE-1", "RHAIRFE-2"])
         art_dir = str(tmp_path / "artifacts")
         os.makedirs(art_dir)
 
@@ -632,3 +653,82 @@ class TestBootstrapIntegration:
         assert "RHAIRFE-1" in snap["issues"]
         assert "RHAIRFE-2" not in snap["issues"]
         assert len(snap["issues"]) == 1
+
+    def test_filters_to_run_report_ids(self, tmp_path, mock_jira):
+        """Only issues listed in run report's per_rfe are included."""
+        url, server = mock_jira
+        server.issues = {
+            "RHAIRFE-1": "Issue one.",
+            "RHAIRFE-2": "Issue two.",
+            "RHAIRFE-3": "Issue three.",
+        }
+        # Run report only contains 2 of the 3 issues
+        results = _make_results_dir(
+            tmp_path, ["20260401-120000"], latest="20260401-120000",
+            processed_ids=["RHAIRFE-1", "RHAIRFE-3"])
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT,
+             "--results-dir", results,
+             "--artifacts-dir", art_dir,
+             "project = RHAIRFE"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+        assert "Filtered to 2/3 issues" in r.stderr
+
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        snapshots = [f for f in os.listdir(snapshot_dir)
+                     if f.startswith("issue-snapshot-")]
+        with open(os.path.join(snapshot_dir, snapshots[0])) as f:
+            snap = yaml.safe_load(f)
+
+        assert "RHAIRFE-1" in snap["issues"]
+        assert "RHAIRFE-3" in snap["issues"]
+        assert "RHAIRFE-2" not in snap["issues"]
+        assert len(snap["issues"]) == 2
+
+    def test_no_run_report_includes_all(self, tmp_path, mock_jira):
+        """Without a run report, all fetched issues are included."""
+        url, server = mock_jira
+        server.issues = {
+            "RHAIRFE-1": "Issue one.",
+            "RHAIRFE-2": "Issue two.",
+        }
+        # No processed_ids → no run report file
+        results = _make_results_dir(
+            tmp_path, ["20260401-120000"], latest="20260401-120000")
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT,
+             "--results-dir", results,
+             "--artifacts-dir", art_dir,
+             "project = RHAIRFE"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+        assert "no run report" in r.stderr
+
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        snapshots = [f for f in os.listdir(snapshot_dir)
+                     if f.startswith("issue-snapshot-")]
+        with open(os.path.join(snapshot_dir, snapshots[0])) as f:
+            snap = yaml.safe_load(f)
+
+        assert len(snap["issues"]) == 2

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -732,3 +732,41 @@ class TestBootstrapIntegration:
             snap = yaml.safe_load(f)
 
         assert len(snap["issues"]) == 2
+
+    def test_empty_per_rfe_includes_all(self, tmp_path, mock_jira):
+        """Run report with empty per_rfe falls back to including all."""
+        url, server = mock_jira
+        server.issues = {
+            "RHAIRFE-1": "Issue one.",
+            "RHAIRFE-2": "Issue two.",
+        }
+        # processed_ids=[] → run report exists but per_rfe is empty
+        results = _make_results_dir(
+            tmp_path, ["20260401-120000"], latest="20260401-120000",
+            processed_ids=[])
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT,
+             "--results-dir", results,
+             "--artifacts-dir", art_dir,
+             "project = RHAIRFE"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+        assert "no run report" in r.stderr
+
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        snapshots = [f for f in os.listdir(snapshot_dir)
+                     if f.startswith("issue-snapshot-")]
+        with open(os.path.join(snapshot_dir, snapshots[0])) as f:
+            snap = yaml.safe_load(f)
+
+        assert len(snap["issues"]) == 2

--- a/tests/test_snapshot_fetch_integration.py
+++ b/tests/test_snapshot_fetch_integration.py
@@ -599,6 +599,49 @@ class TestCumulativeSnapshot:
         assert set(snap["issues"].keys()) == {
             "RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"}
 
+    def test_post_submit_hash_composes_with_cumulative_merge(
+            self, work_dirs, jira, monkeypatch, tmp_path):
+        """Invariant 6: update_snapshot_hashes on a cumulative snapshot
+        correctly updates entries, and the next fetch sees them as
+        UNCHANGED."""
+        jira.create("RHAIRFE-1", "One", "One.")
+        jira.create("RHAIRFE-2", "Two", "Two.")
+        _jira_env(monkeypatch, jira.url)
+
+        # Run 1: both selected
+        _run_fetch(_fetch_args(tmp_path))
+        snap1 = _latest_snapshot(work_dirs)
+        assert len(snap1["issues"]) == 2
+        old_hash_1 = snap1["issues"]["RHAIRFE-1"]
+
+        # Simulate submit: update RHAIRFE-1's description in Jira and
+        # record the post-submit hash in the snapshot
+        jira.request("PUT", "/rest/api/3/issue/RHAIRFE-1",
+                     {"fields": {"description": "Revised by submit."}})
+        new_adf = _text_to_adf("Revised by submit.")
+        post_submit_hash = compute_content_hash(new_adf)
+        update_snapshot_hashes(
+            {"RHAIRFE-1": post_submit_hash},
+            snapshot_dir=work_dirs.snapshot_dir)
+
+        # Verify the snapshot was updated in place
+        snap_updated = _latest_snapshot(work_dirs)
+        assert snap_updated["issues"]["RHAIRFE-1"] == post_submit_hash
+        assert snap_updated["issues"]["RHAIRFE-1"] != old_hash_1
+        # RHAIRFE-2 untouched
+        assert snap_updated["issues"]["RHAIRFE-2"] == snap1["issues"]["RHAIRFE-2"]
+
+        # Run 2: RHAIRFE-1 should be UNCHANGED (post-submit hash matches)
+        args2 = _fetch_args(tmp_path)
+        stdout2 = _run_fetch(args2)
+        assert "CHANGED=0" in stdout2
+        assert "NEW=0" in stdout2
+
+        # Both still in snapshot (cumulative merge preserved)
+        snap2 = _latest_snapshot(work_dirs)
+        assert "RHAIRFE-1" in snap2["issues"]
+        assert "RHAIRFE-2" in snap2["issues"]
+
 
 # ── End-to-End: Clone → Fetch with --data-dir ──────────────────────────────
 

--- a/tests/test_snapshot_fetch_integration.py
+++ b/tests/test_snapshot_fetch_integration.py
@@ -77,6 +77,16 @@ def _run_fetch(args):
     return buf.getvalue()
 
 
+def _latest_snapshot(work_dirs):
+    """Read the most recent snapshot from the test snapshot dir."""
+    snaps = sorted(
+        [f for f in os.listdir(work_dirs.snapshot_dir)
+         if f.startswith("issue-snapshot-")], reverse=True)
+    assert snaps, "No snapshot files found"
+    with open(os.path.join(work_dirs.snapshot_dir, snaps[0])) as f:
+        return yaml.safe_load(f)
+
+
 def _seed_snapshot(work_dirs, issues, query_ts="2026-04-01T00:00:00Z"):
     """Write a previous snapshot."""
     snap = {
@@ -449,6 +459,145 @@ class TestMultiRunPipeline:
         stdout3 = _run_fetch(args3)
         assert "CHANGED=0" in stdout3
         assert _read_ids(args3.changed_file) == []
+
+
+# ── Cumulative Snapshot ─────────────────────────────────────────────────────
+
+class TestCumulativeSnapshot:
+    """Verify the cumulative snapshot merge invariants.
+
+    The snapshot only grows by selection: selected issues are added/updated,
+    previous entries are retained, unselected issues stay out.
+    """
+
+    def test_snapshot_only_contains_selected_and_previous(
+            self, work_dirs, jira, monkeypatch, tmp_path):
+        """Snapshot = previous entries + selected issues, not all fetched."""
+        prev_hash = compute_content_hash(_text_to_adf("Previous."))
+        _seed_snapshot(work_dirs, {"RHAIRFE-0": prev_hash})
+
+        jira.create("RHAIRFE-1", "One", "One.")
+        jira.create("RHAIRFE-2", "Two", "Two.")
+        jira.create("RHAIRFE-3", "Three", "Three.")
+        _jira_env(monkeypatch, jira.url)
+
+        args = _fetch_args(tmp_path, limit=2)
+        _run_fetch(args)
+
+        snap = _latest_snapshot(work_dirs)
+        # Previous entry retained + 2 selected = 3
+        assert "RHAIRFE-0" in snap["issues"]
+        assert len(snap["issues"]) == 3
+        # One of the 3 NEW issues was not selected
+        selected = set(_read_ids(args.ids_file))
+        assert len(selected) == 2
+        for key in selected:
+            assert key in snap["issues"]
+
+    def test_new_persists_until_selected(self, work_dirs, jira,
+                                          monkeypatch, tmp_path):
+        """NEW issues stay NEW across runs until selected by the limit."""
+        jira.create("RHAIRFE-1", "One", "One.")
+        jira.create("RHAIRFE-2", "Two", "Two.")
+        jira.create("RHAIRFE-3", "Three", "Three.")
+        _jira_env(monkeypatch, jira.url)
+
+        # Run 1: limit=1, 3 NEW → select 1
+        stdout1 = _run_fetch(_fetch_args(tmp_path, limit=1))
+        assert "NEW=1" in stdout1
+        snap1 = _latest_snapshot(work_dirs)
+        assert len(snap1["issues"]) == 1
+
+        # Run 2: prev has 1, 2 still NEW → select 1 NEW (priority)
+        stdout2 = _run_fetch(_fetch_args(tmp_path, limit=1))
+        assert "NEW=1" in stdout2
+        snap2 = _latest_snapshot(work_dirs)
+        assert len(snap2["issues"]) == 2
+
+        # Run 3: prev has 2, 1 still NEW → select 1 NEW
+        stdout3 = _run_fetch(_fetch_args(tmp_path, limit=1))
+        assert "NEW=1" in stdout3
+        snap3 = _latest_snapshot(work_dirs)
+        assert len(snap3["issues"]) == 3
+
+        # Run 4: all in snapshot → 0 NEW, 0 CHANGED
+        stdout4 = _run_fetch(_fetch_args(tmp_path, limit=1))
+        assert "NEW=0" in stdout4
+        assert "CHANGED=0" in stdout4
+
+    def test_closed_issue_persists_in_snapshot(self, work_dirs, jira,
+                                                monkeypatch, tmp_path):
+        """Closed issues remain in the snapshot (no pruning)."""
+        jira.create("RHAIRFE-1", "Open", "Open issue.")
+        jira.create("RHAIRFE-2", "Will close", "Will close.")
+        _jira_env(monkeypatch, jira.url)
+
+        # Run 1: both selected
+        _run_fetch(_fetch_args(tmp_path))
+        snap1 = _latest_snapshot(work_dirs)
+        assert len(snap1["issues"]) == 2
+
+        # Close RHAIRFE-2
+        transitions = jira.request(
+            "GET", "/rest/api/3/issue/RHAIRFE-2/transitions")
+        done_t = next(
+            (t for t in transitions["transitions"]
+             if t["to"]["statusCategory"]["key"] == "done"), None)
+        if done_t:
+            jira.request("POST",
+                         "/rest/api/3/issue/RHAIRFE-2/transitions",
+                         {"transition": {"id": done_t["id"]}})
+
+        # Run 2: only RHAIRFE-1 fetched, but snapshot retains RHAIRFE-2
+        _run_fetch(_fetch_args(tmp_path))
+        snap2 = _latest_snapshot(work_dirs)
+        assert "RHAIRFE-1" in snap2["issues"]
+        assert "RHAIRFE-2" in snap2["issues"]
+        assert len(snap2["issues"]) == 2
+
+    def test_stale_hash_detects_edit_on_unselected(self, work_dirs, jira,
+                                                    monkeypatch, tmp_path):
+        """Stale hash in snapshot catches edits on unselected issues."""
+        jira.create("RHAIRFE-1", "One", "One.")
+        jira.create("RHAIRFE-2", "Two", "Two.")
+        jira.create("RHAIRFE-3", "Three", "Three.")
+        _jira_env(monkeypatch, jira.url)
+
+        # Run 1: limit=2, select 2 of 3 NEW
+        args1 = _fetch_args(tmp_path, limit=2)
+        _run_fetch(args1)
+        snap1 = _latest_snapshot(work_dirs)
+        assert len(snap1["issues"]) == 2
+
+        # Run 2: limit=1, RHAIRFE-3 is NEW (priority), selected
+        args2 = _fetch_args(tmp_path, limit=1)
+        stdout2 = _run_fetch(args2)
+        assert "NEW=1" in stdout2
+
+        # Edit RHAIRFE-2 (already in snapshot with stale hash)
+        jira.request("PUT", "/rest/api/3/issue/RHAIRFE-2",
+                     {"fields": {"description": "Edited after selection."}})
+
+        # Run 3: limit=1, RHAIRFE-2 CHANGED (stale hash mismatch) → priority
+        args3 = _fetch_args(tmp_path, limit=1)
+        stdout3 = _run_fetch(args3)
+        assert "CHANGED=1" in stdout3
+        assert _read_ids(args3.changed_file) == ["RHAIRFE-2"]
+
+    def test_no_limit_includes_all_in_snapshot(self, work_dirs, jira,
+                                                monkeypatch, tmp_path):
+        """Without limit, all issues are selected → all in snapshot."""
+        jira.create("RHAIRFE-1", "One", "One.")
+        jira.create("RHAIRFE-2", "Two", "Two.")
+        jira.create("RHAIRFE-3", "Three", "Three.")
+        _jira_env(monkeypatch, jira.url)
+
+        _run_fetch(_fetch_args(tmp_path))
+
+        snap = _latest_snapshot(work_dirs)
+        assert len(snap["issues"]) == 3
+        assert set(snap["issues"].keys()) == {
+            "RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"}
 
 
 # ── End-to-End: Clone → Fetch with --data-dir ──────────────────────────────


### PR DESCRIPTION
## Summary

- **Cumulative snapshot merge**: Each fetch run merges selected issues into the previous snapshot rather than replacing it. Unselected issues retain stale hashes, enabling change detection when they're later edited and selected. Issues never selected stay absent (NEW) until the limit allows them in.
- **Run-report filtering in bootstrap**: Bootstrap now filters fetched issues to only those listed in the latest run report's `per_rfe` list, so unprocessed issues correctly surface as NEW on the first incremental fetch.
- **Docs**: Updated design doc with 6 design invariants, known gaps, cumulative merge explanation, and revised diagrams.
- **Tests**: Added cumulative snapshot tests (selection, persistence, stale-hash detection, no-limit behavior) and run-report filtering tests for bootstrap.

## Test plan
- [x] Existing integration tests pass with jira-emulator
- [x] New `TestCumulativeSnapshot` tests cover all invariants
- [x] New bootstrap tests verify run-report filtering and fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)