### PR TITLE
Polish HTML report and add --generate-report to submit.py

### DIFF
--- a/scripts/generate_review_pdf.py
+++ b/scripts/generate_review_pdf.py
@@ -477,19 +477,33 @@ def main():
     }
     .score-table {
         width: 100%;
-        border-collapse: collapse;
+        border-collapse: separate;
+        border-spacing: 0;
         font-size: 9pt;
+        border-radius: 4pt;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.12);
+        overflow: hidden;
     }
+    .score-table thead tr:first-child th:first-child { border-top-left-radius: 4pt; }
+    .score-table thead tr:first-child th:last-child { border-top-right-radius: 4pt; }
     .score-table th {
         background: #0f3460;
         color: white;
-        padding: 4pt 8pt;
+        padding: 4pt 13pt 4pt 13pt;
         text-align: left;
         font-weight: 600;
+        border: 1px solid #0f3460;
     }
     .score-table td {
-        padding: 3pt 8pt;
-        border-bottom: 1px solid #eee;
+        padding: 3pt 8pt 3pt 13pt;
+        border-top: 1px solid #eee;
+    }
+    .score-table td:first-child { border-left: 1px solid #a0b0c0; }
+    .score-table td:last-child { border-right: 1px solid #a0b0c0; }
+    .score-table tr:last-child td { border-bottom: 1px solid #a0b0c0; }
+    .score-table th:first-child,
+    .score-table td:first-child {
+        width: 50%;
     }
     .score-table tr:nth-child(even) { background: #fafafa; }
     .criterion { font-weight: 600; color: #333; }
@@ -577,20 +591,30 @@ def main():
     .stat-arrow { font-size: 18pt; color: #999; }
     .summary-table {
         width: 100%;
-        border-collapse: collapse;
+        border-collapse: separate;
+        border-spacing: 0;
         font-size: 9pt;
         margin: 12pt 0;
+        border-radius: 4pt;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.12);
+        overflow: hidden;
     }
+    .summary-table thead tr:first-child th:first-child { border-top-left-radius: 4pt; }
+    .summary-table thead tr:first-child th:last-child { border-top-right-radius: 4pt; }
     .summary-table th {
         background: #0f3460;
         color: white;
-        padding: 5pt 8pt;
+        padding: 5pt 13pt 5pt 13pt;
         text-align: left;
+        border: 1px solid #0f3460;
     }
     .summary-table td {
-        padding: 4pt 8pt;
-        border-bottom: 1px solid #eee;
+        padding: 4pt 8pt 4pt 13pt;
+        border-top: 1px solid #eee;
     }
+    .summary-table td:first-child { border-left: 1px solid #a0b0c0; }
+    .summary-table td:last-child { border-right: 1px solid #a0b0c0; }
+    .summary-table tr:last-child td { border-bottom: 1px solid #a0b0c0; }
     .summary-table tr:nth-child(even) { background: #fafafa; }
     .key-col {
         font-family: monospace;
@@ -709,7 +733,7 @@ def main():
         <h1>RFE Review &amp; Remediation Report</h1>
         <p class="subtitle">{", ".join(subtitle_parts)}</p>
 
-        <h3>Existing RFEs</h3>
+        <h3><a href="#section-existing" class="jira-link">Existing RFEs</a></h3>
         <div class="summary-stats">
             <div class="stat-box">
                 <div class="stat-value">{ex_before_passing}/{ex_scored}</div>
@@ -717,7 +741,7 @@ def main():
             </div>
             <div class="stat-arrow">&rarr;</div>
             <div class="stat-box">
-                <div class="stat-value">{ex_after_passing}/{ex_scored}</div>
+                <div class="stat-value">{ex_after_passing}/{ex_scored}{' <span style="color:#2d6a2d;">&#x2191;</span>' if ex_after_passing > ex_before_passing else ''}</div>
                 <div class="stat-label">Passing After</div>
             </div>
             <div class="stat-box">
@@ -726,7 +750,7 @@ def main():
             </div>
             <div class="stat-arrow">&rarr;</div>
             <div class="stat-box">
-                <div class="stat-value">{ex_avg_after:.1f}</div>
+                <div class="stat-value">{ex_avg_after:.1f}{' <span style="color:#2d6a2d;">&#x2191;</span>' if ex_avg_after > ex_avg_before else ''}</div>
                 <div class="stat-label">Avg Score After</div>
             </div>
 {f"""            <div class="stat-box" style="border-color: #e67e22;">
@@ -734,7 +758,7 @@ def main():
                 <div class="stat-label">Errors</div>
             </div>""" if ex_errors else ''}
         </div>
-{f"""        <h3>Split RFEs</h3>
+{f"""        <h3><a href="#section-splits" class="jira-link">Split RFEs</a></h3>
         <div class="summary-stats">
             <div class="stat-box">
                 <div class="stat-value">{len(split_parents)}</div>
@@ -903,7 +927,7 @@ def main():
         return rows
 
     if existing:
-        html += f'''        <tr><td colspan="8" style="background:#e8eaf6;font-weight:700;font-size:9pt;padding:6pt 8pt;color:#0f3460;">Existing RFEs ({len(existing)})</td></tr>
+        html += f'''        <tr id="section-existing"><td colspan="8" style="background:#e8eaf6;font-weight:700;font-size:9pt;padding:6pt 8pt;color:#0f3460;">Existing RFEs ({len(existing)})</td></tr>
 '''
         html += render_table_rows(existing)
 
@@ -913,12 +937,12 @@ def main():
         if sp_error_count:
             sp_header += f', {sp_error_count} refused'
         sp_header += ')'
-        html += f'''        <tr><td colspan="8" style="background:#fff3e0;font-weight:700;font-size:9pt;padding:6pt 8pt;color:#e65100;">{sp_header}</td></tr>
+        html += f'''        <tr id="section-splits"><td colspan="8" style="background:#fff3e0;font-weight:700;font-size:9pt;padding:6pt 8pt;color:#e65100;">{sp_header}</td></tr>
 '''
         html += render_split_parent_rows(split_parents)
 
     if intermediaries:
-        html += f'''        <tr><td colspan="8" style="background:#fff8e1;font-weight:700;font-size:9pt;padding:6pt 8pt;color:#f57f17;">Re-split (superseded) ({len(intermediaries)})</td></tr>
+        html += f'''        <tr><td colspan="8" style="background:#fff8e1;font-weight:700;font-size:9pt;padding:6pt 8pt;color:#f57f17;">Re-split Intermediaries ({len(intermediaries)}) &mdash; superseded by children</td></tr>
 '''
         for r in intermediaries:
             leaves = get_leaf_descendants(r['rfe_id'])
@@ -1122,17 +1146,27 @@ def main():
                         child_prefix = prefix + ('    ' if last else '&#x2502;   ')
                         tree_html += render_tree(c['rfe_id'], child_prefix, last, highlight_id)
                     else:
-                        pass_icon = '&#x2713;' if c['after_pass'] else '&#x2717;'
-                        pass_color = '#2d6a2d' if c['after_pass'] else '#c0392b'
-                        tree_html += f'<div style="white-space:pre;font-family:monospace;font-size:9pt;line-height:1.6;">{prefix}{connector}{hl_start}<a href="#{c["rfe_id"]}" style="color:#0f3460;">{html_escape(c["rfe_id"])}</a>  {html_escape(c["title"])} ({c["after_total"]}/10) <span style="color:{pass_color};font-weight:700;">{pass_icon}</span>{hl_end}</div>\n'
+                        if c.get('parent_refused'):
+                            score_style = 'color:#999;font-style:italic;'
+                            suffix = ' not submitted'
+                        elif c['after_pass']:
+                            score_style = 'color:#2d6a2d;font-weight:700;'
+                            suffix = ''
+                        else:
+                            score_style = 'color:#c0392b;font-weight:700;'
+                            suffix = ''
+                        tree_html += f'<div style="white-space:pre;font-family:monospace;font-size:9pt;line-height:1.6;">{prefix}{connector}{hl_start}<a href="#{c["rfe_id"]}" style="color:#0f3460;">{html_escape(c["rfe_id"])}</a> <span style="{score_style}">[{c["after_total"]}/10]{suffix}</span>  {html_escape(c["title"])}{hl_end}</div>\n'
                 return tree_html
 
             # For intermediaries, show the full tree from the root ancestor
             tree_root = find_tree_root(r) if r.get('is_intermediary') else r
-            highlight_id = r['rfe_id'] if r.get('is_intermediary') else None
+            highlight_id = r['rfe_id']
+            root_hl = (tree_root['rfe_id'] == highlight_id)
+            hl_start = '<span style="background:#fff3cd;padding:1pt 4pt;border-radius:3pt;">' if root_hl else ''
+            hl_end = ' &#x25C0;</span>' if root_hl else ''
             html += '            <div style="background:#f8f9fa;border:1px solid #dee2e6;border-radius:6pt;padding:10pt 14pt;margin-bottom:14pt;">\n'
             # Root node
-            html += f'<div style="white-space:pre;font-family:monospace;font-size:9pt;line-height:1.6;font-weight:700;">{html_escape(tree_root["rfe_id"])}  {html_escape(tree_root["title"])} ({tree_root["before_total"]}/10)</div>\n'
+            html += f'<div style="white-space:pre;font-family:monospace;font-size:9pt;line-height:1.6;font-weight:700;">{hl_start}<a href="#{tree_root["rfe_id"]}" style="color:inherit;">{html_escape(tree_root["rfe_id"])}</a>  {html_escape(tree_root["title"])} ({tree_root["before_total"]}/10){hl_end}</div>\n'
             html += render_tree(tree_root['rfe_id'], highlight_id=highlight_id)
             html += '            </div>\n'
 
@@ -1202,7 +1236,7 @@ def main():
             if tree_root['rfe_id'] != r['rfe_id']:
                 html += '            <h3>Split Tree</h3>\n'
                 html += '            <div style="background:#f8f9fa;border:1px solid #dee2e6;border-radius:6pt;padding:10pt 14pt;margin-bottom:14pt;">\n'
-                html += f'<div style="white-space:pre;font-family:monospace;font-size:9pt;line-height:1.6;font-weight:700;">{html_escape(tree_root["rfe_id"])}  {html_escape(tree_root["title"])} ({tree_root["before_total"]}/10)</div>\n'
+                html += f'<div style="white-space:pre;font-family:monospace;font-size:9pt;line-height:1.6;font-weight:700;"><a href="#{tree_root["rfe_id"]}" style="color:inherit;">{html_escape(tree_root["rfe_id"])}</a>  {html_escape(tree_root["title"])} ({tree_root["before_total"]}/10)</div>\n'
                 html += render_tree(tree_root['rfe_id'], highlight_id=r['rfe_id'])
                 html += '            </div>\n'
 

--- a/scripts/generate_review_pdf.py
+++ b/scripts/generate_review_pdf.py
@@ -11,10 +11,7 @@ import yaml
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from artifact_utils import find_artifact_file_including_archived, read_frontmatter
 
-ARTIFACTS = os.path.join(os.path.dirname(__file__), '..', 'artifacts')
-REVIEWS_DIR = os.path.join(ARTIFACTS, 'rfe-reviews')
-TASKS_DIR = os.path.join(ARTIFACTS, 'rfe-tasks')
-ORIGINALS_DIR = os.path.join(ARTIFACTS, 'rfe-originals')
+DEFAULT_ARTIFACTS = os.path.join(os.path.dirname(__file__), '..', 'artifacts')
 
 def get_revision_history(body):
     """Extract revision history section from review body."""
@@ -39,18 +36,18 @@ def parse_before_scores(revision_history, after_scores):
             before[key] = before_val
     return before
 
-def read_removed_context(rfe_id):
+def read_removed_context(rfe_id, tasks_dir):
     """Read removed-context YAML file if it exists."""
-    path = os.path.join(TASKS_DIR, f'{rfe_id}-removed-context.yaml')
+    path = os.path.join(tasks_dir, f'{rfe_id}-removed-context.yaml')
     if not os.path.exists(path):
         return None
     with open(path) as f:
         return yaml.safe_load(f)
 
-def generate_diff(rfe_id):
+def generate_diff(rfe_id, tasks_dir, originals_dir):
     """Generate unified diff between original and revised RFE."""
-    orig = os.path.join(ORIGINALS_DIR, f'{rfe_id}.md')
-    revised = os.path.join(TASKS_DIR, f'{rfe_id}.md')
+    orig = os.path.join(originals_dir, f'{rfe_id}.md')
+    revised = os.path.join(tasks_dir, f'{rfe_id}.md')
     if not os.path.exists(orig) or not os.path.exists(revised):
         return None
 
@@ -145,19 +142,26 @@ def main():
                              '(summary table still shows all)')
     parser.add_argument('--output', type=str, default=None,
                         help='Output file path (default: artifacts/review-report.html)')
+    parser.add_argument('--artifacts-dir', type=str, default=None,
+                        help='Artifacts directory (default: ../artifacts relative to script)')
     args = parser.parse_args()
+
+    artifacts_dir = args.artifacts_dir or DEFAULT_ARTIFACTS
+    reviews_dir = os.path.join(artifacts_dir, 'rfe-reviews')
+    tasks_dir = os.path.join(artifacts_dir, 'rfe-tasks')
+    originals_dir = os.path.join(artifacts_dir, 'rfe-originals')
 
     jira_server = os.environ.get('JIRA_SERVER', '').rstrip('/')
 
     rfes = []
-    review_files = sorted([f for f in os.listdir(REVIEWS_DIR) if f.endswith('-review.md')])
+    review_files = sorted([f for f in os.listdir(reviews_dir) if f.endswith('-review.md')])
 
     for rf in review_files:
         rfe_id = rf.replace('-review.md', '')
-        review_fm, review_body = read_frontmatter(os.path.join(REVIEWS_DIR, rf))
+        review_fm, review_body = read_frontmatter(os.path.join(reviews_dir, rf))
 
         task_path = find_artifact_file_including_archived(
-            os.path.dirname(TASKS_DIR), rfe_id)
+            os.path.dirname(tasks_dir), rfe_id)
         task_fm = {}
         if task_path and os.path.exists(task_path):
             task_fm, _ = read_frontmatter(task_path)
@@ -180,8 +184,8 @@ def main():
         before_pass = before_total >= 7 and all(v > 0 for v in before_scores.values())
         after_pass = review_fm.get('pass', False)
 
-        diff_text = generate_diff(rfe_id)
-        removed_context = read_removed_context(rfe_id)
+        diff_text = generate_diff(rfe_id, tasks_dir, originals_dir)
+        removed_context = read_removed_context(rfe_id, tasks_dir)
 
         error = review_fm.get('error')
 
@@ -1325,7 +1329,7 @@ window.addEventListener('scroll', function() {
 </html>
 '''
 
-    output_path = args.output or os.path.join(ARTIFACTS, 'review-report.html')
+    output_path = args.output or os.path.join(artifacts_dir, 'review-report.html')
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
     with open(output_path, 'w') as f:
         f.write(html)

--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -3,6 +3,7 @@
 
 import argparse
 import os
+import re
 import sys
 from datetime import datetime, timezone
 
@@ -11,16 +12,27 @@ import yaml
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from artifact_utils import find_review_file, read_frontmatter, scan_task_files
 
-ARTIFACTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                             "..", "artifacts")
+DEFAULT_ARTIFACTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                    "..", "artifacts")
 SCORE_FIELDS = ["what", "why", "open_to_how", "not_a_task", "right_sized"]
 
 
-def build_report(rfe_ids, start_time, batch_size, retried_ids, retry_success_ids):
+def _parse_run_id(start_time):
+    """Derive run_id from a timestamp. Accepts YYYYMMDD-HHMMSS or ISO format."""
+    if re.match(r'^\d{8}-\d{6}$', start_time):
+        return start_time
+    return (datetime.fromisoformat(start_time.replace("Z", "+00:00"))
+            .strftime("%Y%m%d-%H%M%S"))
+
+
+def build_report(rfe_ids, start_time, batch_size, retried_ids, retry_success_ids,
+                 artifacts_dir=None):
+    if artifacts_dir is None:
+        artifacts_dir = DEFAULT_ARTIFACTS_DIR
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     # Build parent->children map from task files
     children_map = {}
-    for _, task_data in scan_task_files(ARTIFACTS_DIR):
+    for _, task_data in scan_task_files(artifacts_dir):
         parent = task_data.get("parent_key")
         if parent:
             children_map.setdefault(parent, []).append(task_data["rfe_id"])
@@ -36,7 +48,7 @@ def build_report(rfe_ids, start_time, batch_size, retried_ids, retry_success_ids
     counts = {"passed": 0, "failed": 0, "split": 0, "errors": 0}
 
     for rfe_id in expanded_ids:
-        review_path = find_review_file(ARTIFACTS_DIR, rfe_id)
+        review_path = find_review_file(artifacts_dir, rfe_id)
         if not review_path:
             per_rfe.append({"id": rfe_id, "error": "review file not found"})
             counts["errors"] += 1
@@ -97,8 +109,7 @@ def build_report(rfe_ids, start_time, batch_size, retried_ids, retry_success_ids
         return round(sum(lst) / len(lst), 1) if lst else 0.0
 
     report = {
-        "run_id": datetime.fromisoformat(start_time.replace("Z", "+00:00"))
-                  .strftime("%Y%m%d-%H%M%S"),
+        "run_id": _parse_run_id(start_time),
         "started": start_time,
         "completed": now,
         "batch_size": batch_size,
@@ -124,21 +135,33 @@ def build_report(rfe_ids, start_time, batch_size, retried_ids, retry_success_ids
 
 def main():
     parser = argparse.ArgumentParser(description="Generate auto-fix run report")
-    parser.add_argument("--start-time", required=True, help="ISO timestamp")
+    parser.add_argument("--start-time", required=True,
+                        help="Timestamp (YYYYMMDD-HHMMSS or ISO format)")
     parser.add_argument("--batch-size", type=int, default=5)
     parser.add_argument("--retried", default="", help="Comma-separated retried IDs")
     parser.add_argument("--retry-successes", default="",
                         help="Comma-separated retry success IDs")
-    parser.add_argument("rfe_ids", nargs="+", help="RFE IDs to include")
+    parser.add_argument("--artifacts-dir", default=None,
+                        help="Artifacts directory (default: ../artifacts relative to script)")
+    parser.add_argument("rfe_ids", nargs="*", help="RFE IDs (default: scan review files)")
     args = parser.parse_args()
+
+    artifacts_dir = args.artifacts_dir or DEFAULT_ARTIFACTS_DIR
+
+    # If no IDs provided, scan review files
+    if not args.rfe_ids:
+        reviews_dir = os.path.join(artifacts_dir, "rfe-reviews")
+        args.rfe_ids = [f.replace("-review.md", "")
+                        for f in sorted(os.listdir(reviews_dir))
+                        if f.endswith("-review.md")]
 
     retried = [x for x in args.retried.split(",") if x]
     retry_ok = [x for x in args.retry_successes.split(",") if x]
 
     report = build_report(args.rfe_ids, args.start_time, args.batch_size,
-                          retried, retry_ok)
+                          retried, retry_ok, artifacts_dir=artifacts_dir)
 
-    out_dir = os.path.join(ARTIFACTS_DIR, "auto-fix-runs")
+    out_dir = os.path.join(artifacts_dir, "auto-fix-runs")
     os.makedirs(out_dir, exist_ok=True)
     out_path = os.path.join(out_dir, f"{report['run_id']}.yaml")
 

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -29,6 +29,7 @@ sys.stdout.reconfigure(line_buffering=True)
 
 import yaml
 
+from generate_run_report import _parse_run_id
 from jira_utils import (
     require_env,
     create_issue,
@@ -136,7 +137,16 @@ def main():
                         help="Print planned actions without making API calls")
     parser.add_argument("--artifacts-dir", default="artifacts",
                         help="Artifacts directory (default: artifacts)")
+    parser.add_argument("--generate-report", action="store_true",
+                        help="Generate YAML and HTML reports after submission")
+    parser.add_argument("--report-timestamp",
+                        help="Run timestamp for report naming "
+                             "(required with --generate-report)")
     args = parser.parse_args()
+
+    if args.generate_report and not args.report_timestamp:
+        parser.error("--report-timestamp is required when "
+                     "--generate-report is set")
 
     server, user, token = require_env()
 
@@ -546,6 +556,39 @@ def main():
     # Rebuild index
     rebuild_index(args.artifacts_dir)
     print(f"Done. Index rebuilt at {args.artifacts_dir}/rfes.md")
+
+    # Generate reports if requested
+    if args.generate_report:
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        ts = args.report_timestamp
+        run_id = _parse_run_id(ts)
+
+        print("\nGenerating reports...")
+
+        # YAML report
+        yaml_cmd = [sys.executable,
+                    os.path.join(script_dir, "generate_run_report.py"),
+                    "--start-time", ts,
+                    "--artifacts-dir", args.artifacts_dir]
+        result = subprocess.run(yaml_cmd, capture_output=True, text=True)
+        if result.returncode == 0:
+            print(f"  YAML report: {result.stdout.strip()}")
+        else:
+            print(f"Warning: YAML report generation failed: "
+                  f"{result.stderr}", file=sys.stderr)
+
+        # HTML report
+        html_output = os.path.join(args.artifacts_dir, "auto-fix-runs",
+                                   f"{run_id}-report.html")
+        html_cmd = [sys.executable,
+                    os.path.join(script_dir, "generate_review_pdf.py"),
+                    "--revised-only",
+                    "--artifacts-dir", args.artifacts_dir,
+                    "--output", html_output]
+        result = subprocess.run(html_cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"Warning: HTML report generation failed: "
+                  f"{result.stderr}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -7,7 +7,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
-from generate_run_report import build_report
+from generate_run_report import build_report, _parse_run_id
 
 TASK_TEMPLATE = """\
 ---
@@ -56,7 +56,7 @@ def art_dir(tmp_path, monkeypatch):
     for d in ["rfe-tasks", "rfe-reviews"]:
         os.makedirs(tmp_path / "artifacts" / d)
     import generate_run_report
-    monkeypatch.setattr(generate_run_report, "ARTIFACTS_DIR",
+    monkeypatch.setattr(generate_run_report, "DEFAULT_ARTIFACTS_DIR",
                         str(tmp_path / "artifacts"))
     return str(tmp_path / "artifacts")
 
@@ -156,3 +156,99 @@ class TestSplitChildrenIncluded:
 
         assert len(report["per_rfe"]) == 1
         assert report["per_rfe"][0]["id"] == "RHAIRFE-1234"
+
+
+class TestParseRunId:
+    def test_yyyymmdd_hhmmss_format(self):
+        """YYYYMMDD-HHMMSS passes through unchanged."""
+        assert _parse_run_id("20260404-170041") == "20260404-170041"
+
+    def test_iso_format(self):
+        """ISO timestamp is converted to YYYYMMDD-HHMMSS."""
+        assert _parse_run_id("2026-04-04T17:00:41Z") == "20260404-170041"
+
+    def test_iso_format_with_offset(self):
+        """ISO timestamp with UTC offset."""
+        assert _parse_run_id("2026-04-04T17:00:41+00:00") == "20260404-170041"
+
+
+class TestScanReviewFiles:
+    def test_build_report_with_artifacts_dir(self, art_dir):
+        """build_report accepts artifacts_dir parameter."""
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               TASK_TEMPLATE.format(rfe_id="RHAIRFE-1234", extra=""))
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               REVIEW_TEMPLATE.format(rfe_id="RHAIRFE-1234", score=9,
+                                      pass_val="true", recommendation="submit",
+                                      right_sized=2))
+
+        report = build_report(["RHAIRFE-1234"], "20260404-170041", 5,
+                              [], [], artifacts_dir=art_dir)
+
+        assert report["run_id"] == "20260404-170041"
+        assert len(report["per_rfe"]) == 1
+
+    def test_cli_scan_review_files(self, tmp_path):
+        """When no IDs passed on CLI, scan review files."""
+        art = str(tmp_path / "artifacts")
+        for d in ["rfe-tasks", "rfe-reviews"]:
+            os.makedirs(os.path.join(art, d))
+        _write(f"{art}/rfe-tasks/RHAIRFE-100.md",
+               TASK_TEMPLATE.format(rfe_id="RHAIRFE-100", extra=""))
+        _write(f"{art}/rfe-reviews/RHAIRFE-100-review.md",
+               REVIEW_TEMPLATE.format(rfe_id="RHAIRFE-100", score=8,
+                                      pass_val="true", recommendation="submit",
+                                      right_sized=2))
+        _write(f"{art}/rfe-tasks/RHAIRFE-200.md",
+               TASK_TEMPLATE.format(rfe_id="RHAIRFE-200", extra=""))
+        _write(f"{art}/rfe-reviews/RHAIRFE-200-review.md",
+               REVIEW_TEMPLATE.format(rfe_id="RHAIRFE-200", score=7,
+                                      pass_val="true", recommendation="submit",
+                                      right_sized=1))
+
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, os.path.join(os.path.dirname(__file__),
+             "..", "scripts", "generate_run_report.py"),
+             "--start-time", "20260404-170041",
+             "--artifacts-dir", art],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        # Should have found both review files
+        import yaml
+        out_path = result.stdout.strip()
+        with open(out_path) as f:
+            report = yaml.safe_load(f)
+        ids = [e["id"] for e in report["per_rfe"]]
+        assert "RHAIRFE-100" in ids
+        assert "RHAIRFE-200" in ids
+
+
+class TestGenerateReviewPdfArtifactsDir:
+    def test_artifacts_dir_uses_correct_paths(self, tmp_path):
+        """generate_review_pdf.py --artifacts-dir reads from the given dir."""
+        art = str(tmp_path / "custom-artifacts")
+        for d in ["rfe-tasks", "rfe-reviews", "rfe-originals"]:
+            os.makedirs(os.path.join(art, d))
+        _write(f"{art}/rfe-tasks/RHAIRFE-500.md",
+               TASK_TEMPLATE.format(rfe_id="RHAIRFE-500", extra=""))
+        _write(f"{art}/rfe-reviews/RHAIRFE-500-review.md",
+               REVIEW_TEMPLATE.format(rfe_id="RHAIRFE-500", score=8,
+                                      pass_val="true", recommendation="submit",
+                                      right_sized=2))
+
+        out_file = str(tmp_path / "report.html")
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, os.path.join(os.path.dirname(__file__),
+             "..", "scripts", "generate_review_pdf.py"),
+             "--artifacts-dir", art,
+             "--output", out_file],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert os.path.exists(out_file)
+        with open(out_file) as f:
+            html = f.read()
+        assert "RHAIRFE-500" in html

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -366,3 +366,44 @@ class TestSnapshotUpdate:
         # Dry run should NOT create any snapshot files
         snap_dir = os.path.join(art_dir, "auto-fix-runs")
         assert not os.path.exists(snap_dir)
+
+
+class TestGenerateReportFlag:
+    """Tests for --generate-report / --report-timestamp validation."""
+
+    def test_generate_report_without_timestamp_fails(self):
+        """--generate-report without --report-timestamp → error exit."""
+        env = {
+            **os.environ,
+            "JIRA_SERVER": "",
+            "JIRA_USER": "",
+            "JIRA_TOKEN": "",
+        }
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--dry-run", "--generate-report"],
+            capture_output=True, text=True, env=env,
+        )
+        assert result.returncode != 0
+        assert "--report-timestamp is required" in result.stderr
+
+    def test_generate_report_with_timestamp_accepted(self, art_dir):
+        """--generate-report with --report-timestamp → no validation error."""
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
+               REVIEW_FM.format(rfe_id="RFE-001", auto_revised="false"))
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": "https://fake.atlassian.net",
+            "JIRA_USER": "fake@example.com",
+            "JIRA_TOKEN": "fake-token",
+        }
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--dry-run",
+             "--generate-report", "--report-timestamp", "20260404-170041",
+             "--artifacts-dir", art_dir],
+            capture_output=True, text=True, env=env,
+        )
+        assert result.returncode == 0
+        assert "--report-timestamp is required" not in result.stderr


### PR DESCRIPTION
## Summary
- **HTML report polish**: consistent badge sizes, table styling (borders, shadows, radius), split tree with color-coded scores, section anchor links, green trend arrows for improvements
- **`--generate-report` / `--report-timestamp` on submit.py**: generates YAML and HTML reports after submission for CI pipeline use
- **`--artifacts-dir` on report scripts**: both `generate_run_report.py` and `generate_review_pdf.py` accept arbitrary artifact directories
- **`generate_run_report.py` scans review files**: when no IDs passed, auto-discovers from `rfe-reviews/` directory
- **Dual timestamp format**: `YYYYMMDD-HHMMSS` (primary, passthrough) and ISO format both supported

## Test plan
- [x] All 235 tests pass
- [x] New tests for `_parse_run_id`, `--artifacts-dir`, review file scanning, `--generate-report` validation
- [x] Visual inspection of HTML report generated from CI run data

🤖 Generated with [Claude Code](https://claude.com/claude-code)