### PR TITLE
Fix sed -i for GNU/Linux compatibility

### DIFF
--- a/scripts/bootstrap-assess-rfe.sh
+++ b/scripts/bootstrap-assess-rfe.sh
@@ -31,7 +31,7 @@ done
 ASSESS_SKILL=".claude/skills/assess-rfe/SKILL.md"
 if [ -f "$ASSESS_SKILL" ]; then
   ABS_CONTEXT_DIR="$(cd "$CONTEXT_DIR" && pwd)"
-  sed -i '' "s|When this skill is invoked, resolve the absolute path of the plugin root directory. This SKILL.md is at \`<plugin_root>/skills/assess-rfe/SKILL.md\` — the plugin root is two levels up. Determine this path once at the start and use it for all script and file references. Store it as \`{PLUGIN_ROOT}\` for substitution into commands and agent prompts.|The plugin root is \`$ABS_CONTEXT_DIR\`. Use this as \`{PLUGIN_ROOT}\` for all script and file references.|" "$ASSESS_SKILL"
+  sed -i "s|When this skill is invoked, resolve the absolute path of the plugin root directory. This SKILL.md is at \`<plugin_root>/skills/assess-rfe/SKILL.md\` — the plugin root is two levels up. Determine this path once at the start and use it for all script and file references. Store it as \`{PLUGIN_ROOT}\` for substitution into commands and agent prompts.|The plugin root is \`$ABS_CONTEXT_DIR\`. Use this as \`{PLUGIN_ROOT}\` for all script and file references.|" "$ASSESS_SKILL"
 fi
 
 # Install agent definitions


### PR DESCRIPTION
## Summary
- Remove empty string argument from `sed -i ''` in `bootstrap-assess-rfe.sh`
- BSD sed (macOS) requires the explicit empty backup suffix, but GNU sed (Linux) interprets it as a filename, causing the PLUGIN_ROOT substitution to silently fail in CI
- Without this fix, the assess-rfe skill retains the generic "resolve the absolute path" instruction instead of getting the hardcoded path

## Test plan
- [ ] Run bootstrap-assess-rfe.sh on Linux (CI) and verify no sed error in output
- [ ] Verify .claude/skills/assess-rfe/SKILL.md has the hardcoded PLUGIN_ROOT path after bootstrap

Generated with [Claude Code](https://claude.com/claude-code)