### PR TITLE
Fix markdown_to_adf infinite loop on malformed headings

### DIFF
--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -348,11 +348,14 @@ def markdown_to_adf(markdown):
             continue
 
         # Heading
-        heading_match = re.match(r'^(#{1,6})\s+(.+)$', line)
+        heading_match = re.match(r'^(#{1,6})\s+(.*)', line)
         if heading_match:
             level = len(heading_match.group(1))
-            text = heading_match.group(2)
-            content.append(_adf_heading(level, _parse_inline(text)))
+            text = heading_match.group(2).strip()
+            if text:
+                content.append(_adf_heading(level, _parse_inline(text)))
+            else:
+                content.append(_adf_heading(level, [_adf_text("")]))
             i += 1
             continue
 
@@ -435,6 +438,12 @@ def markdown_to_adf(markdown):
         if para_lines:
             text = " ".join(para_lines)
             content.append(_adf_paragraph(_parse_inline(text)))
+        else:
+            # Safety net: no branch matched and i was not advanced.
+            # Treat the line as a standalone paragraph to prevent
+            # infinite loops on any unrecognized line format.
+            content.append(_adf_paragraph(_parse_inline(line)))
+            i += 1
 
     return _adf_doc(content) if content else \
         _adf_doc([_adf_paragraph([_adf_text("")])])

--- a/tests/test_markdown_to_adf.py
+++ b/tests/test_markdown_to_adf.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Tests for markdown_to_adf — focused on the heading/paragraph infinite loop fix.
+
+Bug: Lines starting with # that don't match the heading regex
+(e.g. '### ' with no text, '##' with no space) caused an infinite loop
+because they were excluded from both the heading handler AND the paragraph
+accumulator, so `i` never advanced.
+"""
+import os
+import signal
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from jira_utils import markdown_to_adf
+
+
+# ── Timeout helper ──────────────────────────────────────────────────────────
+
+class _Timeout(Exception):
+    pass
+
+
+def _timeout_handler(signum, frame):
+    raise _Timeout("markdown_to_adf did not complete within timeout")
+
+
+@pytest.fixture(autouse=True)
+def enforce_timeout():
+    """Kill any test that takes longer than 5 seconds — catches infinite loops."""
+    old_handler = signal.signal(signal.SIGALRM, _timeout_handler)
+    signal.alarm(5)
+    yield
+    signal.alarm(0)
+    signal.signal(signal.SIGALRM, old_handler)
+
+
+# ── Well-formed markdown (behavior must not change) ────────────────────────
+
+class TestWellFormedHeadings:
+    def test_h1(self):
+        result = markdown_to_adf("# Hello")
+        assert result["content"][0]["type"] == "heading"
+        assert result["content"][0]["attrs"]["level"] == 1
+        assert result["content"][0]["content"][0]["text"] == "Hello"
+
+    def test_h3(self):
+        result = markdown_to_adf("### Sub-heading")
+        assert result["content"][0]["type"] == "heading"
+        assert result["content"][0]["attrs"]["level"] == 3
+        assert result["content"][0]["content"][0]["text"] == "Sub-heading"
+
+    def test_h6(self):
+        result = markdown_to_adf("###### Deep")
+        assert result["content"][0]["type"] == "heading"
+        assert result["content"][0]["attrs"]["level"] == 6
+
+    def test_heading_with_inline_formatting(self):
+        result = markdown_to_adf("## **Bold heading**")
+        heading = result["content"][0]
+        assert heading["type"] == "heading"
+        assert heading["attrs"]["level"] == 2
+
+    def test_paragraph_text(self):
+        result = markdown_to_adf("Just some text")
+        assert result["content"][0]["type"] == "paragraph"
+        assert result["content"][0]["content"][0]["text"] == "Just some text"
+
+    def test_mixed_content(self):
+        md = "## Title\n\nSome text\n\n### Section\n\nMore text"
+        result = markdown_to_adf(md)
+        types = [node["type"] for node in result["content"]]
+        assert types == ["heading", "paragraph", "heading", "paragraph"]
+
+
+# ── Malformed headings that caused infinite loops ──────────────────────────
+
+class TestMalformedHeadings:
+    """Lines starting with # that don't match the heading regex."""
+
+    def test_hash_space_no_text(self):
+        """'### ' with trailing space but no text — the CI trigger."""
+        result = markdown_to_adf("### ")
+        assert result["content"][0]["type"] == "heading"
+        assert result["content"][0]["attrs"]["level"] == 3
+
+    def test_hash_space_no_text_h1(self):
+        result = markdown_to_adf("# ")
+        assert result["content"][0]["type"] == "heading"
+        assert result["content"][0]["attrs"]["level"] == 1
+
+    def test_hash_space_no_text_h6(self):
+        result = markdown_to_adf("###### ")
+        assert result["content"][0]["type"] == "heading"
+        assert result["content"][0]["attrs"]["level"] == 6
+
+    def test_hashes_no_space(self):
+        """'##' with no space — not a valid heading, should be paragraph."""
+        result = markdown_to_adf("##")
+        assert result["content"][0]["type"] == "paragraph"
+        assert result["content"][0]["content"][0]["text"] == "##"
+
+    def test_hash_text_no_space(self):
+        """'#text' — no space after hash, should be paragraph."""
+        result = markdown_to_adf("#text")
+        assert result["content"][0]["type"] == "paragraph"
+        assert result["content"][0]["content"][0]["text"] == "#text"
+
+    def test_seven_hashes(self):
+        """'#######' — too many hashes, should be paragraph."""
+        result = markdown_to_adf("#######")
+        assert result["content"][0]["type"] == "paragraph"
+        assert result["content"][0]["content"][0]["text"] == "#######"
+
+    def test_seven_hashes_with_space_and_text(self):
+        """'####### text' — too many hashes, should be paragraph."""
+        result = markdown_to_adf("####### text")
+        assert result["content"][0]["type"] == "paragraph"
+        assert result["content"][0]["content"][0]["text"] == "####### text"
+
+    def test_hash_only(self):
+        """Just '#' — no space, should be paragraph."""
+        result = markdown_to_adf("#")
+        assert result["content"][0]["type"] == "paragraph"
+        assert result["content"][0]["content"][0]["text"] == "#"
+
+
+# ── Real CI failure patterns ──────────────────────────────────────────────
+
+class TestCIFailurePatterns:
+    """Reproduce the exact patterns from the 2026-04-04 CI run."""
+
+    def test_heading_marker_then_bold_text(self):
+        """The exact pattern from RHAIRFE-1461 et al."""
+        md = "### \n**Proposed Solution/Rationale**"
+        result = markdown_to_adf(md)
+        types = [node["type"] for node in result["content"]]
+        assert "heading" in types
+        assert "paragraph" in types
+
+    def test_multiple_malformed_in_sequence(self):
+        """Multiple malformed headings in a row."""
+        md = "### \n## \n# \nSome text"
+        result = markdown_to_adf(md)
+        assert len(result["content"]) == 4  # 3 empty headings + 1 paragraph
+
+    def test_malformed_heading_in_blockquote(self):
+        """Blockquote prefix stripping can produce malformed headings."""
+        md = "> ### \n> **Some text**"
+        result = markdown_to_adf(md)
+        bq = result["content"][0]
+        assert bq["type"] == "blockquote"
+        assert len(bq["content"]) >= 1
+
+    def test_full_document_with_malformed_headings(self):
+        """Simulates a full RFE with the problematic pattern throughout."""
+        md = (
+            "## Summary\n\n"
+            "Some summary text.\n\n"
+            "### \n"
+            "**Problem Statement**\n\n"
+            "The problem is described here.\n\n"
+            "### \n"
+            "**Acceptance Criteria**\n\n"
+            "- Criterion one\n"
+            "- Criterion two\n\n"
+            "### \n"
+            "**Scope**\n\n"
+            "In scope items.\n"
+        )
+        result = markdown_to_adf(md)
+        assert len(result["content"]) > 0
+        # Verify we got headings, paragraphs, and a bullet list
+        types = [node["type"] for node in result["content"]]
+        assert "heading" in types
+        assert "paragraph" in types
+        assert "bulletList" in types
+
+
+# ── Safety net tests ──────────────────────────────────────────────────────
+
+class TestSafetyNet:
+    """Verify the defensive fallback handles any unrecognized line."""
+
+    def test_deeply_nested_hashes(self):
+        """10 hashes — way beyond valid heading range."""
+        result = markdown_to_adf("##########")
+        assert result["content"][0]["type"] == "paragraph"
+
+    def test_hash_with_only_whitespace(self):
+        """'#   ' — hash followed by spaces only."""
+        result = markdown_to_adf("#   ")
+        assert result["content"][0]["type"] == "heading"
+        assert result["content"][0]["attrs"]["level"] == 1


### PR DESCRIPTION
## Summary

- Fixes infinite loop in `markdown_to_adf` when input contains lines like `### ` (heading marker with trailing space but no text) — the heading regex required `.+` (at least one char) so these fell through all checks without advancing `i`
- Adds a defensive safety net so no unrecognized line format can ever cause an infinite loop
- This was the root cause of the CI submit job hanging indefinitely on the 2026-04-04 run

## Test plan

- [x] 20 new unit tests in `tests/test_markdown_to_adf.py` covering well-formed headings, all malformed patterns, exact CI failure reproductions, and safety net edge cases
- [x] All tests use a 5-second SIGALRM timeout fixture to catch infinite loops
- [x] Full test suite passes (215/215 including jira-emulator integration tests)
- [x] Verified against all 6 affected RFE files from the CI artifact dump — all complete in <1ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)