### PR TITLE
Add conflict detection to split submission

### DIFF
--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -38,6 +38,8 @@ from jira_utils import (
     get_transitions,
     do_transition,
     markdown_to_adf,
+    adf_to_markdown,
+    normalize_for_compare,
     text_to_adf_paragraph,
     archival_comment_adf,
     strip_metadata,
@@ -393,6 +395,35 @@ def main():
     for i, (rfe_id, title, priority, _) in enumerate(children, 1):
         print(f"  {i}. {rfe_id}: {title} (Priority: {priority})")
     print()
+
+    # Check for Jira conflicts on the parent before starting
+    if not args.dry_run:
+        original_path = os.path.join(
+            args.artifacts_dir, "rfe-originals", f"{args.parent_key}.md")
+        if os.path.exists(original_path):
+            try:
+                with open(original_path, encoding="utf-8") as f:
+                    orig_snap = normalize_for_compare(f.read())
+                issue = get_issue(server, user, token, args.parent_key,
+                                  fields=["description"])
+                desc_raw = issue.get("fields", {}).get("description")
+                if isinstance(desc_raw, dict):
+                    jira_desc = normalize_for_compare(
+                        adf_to_markdown(desc_raw))
+                elif desc_raw is None:
+                    jira_desc = ""
+                else:
+                    jira_desc = normalize_for_compare(str(desc_raw))
+                if orig_snap != jira_desc:
+                    print(f"Error: {args.parent_key} description was modified "
+                          f"in Jira since fetch. Refusing to split — requires "
+                          f"human review.", file=sys.stderr)
+                    sys.exit(3)
+            except SystemExit:
+                raise
+            except Exception as e:
+                print(f"Warning: conflict check failed for "
+                      f"{args.parent_key}: {e}", file=sys.stderr)
 
     # Discover state (skip for dry-run without credentials)
     if args.dry_run and not all([server, user, token]):

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -209,6 +209,38 @@ def main():
                     add_labels(server, user, token, parent_key,
                                ["rfe-creator-needs-attention"])
                 continue
+            elif result.returncode == 3:
+                # Jira conflict — parent modified since fetch
+                print(f"  {parent_key}: Split refused — Jira conflict")
+                review_path = os.path.join(args.artifacts_dir, "rfe-reviews",
+                                           f"{parent_key}-review.md")
+                attn_reason = (
+                    "Parent RFE description was modified in Jira since "
+                    "fetch. Split submission skipped to avoid "
+                    "overwriting human edits."
+                )
+                update_frontmatter(review_path, {
+                    "error": "split_refused: jira conflict",
+                    "needs_attention": True,
+                    "needs_attention_reason": attn_reason,
+                }, "rfe-review")
+
+                parent_labels = (split_parent_data[parent_key]
+                                 .get("original_labels") or [])
+                refusal_entry = {
+                    "rfe_id": parent_key,
+                    "attn_reason": attn_reason,
+                    "original_labels": parent_labels,
+                }
+                refusal_results = {parent_key: parent_key}
+                _post_needs_attention_comment(
+                    server, user, token, refusal_entry,
+                    refusal_results, args.dry_run)
+
+                if not args.dry_run:
+                    add_labels(server, user, token, parent_key,
+                               ["rfe-creator-needs-attention"])
+                continue
             elif result.returncode != 0:
                 print(f"Error: split_submit.py failed for {parent_key} "
                       f"(exit code {result.returncode})", file=sys.stderr)

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -506,3 +506,90 @@ class TestSnapshotUpdate:
             data = yaml.safe_load(f)
         # Snapshot untouched — still just the original issue
         assert data["issues"] == {"RHAIRFE-1234": "existing"}
+
+
+class TestSplitConflictDetection:
+    """Integration test: split_submit.py detects parent conflict."""
+
+    SPLIT_SCRIPT = os.path.join(os.path.dirname(__file__), "..",
+                                "scripts", "split_submit.py")
+
+    PARENT_TASK = (
+        "---\nrfe_id: RHAIRFE-1000\ntitle: Parent RFE\n"
+        "priority: Major\nstatus: Archived\n---\n\nOriginal content.\n"
+    )
+    CHILD_TASK = (
+        "---\nrfe_id: RFE-001\ntitle: Child RFE\n"
+        "priority: Major\nstatus: Ready\n"
+        "parent_key: RHAIRFE-1000\n---\n\nChild content.\n"
+    )
+
+    def test_conflict_exits_code_3(self, art_dir, jira):
+        """Parent modified in Jira since fetch → exit code 3."""
+        # Jira has different content than our original
+        jira.create("RHAIRFE-1000", "Parent RFE", "Edited by someone.")
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1000.md",
+               "Original content.")
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md", self.CHILD_TASK)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": jira.url,
+            "JIRA_USER": "admin",
+            "JIRA_TOKEN": "admin",
+        }
+        r = subprocess.run(
+            [sys.executable, self.SPLIT_SCRIPT, "RHAIRFE-1000",
+             "--artifacts-dir", art_dir],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 3
+        assert "modified in Jira since fetch" in r.stderr
+
+    def test_no_conflict_proceeds(self, art_dir, jira):
+        """Parent unchanged in Jira → no conflict exit."""
+        body = "Original content."
+        jira.create("RHAIRFE-1000", "Parent RFE", body)
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1000.md", body)
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md", self.CHILD_TASK)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": jira.url,
+            "JIRA_USER": "admin",
+            "JIRA_TOKEN": "admin",
+        }
+        r = subprocess.run(
+            [sys.executable, self.SPLIT_SCRIPT, "RHAIRFE-1000",
+             "--artifacts-dir", art_dir],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode != 3
+
+    def test_submit_handles_conflict_refusal(self, art_dir, jira):
+        """submit.py handles split conflict (exit 3) gracefully."""
+        # Parent in Jira has different content than our original
+        jira.create("RHAIRFE-1000", "Parent RFE", "Edited by someone.")
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1000.md",
+               "Original content.")
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md", self.CHILD_TASK)
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md",
+               _review("RHAIRFE-1000"))
+
+        r = _run_submit(art_dir, jira.url)
+        assert r.returncode == 0  # continues after refusal
+        assert "Jira conflict" in r.stdout
+
+        # Check review frontmatter was updated
+        fm = _read_frontmatter(
+            f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md")
+        assert fm["needs_attention"] is True
+        assert "modified in Jira" in fm["needs_attention_reason"]
+        assert fm["error"] == "split_refused: jira conflict"
+
+        # Check needs-attention label was added
+        issue = jira.get("RHAIRFE-1000")
+        assert "rfe-creator-needs-attention" in issue["fields"]["labels"]


### PR DESCRIPTION
## Summary
- `split_submit.py` checks parent's Jira description against `rfe-originals/` snapshot before starting — exits code 3 if modified since fetch
- `submit.py` handles exit code 3: sets `needs_attention` + reason + error in review frontmatter, posts Jira comment, adds `rfe-creator-needs-attention` label, continues processing remaining RFEs
- Prevents split submission from archiving stale content and closing a parent that was edited by a human

## Test plan
- [x] `split_submit.py` exits code 3 when parent description differs from snapshot (integration test against jira-emulator)
- [x] `split_submit.py` proceeds normally when parent is unchanged
- [x] `submit.py` handles exit code 3 gracefully — sets frontmatter, posts comment, adds label, continues
- [x] Full test suite passes (224 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)