### PR TITLE
Fix submit hang: add urllib timeout and stdout line buffering

### DIFF
--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -33,7 +33,7 @@ def make_request(url, user, token, body=None, method=None):
         headers["Content-Type"] = "application/json"
         data = json.dumps(body).encode()
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(req, timeout=30) as resp:
+    with urllib.request.urlopen(req, timeout=60) as resp:
         if resp.status == 204:
             return None
         resp_body = resp.read()

--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -33,7 +33,7 @@ def make_request(url, user, token, body=None, method=None):
         headers["Content-Type"] = "application/json"
         data = json.dumps(body).encode()
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(req) as resp:
+    with urllib.request.urlopen(req, timeout=30) as resp:
         if resp.status == 204:
             return None
         resp_body = resp.read()

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -23,6 +23,10 @@ import os
 import re
 import sys
 
+# Ensure progress output is visible immediately when stdout is redirected
+# to a file or pipe (Python defaults to full buffering in that case).
+sys.stdout.reconfigure(line_buffering=True)
+
 from jira_utils import (
     require_env,
     get_issue,

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -23,6 +23,10 @@ import re
 import subprocess
 import sys
 
+# Ensure progress output is visible immediately when stdout is redirected
+# to a file or pipe (Python defaults to full buffering in that case).
+sys.stdout.reconfigure(line_buffering=True)
+
 import yaml
 
 from jira_utils import (


### PR DESCRIPTION
## Summary
- Add `sys.stdout.reconfigure(line_buffering=True)` to `submit.py` and `split_submit.py` so progress output flushes immediately when stdout is redirected to a file/pipe
- Add `timeout=30` to `urllib.request.urlopen` in `jira_utils.py` so stalled Jira connections raise `URLError` and get retried by existing retry logic instead of blocking forever

Cherry-pick of #43 targeting ci-prod.

Generated with [Claude Code](https://claude.com/claude-code)