### PR TITLE
Log selected issue IDs at start of auto-fix run

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -42,6 +42,7 @@ python3 scripts/state.py write-ids tmp/autofix-changed-ids.txt
 If no IDs and no JQL query, stop with usage instructions.
 
 Output: `[AUTOFIX] Step 0: Parsed N IDs (C changed, W new, U unchanged), batch_size=M`
+Then read `tmp/autofix-all-ids.txt` and output: `[AUTOFIX] Selected IDs: <space-separated list>`
 
 ## Step 1: Bootstrap Pre-flight
 


### PR DESCRIPTION
## Summary
- Adds a line to the auto-fix skill prompt so the LLM prints the full list of selected issue IDs after step 0 parsing
- IDs are already in `tmp/autofix-all-ids.txt` from `snapshot_fetch.py` — the LLM just reads and prints them
- No script changes needed

## Test plan
- [x] Verified the IDs file is written by `snapshot_fetch.py` before this log line executes
- [x] Prompt-only change — no code to break

🤖 Generated with [Claude Code](https://claude.com/claude-code)