### PR TITLE
Format split summary comment with clickable issue links

### DIFF
--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -261,6 +261,37 @@ def phase2_create_link(server, user, token, parent_key, children, state,
         state.phase2_done[idx] = child_key
 
 
+def build_split_summary_adf(server, children, state, total):
+    """Build ADF for the split summary comment with inlineCard smart links."""
+    list_items = []
+    for idx, (_, title, _, _) in enumerate(children, 1):
+        child_key = state.phase2_done[idx]
+        url = f"{server.rstrip('/')}/browse/{child_key}"
+        list_items.append({
+            "type": "listItem",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "inlineCard", "attrs": {"url": url}},
+                {"type": "text", "text": f": {title}"},
+            ]}]
+        })
+    return {
+        "type": "doc", "version": 1,
+        "content": [
+            {"type": "paragraph", "content": [
+                {"type": "text", "text": "[RFE Creator]",
+                 "marks": [{"type": "em"}]},
+                {"type": "text", "text": f" This RFE has been split into "
+                                         f"{total} child RFEs:"},
+            ]},
+            {"type": "bulletList", "content": list_items},
+            {"type": "paragraph", "content": [
+                {"type": "text",
+                 "text": "Original content preserved in comments above."},
+            ]},
+        ]
+    }
+
+
 def phase3_close(server, user, token, parent_key, children, state, dry_run):
     """Close the parent ticket with resolution Obsolete."""
     if state.parent_closed:
@@ -309,18 +340,9 @@ def phase3_close(server, user, token, parent_key, children, state, dry_run):
                   fields={"resolution": {"name": "Obsolete"}})
     print(f"  Phase 3: Transitioned {parent_key} to Closed (Obsolete)")
 
-    # Post summary comment
-    child_lines = []
-    for idx, (_, title, _, _) in enumerate(children, 1):
-        child_key = state.phase2_done[idx]
-        child_lines.append(f"- {child_key}: {title}")
-    summary = (
-        f"[RFE Creator] This RFE has been split into {total} child RFEs:\n"
-        + "\n".join(child_lines)
-        + "\n\nOriginal content preserved in comments above."
-    )
-    add_comment(server, user, token, parent_key,
-                text_to_adf_paragraph(summary))
+    # Post summary comment with smart-linked child keys
+    summary_adf = build_split_summary_adf(server, children, state, total)
+    add_comment(server, user, token, parent_key, summary_adf)
     print(f"  Phase 3: Posted summary comment")
 
 

--- a/tests/test_split_submit.py
+++ b/tests/test_split_submit.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-"""Tests for scripts/split_submit.py — max children guardrail."""
+"""Tests for scripts/split_submit.py — guardrails and ADF output."""
 import os
 import subprocess
 import sys
 
 import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+from split_submit import build_split_summary_adf, SubmissionState
 
 SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts",
                       "split_submit.py")
@@ -107,3 +110,47 @@ class TestMaxLeafChildren:
         result = _run_split_submit(art_dir)
         assert result.returncode != 2
         assert "Refusing to submit" not in result.stderr
+
+
+class TestSplitSummaryAdf:
+    def test_produces_inline_cards(self):
+        """Summary ADF uses inlineCard nodes for child keys."""
+        state = SubmissionState()
+        state.phase2_done = {1: "RHAIRFE-100", 2: "RHAIRFE-101"}
+        children = [
+            ("RFE-001", "First child", "Major", "/fake/path1"),
+            ("RFE-002", "Second child", "Major", "/fake/path2"),
+        ]
+        adf = build_split_summary_adf(
+            "https://jira.example.com", children, state, 2)
+
+        # Top-level structure
+        assert adf["type"] == "doc"
+        content = adf["content"]
+        assert len(content) == 3  # paragraph, bulletList, paragraph
+        assert content[1]["type"] == "bulletList"
+
+        # Correct number of list items
+        items = content[1]["content"]
+        assert len(items) == 2
+
+        # Each item has inlineCard with correct URL
+        for i, item in enumerate(items):
+            para = item["content"][0]
+            inline_card = para["content"][0]
+            assert inline_card["type"] == "inlineCard"
+            expected_key = state.phase2_done[i + 1]
+            assert inline_card["attrs"]["url"] == \
+                f"https://jira.example.com/browse/{expected_key}"
+
+    def test_strips_trailing_slash(self):
+        """Trailing slash on server URL does not produce double slash."""
+        state = SubmissionState()
+        state.phase2_done = {1: "RHAIRFE-100"}
+        children = [("RFE-001", "Child", "Major", "/fake/path")]
+        adf = build_split_summary_adf(
+            "https://jira.example.com/", children, state, 1)
+
+        item = adf["content"][1]["content"][0]
+        url = item["content"][0]["content"][0]["attrs"]["url"]
+        assert "//" not in url.replace("https://", "")


### PR DESCRIPTION
## Summary
- Split summary comment on the parent now renders child RFE keys as clickable Jira smart links using ADF `inlineCard` nodes
- Extracted `build_split_summary_adf()` helper for testability
- Defensive `rstrip("/")` on server URL to prevent double slashes

## Test plan
- [x] Full test suite passes (227 tests)
- [x] Unit test: correct number of list items, inlineCard URLs match expected keys
- [x] Unit test: trailing slash on server URL stripped
- [x] Manual verification: test comment posted to Jira, confirmed smart links render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)