### PR TITLE
Remove bootstrap submitted-hash merge that hid changed issues

### DIFF
--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -368,27 +368,7 @@ def main():
         print(f"Excluded {done_excluded} issues (Done at run time)",
               file=sys.stderr)
 
-    # Step 5: Merge submitted hashes from run report
-    # Issues whose descriptions were changed by the run have historical
-    # (pre-submit) hashes in the snapshot, but Jira now has the post-submit
-    # content. Use current hashes for these so the next fetch doesn't
-    # re-flag our own changes.
-    if report is not None:
-        submitted_ids = [
-            e["id"] for e in report.get("per_rfe", [])
-            if e.get("auto_revised")
-            and e.get("recommendation") not in ("reject", "autorevise_reject")
-        ]
-        merged = 0
-        for key in submitted_ids:
-            if key in current and key in snapshot_issues:
-                snapshot_issues[key] = current[key]["content_hash"]
-                merged += 1
-        if merged:
-            print(f"Merged {merged} submitted hashes from run report",
-                  file=sys.stderr)
-
-    # Step 6: Write snapshot
+    # Step 5: Write snapshot
     if args.dry_run:
         print(f"\nDry run — would write snapshot with "
               f"{len(snapshot_issues)} issue hashes")

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -751,12 +751,15 @@ class TestBootstrapIntegration:
 
         assert len(snap["issues"]) == 2
 
-    def test_revise_recommendation_merges_submitted_hash(
+    def test_auto_revised_keeps_historical_hash(
             self, tmp_path, mock_jira):
-        """auto_revised issues with recommendation=revise get current hash.
+        """auto_revised issues keep historical hashes, not current.
 
-        submit.py submits all non-rejected entries, not just those with
-        recommendation=submit.  The bootstrap merge must mirror this.
+        The bootstrap should not overwrite historical hashes for
+        auto_revised issues. submit.py's update_snapshot_hashes is the
+        sole authority for recording post-submit state. The bootstrap
+        uses only changelog-derived historical hashes so that genuinely
+        changed issues are detected on the next fetch.
         """
         url, server = mock_jira
         server.issues = {
@@ -810,7 +813,6 @@ class TestBootstrapIntegration:
             capture_output=True, text=True, env=env,
         )
         assert r.returncode == 0, r.stderr
-        assert "Merged 2 submitted hashes" in r.stderr
 
         snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
         snapshots = [f for f in os.listdir(snapshot_dir)
@@ -818,15 +820,13 @@ class TestBootstrapIntegration:
         with open(os.path.join(snapshot_dir, snapshots[0])) as f:
             snap = yaml.safe_load(f)
 
-        current_hash_1 = _md_hash("Auto-revised and submitted.")
-        current_hash_2 = _md_hash("Also revised, submitted.")
+        historical_hash_1 = _md_hash("Original RHAIRFE-1.")
+        historical_hash_2 = _md_hash("Original RHAIRFE-2.")
         historical_hash_3 = _md_hash("Original RHAIRFE-3.")
 
-        # revise + auto_revised → current hash (submitted)
-        assert snap["issues"]["RHAIRFE-1"] == current_hash_1
-        # submit + auto_revised → current hash (submitted)
-        assert snap["issues"]["RHAIRFE-2"] == current_hash_2
-        # autorevise_reject → historical hash (not submitted)
+        # All three keep historical hashes — bootstrap never overwrites
+        assert snap["issues"]["RHAIRFE-1"] == historical_hash_1
+        assert snap["issues"]["RHAIRFE-2"] == historical_hash_2
         assert snap["issues"]["RHAIRFE-3"] == historical_hash_3
 
     def test_empty_per_rfe_includes_all(self, tmp_path, mock_jira):


### PR DESCRIPTION
## Summary
- Removes Step 5 from bootstrap_snapshot.py which incorrectly overwrote historical hashes with current Jira hashes for auto_revised issues
- auto_revised only means Claude edited the local artifact, not that submit.py pushed it to Jira. submit.py's update_snapshot_hashes is the sole authority for post-submit state
- This was hiding 17 genuinely changed issues from future change detection, making them permanently invisible to diff_snapshots
- Updates test to verify auto_revised issues now keep their historical hashes

## Test plan
- [x] All 28 bootstrap snapshot tests pass
- [x] Verified corrected bootstrap produces CHANGED=17 (up from 5) when diffed against current Jira state
- [x] Corrected snapshot data already pushed to results repo

Generated with [Claude Code](https://claude.com/claude-code)