### PR TITLE
Add split guardrails: cap leaf children and reduce correction cycles

### DIFF
--- a/.claude/skills/rfe.split/SKILL.md
+++ b/.claude/skills/rfe.split/SKILL.md
@@ -84,7 +84,9 @@ If there are children to review, invoke `/rfe.review` as an inline Skill, passin
 
 This triggers the full agent delegation review pipeline on all children.
 
-## Step 3: Right-sizing Self-Correction (up to 3 cycles)
+## Step 3: Right-sizing Self-Correction (up to 1 cycle)
+
+Limited to 1 cycle because repeated re-splitting compounds child count (e.g. 5 → 9) and produces diminishing returns — if decomposition is still wrong after one correction, it needs human judgment.
 
 Initialize the correction cycle counter on disk (set-default is safe if compression causes re-entry — it won't reset an existing counter):
 
@@ -98,7 +100,7 @@ After `/rfe.review` completes on children, re-read config and parent IDs (contex
 python3 scripts/state.py read tmp/split-config.yaml
 ```
 
-If `correction_cycle` is 3 or higher, stop and report remaining right-sizing concerns. Otherwise, re-derive child IDs:
+If `correction_cycle` is 1 or higher, stop and report remaining right-sizing concerns. Otherwise, re-derive child IDs:
 
 ```bash
 python3 scripts/collect_children.py $(python3 scripts/state.py read-ids tmp/split-all-ids.txt)
@@ -124,7 +126,7 @@ After each cycle, increment the counter on disk:
 python3 scripts/state.py set tmp/split-config.yaml correction_cycle=<N+1>
 ```
 
-Re-read config before starting the next cycle to check the counter. Stop after 3 cycles and report remaining right-sizing concerns.
+Re-read config before starting the next cycle to check the counter. Stop after 1 cycle and report remaining right-sizing concerns.
 
 **Do not re-split for non-Right-sized criteria.** This loop only corrects grouping mistakes caught by the Right-sized score. Other criteria are handled by `/rfe.review`'s auto-revision.
 

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -55,6 +55,8 @@ from artifact_utils import (
     ValidationError,
 )
 
+MAX_LEAF_CHILDREN = 6
+
 
 # ─── Recovery / State Detection ──────────────────────────────────────────────
 
@@ -370,6 +372,12 @@ def main():
         print("Error: No child RFEs found with parent_key="
               f"{args.parent_key}.", file=sys.stderr)
         sys.exit(1)
+
+    if len(child_tasks) > MAX_LEAF_CHILDREN:
+        print(f"Error: {args.parent_key} has {len(child_tasks)} leaf children "
+              f"(max {MAX_LEAF_CHILDREN}). Refusing to submit — requires "
+              f"human review.", file=sys.stderr)
+        sys.exit(2)
 
     # Build children list: (rfe_id, title, priority, artifact_path)
     children = []

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -157,10 +157,11 @@ def main():
     # Find RHAIRFE parents that were split (Archived + have children)
     child_parent_keys = {data.get("parent_key") for _, data in tasks
                          if data.get("parent_key")}
-    split_parents = [data["rfe_id"] for _, data in tasks
-                     if data.get("status") == "Archived"
-                     and data["rfe_id"].startswith("RHAIRFE-")
-                     and data["rfe_id"] in child_parent_keys]
+    split_parent_data = {data["rfe_id"]: data for _, data in tasks
+                         if data.get("status") == "Archived"
+                         and data["rfe_id"].startswith("RHAIRFE-")
+                         and data["rfe_id"] in child_parent_keys}
+    split_parents = list(split_parent_data.keys())
 
     if split_parents:
         print(f"Phase 1: Submitting {len(split_parents)} split parent(s)\n")
@@ -174,7 +175,41 @@ def main():
                 cmd.append("--dry-run")
             print(f"--- {parent_key} ---")
             result = subprocess.run(cmd)
-            if result.returncode != 0:
+            if result.returncode == 2:
+                # Too many children — record refusal, flag for human review
+                print(f"  {parent_key}: Split refused — too many children")
+                review_path = os.path.join(args.artifacts_dir, "rfe-reviews",
+                                           f"{parent_key}-review.md")
+                attn_reason = (
+                    "Automatic splitting produced too many child RFEs. "
+                    "The decomposition needs human review to determine "
+                    "the right granularity."
+                )
+                update_frontmatter(review_path, {
+                    "error": "split_refused: too many leaf children",
+                    "needs_attention": True,
+                    "needs_attention_reason": attn_reason,
+                }, "rfe-review")
+
+                # Reuse the existing helper for the Jira comment
+                parent_labels = (split_parent_data[parent_key]
+                                 .get("original_labels") or [])
+                refusal_entry = {
+                    "rfe_id": parent_key,
+                    "attn_reason": attn_reason,
+                    "original_labels": parent_labels,
+                }
+                refusal_results = {parent_key: parent_key}
+                _post_needs_attention_comment(
+                    server, user, token, refusal_entry,
+                    refusal_results, args.dry_run)
+
+                # Add label (helper only posts comment)
+                if not args.dry_run:
+                    add_labels(server, user, token, parent_key,
+                               ["rfe-creator-needs-attention"])
+                continue
+            elif result.returncode != 0:
                 print(f"Error: split_submit.py failed for {parent_key} "
                       f"(exit code {result.returncode})", file=sys.stderr)
                 sys.exit(result.returncode)

--- a/tests/test_split_submit.py
+++ b/tests/test_split_submit.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Tests for scripts/split_submit.py — max children guardrail."""
+import os
+import subprocess
+import sys
+
+import pytest
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts",
+                      "split_submit.py")
+
+
+def _write(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+
+
+PARENT_TASK = """\
+---
+rfe_id: RHAIRFE-1000
+title: Parent RFE
+priority: Major
+status: Archived
+---
+
+## Problem Statement
+
+Original parent content.
+"""
+
+CHILD_TASK = """\
+---
+rfe_id: RFE-{num:03d}
+title: Child RFE {num}
+priority: Major
+status: Ready
+parent_key: RHAIRFE-1000
+---
+
+## Problem Statement
+
+Child {num} content.
+"""
+
+
+def _run_split_submit(artifacts_dir, parent_key="RHAIRFE-1000"):
+    """Run split_submit.py --dry-run and return result."""
+    env = {
+        **os.environ,
+        "JIRA_SERVER": "",
+        "JIRA_USER": "",
+        "JIRA_TOKEN": "",
+    }
+    return subprocess.run(
+        [sys.executable, SCRIPT, parent_key, "--dry-run",
+         "--artifacts-dir", artifacts_dir],
+        capture_output=True, text=True, env=env,
+    )
+
+
+@pytest.fixture
+def art_dir(tmp_path):
+    """Create a minimal artifacts directory."""
+    for d in ["rfe-tasks", "rfe-reviews"]:
+        os.makedirs(tmp_path / d)
+    orig = os.getcwd()
+    os.chdir(tmp_path)
+    yield str(tmp_path)
+    os.chdir(orig)
+
+
+class TestMaxLeafChildren:
+    def test_exits_code_2_when_over_limit(self, art_dir):
+        """More than MAX_LEAF_CHILDREN → exit code 2."""
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", PARENT_TASK)
+        for i in range(1, 8):  # 7 children > 6 limit
+            _write(f"{art_dir}/rfe-tasks/RFE-{i:03d}.md",
+                   CHILD_TASK.format(num=i))
+
+        result = _run_split_submit(art_dir)
+        assert result.returncode == 2
+        assert "Refusing to submit" in result.stderr
+        assert "requires human review" in result.stderr
+        assert "7 leaf children" in result.stderr
+
+    def test_accepts_at_limit(self, art_dir):
+        """Exactly MAX_LEAF_CHILDREN → proceeds (no exit code 2)."""
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", PARENT_TASK)
+        for i in range(1, 7):  # 6 children = limit
+            _write(f"{art_dir}/rfe-tasks/RFE-{i:03d}.md",
+                   CHILD_TASK.format(num=i))
+
+        result = _run_split_submit(art_dir)
+        # Should not exit with code 2 (may fail for other reasons
+        # in dry-run without Jira creds, but NOT the cap)
+        assert result.returncode != 2
+        assert "Refusing to submit" not in result.stderr
+
+    def test_accepts_under_limit(self, art_dir):
+        """Fewer than MAX_LEAF_CHILDREN → proceeds."""
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", PARENT_TASK)
+        for i in range(1, 4):  # 3 children
+            _write(f"{art_dir}/rfe-tasks/RFE-{i:03d}.md",
+                   CHILD_TASK.format(num=i))
+
+        result = _run_split_submit(art_dir)
+        assert result.returncode != 2
+        assert "Refusing to submit" not in result.stderr

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -277,6 +277,80 @@ class TestRemoveLabels:
         assert "Would remove labels" in stdout
 
 
+class TestSplitRefusal:
+    """Tests for submit.py handling split_submit.py exit code 2."""
+
+    PARENT_TASK = (
+        "---\nrfe_id: RHAIRFE-1000\ntitle: Parent RFE\n"
+        "priority: Major\nstatus: Archived\n---\n\nParent content.\n"
+    )
+
+    CHILD_TASK_TPL = (
+        "---\nrfe_id: RFE-{num:03d}\ntitle: Child RFE {num}\n"
+        "priority: Major\nstatus: Ready\n"
+        "parent_key: RHAIRFE-1000\n---\n\nChild {num} content.\n"
+    )
+
+    REVIEW = (
+        "---\nrfe_id: RHAIRFE-1000\nscore: 9\npass: true\n"
+        "recommendation: submit\nfeasibility: feasible\n"
+        "auto_revised: false\nneeds_attention: false\n"
+        "scores:\n  what: 2\n  why: 2\n  open_to_how: 2\n"
+        "  not_a_task: 2\n  right_sized: 1\n---\n\nLooks good.\n"
+    )
+
+    def _setup_oversized_split(self, art_dir, num_children=7):
+        """Create a parent with too many children to trigger refusal."""
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md", self.REVIEW)
+        for i in range(1, num_children + 1):
+            _write(f"{art_dir}/rfe-tasks/RFE-{i:03d}.md",
+                   self.CHILD_TASK_TPL.format(num=i))
+
+    def test_refusal_sets_frontmatter_fields(self, art_dir):
+        """Exit code 2 → needs_attention + reason + error in review."""
+        self._setup_oversized_split(art_dir)
+
+        stdout, stderr, rc = _run_submit(art_dir)
+        assert rc == 0  # submit.py continues after refusal
+
+        assert "Split refused" in stdout
+
+        # Check review frontmatter was updated
+        import yaml
+        review_path = f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md"
+        with open(review_path) as f:
+            content = f.read()
+        end = content.index("---", 3)
+        fm = yaml.safe_load(content[3:end])
+        assert fm["needs_attention"] is True
+        assert "too many child RFEs" in fm["needs_attention_reason"]
+        assert fm["error"] == "split_refused: too many leaf children"
+
+    def test_refusal_prints_needs_attention(self, art_dir):
+        """Exit code 2 → dry-run prints needs-attention comment."""
+        self._setup_oversized_split(art_dir)
+
+        stdout, stderr, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert "Would post needs-attention comment" in stdout
+
+    def test_refusal_continues_processing(self, art_dir):
+        """Refused split doesn't abort — other RFEs still submitted."""
+        self._setup_oversized_split(art_dir)
+
+        # Add a regular (non-split) RFE that should still be processed
+        _write(f"{art_dir}/rfe-tasks/RFE-099.md",
+               TASK_FM.format(rfe_id="RFE-099"))
+        _write(f"{art_dir}/rfe-reviews/RFE-099-review.md",
+               REVIEW_FM.format(rfe_id="RFE-099", auto_revised="false"))
+
+        stdout, stderr, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert "Split refused" in stdout
+        assert "Would create" in stdout  # RFE-099 still processed
+
+
 class TestSnapshotUpdate:
     """Tests for snapshot update after submission."""
 


### PR DESCRIPTION
## Summary
- Hard cap of 6 leaf children in `split_submit.py` (exit code 2 when exceeded) — constant is hardcoded, not overridable by CLI or LLM
- Reduce right-sizing correction cycles from 3 to 1 in the split skill — if decomposition is still wrong after one correction, it needs human judgment
- `submit.py` handles refusal gracefully: sets `needs_attention` + `needs_attention_reason` + `error` in review frontmatter, posts a Jira comment, adds `rfe-creator-needs-attention` label, and continues processing remaining RFEs

## Test plan
- [x] `split_submit.py` exits code 2 when >6 children (3 tests: over/at/under limit)
- [x] `submit.py` sets all three frontmatter fields on refusal
- [x] Dry-run prints needs-attention comment intent
- [x] Refusal doesn't abort — remaining RFEs still processed
- [x] Full test suite passes (221 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)