### PR TITLE
Inherit parent components and labels when splitting RFEs

### DIFF
--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -123,7 +123,7 @@ def add_comment(server, user, token, issue_key, body_adf):
 
 
 def create_issue(server, user, token, project, issue_type, summary,
-                 description_adf, priority, labels=None):
+                 description_adf, priority, labels=None, components=None):
     """POST /rest/api/3/issue — returns the created issue key."""
     body = {
         "fields": {
@@ -136,6 +136,8 @@ def create_issue(server, user, token, project, issue_type, summary,
     }
     if labels:
         body["fields"]["labels"] = labels
+    if components:
+        body["fields"]["components"] = [{"name": c} for c in components]
     result = api_call_with_retry(server, "/issue", user, token, body=body)
     return result["key"]
 

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -83,6 +83,8 @@ class SubmissionState:
         self.phase2_done = {}   # child_index -> created Jira key
         self.parent_closed = False
         self.total_children = 0
+        self.parent_components = []  # inherited by children
+        self.parent_labels = []      # non-automation labels inherited
 
 
 def discover_state(server, user, token, parent_key, expected_children):
@@ -113,9 +115,9 @@ def discover_state(server, user, token, parent_key, expected_children):
             state.phase2_done[idx] = created_key
             continue
 
-    # 2. Check issue links for "Issue split" outward links
+    # 2. Check issue links, components, and labels
     issue = get_issue(server, user, token, parent_key,
-                      ["issuelinks", "status"])
+                      ["issuelinks", "status", "components", "labels"])
     for link in issue.get("fields", {}).get("issuelinks", []):
         if link.get("type", {}).get("name") != "Issue split":
             continue
@@ -127,6 +129,16 @@ def discover_state(server, user, token, parent_key, expected_children):
         for idx, (_, title, _, _) in enumerate(expected_children, 1):
             if title == child_summary and idx not in state.phase2_done:
                 state.phase2_done[idx] = child_key
+
+    # Capture parent's components and non-automation labels for inheritance
+    state.parent_components = [
+        c["name"] for c in
+        issue.get("fields", {}).get("components", [])
+    ]
+    state.parent_labels = [
+        l for l in issue.get("fields", {}).get("labels", [])
+        if not l.startswith("rfe-creator-")
+    ]
 
     # 3. Check parent status
     status_cat = (issue.get("fields", {}).get("status", {})
@@ -200,20 +212,27 @@ def phase2_create_link(server, user, token, parent_key, children, state,
         if review_rec == "submit":
             labels.append("rfe-creator-autofix-rubric-pass")
 
+        # Inherit non-automation labels from parent
+        labels = state.parent_labels + labels
+
         if dry_run:
             print(f"  Phase 2: Would create RHAIRFE ticket for child "
                   f"{idx}/{total}: {title} (priority: {priority})")
             print(f"           Labels: {', '.join(labels)}")
+            if state.parent_components:
+                print(f"           Components: "
+                      f"{', '.join(state.parent_components)}")
             print(f"           Would link to {parent_key} via 'Issue split'")
             if attn_reason:
                 print(f"           Would post needs-attention comment")
             state.phase2_done[idx] = "RHAIRFE-DRY"
             continue
 
-        # 1. Create ticket with labels
+        # 1. Create ticket with labels and inherited components
         child_key = create_issue(server, user, token, "RHAIRFE",
                                  "Feature Request", title, description_adf,
-                                 priority, labels=labels)
+                                 priority, labels=labels,
+                                 components=state.parent_components)
         print(f"  Phase 2: Created {child_key} for child {idx}/{total}: "
               f"{title}")
         print(f"           Labels: {', '.join(labels)}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,8 @@ def jira(jira_emu):
         url = jira_emu
 
         @staticmethod
-        def create(key, summary, description, labels=None):
+        def create(key, summary, description, labels=None,
+                   components=None):
             """Import an issue with a specific key."""
             issue = {
                 "key": key,
@@ -106,6 +107,8 @@ def jira(jira_emu):
             }
             if labels:
                 issue["labels"] = labels
+            if components:
+                issue["components"] = [{"name": c} for c in components]
             _jira_request(jira_emu, "POST", "/api/admin/import",
                           {"issues": [issue]})
 

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -593,3 +593,69 @@ class TestSplitConflictDetection:
         # Check needs-attention label was added
         issue = jira.get("RHAIRFE-1000")
         assert "rfe-creator-needs-attention" in issue["fields"]["labels"]
+
+
+class TestSplitFieldInheritance:
+    """Integration test: children inherit parent's components and labels."""
+
+    SPLIT_SCRIPT = os.path.join(os.path.dirname(__file__), "..",
+                                "scripts", "split_submit.py")
+
+    PARENT_TASK = (
+        "---\nrfe_id: RHAIRFE-1000\ntitle: Parent RFE\n"
+        "priority: Major\nstatus: Archived\n---\n\nParent content.\n"
+    )
+    CHILD_TASK_TPL = (
+        "---\nrfe_id: RFE-{num:03d}\ntitle: Child RFE {num}\n"
+        "priority: Major\nstatus: Ready\n"
+        "parent_key: RHAIRFE-1000\n---\n\nChild {num} content.\n"
+    )
+
+    def test_children_inherit_components_and_labels(self, art_dir, jira):
+        """Split children get parent's components and non-automation labels."""
+        jira.create("RHAIRFE-1000", "Parent RFE", "Parent content.",
+                    labels=["3.5-candidate", "rfe-creator-auto-revised"],
+                    components=["AI Safety"])
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1000.md",
+               "Parent content.")
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               self.CHILD_TASK_TPL.format(num=1))
+        _write(f"{art_dir}/rfe-tasks/RFE-002.md",
+               self.CHILD_TASK_TPL.format(num=2))
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": jira.url,
+            "JIRA_USER": "admin",
+            "JIRA_TOKEN": "admin",
+        }
+        r = subprocess.run(
+            [sys.executable, self.SPLIT_SCRIPT, "RHAIRFE-1000",
+             "--artifacts-dir", art_dir],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+
+        # Find the created children
+        issues = jira.search("project = RHAIRFE",
+                             fields="key,labels,components")
+        children = [i for i in issues
+                    if i["key"] != "RHAIRFE-1000"]
+        assert len(children) == 2
+
+        for child in children:
+            child_detail = jira.get(child["key"])
+            labels = child_detail["fields"]["labels"]
+            components = [c["name"] for c in
+                          child_detail["fields"].get("components", [])]
+
+            # Should inherit non-automation label
+            assert "3.5-candidate" in labels
+            # Should NOT inherit automation labels
+            assert "rfe-creator-auto-revised" not in labels
+            # Should have its own automation labels
+            assert "rfe-creator-auto-created" in labels
+            assert "rfe-creator-split-result" in labels
+            # Should inherit component
+            assert "AI Safety" in components


### PR DESCRIPTION
## Summary
- `split_submit.py` now fetches the parent's components and labels during state discovery and passes them to each child ticket at creation time
- Non-automation labels (anything not prefixed `rfe-creator-`) are inherited; automation labels are not (children get their own)
- Components are inherited as-is
- Added `components` parameter to `create_issue()` in `jira_utils.py`

## Test plan
- [x] Integration test: parent with component "AI Safety" and label "3.5-candidate" → children inherit both
- [x] Automation labels (`rfe-creator-auto-revised`) are NOT inherited
- [x] Children still get their own automation labels (`rfe-creator-auto-created`, `rfe-creator-split-result`)
- [x] Full test suite passes (225 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)