### PR TITLE
Prioritize changed issues over new when applying limit

### DIFF
--- a/scripts/snapshot_fetch.py
+++ b/scripts/snapshot_fetch.py
@@ -297,17 +297,17 @@ def cmd_fetch(args):
     # Diff against previous snapshot
     changed, new = diff_snapshots(current, prev_data)
 
-    # Maintain Jira's original order across both sets
+    # Maintain Jira's original order within each category
     changed_set = set(changed)
     new_set = set(new)
-    priority_ids = [k for k in current.keys()
-                    if k in changed_set or k in new_set]
+    changed_ids = [k for k in current.keys() if k in changed_set]
+    new_ids = [k for k in current.keys() if k in new_set]
     unchanged_ids = [k for k in current.keys()
                      if k not in changed_set and k not in new_set]
 
-    # Changed/new get priority ordering; total capped at limit
+    # Changed get highest priority, then new, then unchanged; total capped at limit
     limit = args.limit or len(current)
-    all_ids = (priority_ids + unchanged_ids)[:limit]
+    all_ids = (changed_ids + new_ids + unchanged_ids)[:limit]
 
     # Build cumulative snapshot: previous entries + selected issues.
     # Only selected issues get their hashes recorded (or updated).


### PR DESCRIPTION
## Summary
- Split the single `priority_ids` list into separate `changed_ids` and `new_ids` lists
- Order is now: changed first, then new, then unchanged (previously changed and new were interleaved in Jira fetch order)
- When the limit is small and there are many new issues, changed issues now get processed first instead of being crowded out

## Test plan
- [x] All 23 unit tests pass
- [x] All 21 integration tests pass (44 total, 0 failures)
- [ ] Verify in next CI run that changed issues appear before new in processing order

🤖 Generated with [Claude Code](https://claude.com/claude-code)