### PR TITLE
Add RFE_SKIP_BOOTSTRAP env var to skip dependency bootstrapping

### DIFF
--- a/scripts/bootstrap-assess-rfe.sh
+++ b/scripts/bootstrap-assess-rfe.sh
@@ -2,6 +2,11 @@
 # Ensures the assess-rfe plugin is available locally.
 # Safe to run multiple times — clones on first run, pulls updates after.
 
+if [ -n "${RFE_SKIP_BOOTSTRAP:-}" ]; then
+  echo "RFE_SKIP_BOOTSTRAP set - skipping dependency bootstrapping step"
+  exit 0
+fi
+
 CONTEXT_DIR=".context/assess-rfe"
 RUBRIC_FILE="$CONTEXT_DIR/scripts/agent_prompt.md"
 

--- a/scripts/fetch-architecture-context.sh
+++ b/scripts/fetch-architecture-context.sh
@@ -2,6 +2,11 @@
 # Fetches the latest RHOAI architecture context via sparse checkout.
 # Safe to run multiple times — pulls updates if already cloned.
 
+if [ -n "${RFE_SKIP_BOOTSTRAP:-}" ]; then
+  echo "RFE_SKIP_BOOTSTRAP set - skipping dependency bootstrapping step"
+  exit 0
+fi
+
 CONTEXT_DIR=".context/architecture-context"
 
 LATEST=$(curl -sL https://api.github.com/repos/opendatahub-io/architecture-context/contents/architecture | python3 -c "import sys,json; entries=json.load(sys.stdin); names=sorted(e['name'] for e in entries if e['name'].startswith('rhoai-')); print(names[-1] if names else '')")


### PR DESCRIPTION
## Summary
- When `RFE_SKIP_BOOTSTRAP` is set, `bootstrap-assess-rfe.sh` and `fetch-architecture-context.sh` exit immediately
- Allows CI to bootstrap dependencies once upfront, then set the env var so parallel agents don't race on git clones and pulls

## Test plan
- [ ] Verify `RFE_SKIP_BOOTSTRAP=1 bash scripts/bootstrap-assess-rfe.sh` prints skip message and exits 0
- [ ] Verify `RFE_SKIP_BOOTSTRAP=1 bash scripts/fetch-architecture-context.sh` prints skip message and exits 0
- [ ] Verify normal behavior is unchanged when env var is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)