### PR TITLE
Fix ADF panel round-trip and add submit error resilience

### DIFF
--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -397,10 +397,23 @@ def markdown_to_adf(markdown):
                 i += 1
             quote_md = "\n".join(quote_lines)
             inner = markdown_to_adf(quote_md)
-            content.append({
-                "type": "blockquote",
-                "content": inner.get("content", []),
-            })
+            inner_content = inner.get("content", [])
+            has_headings = any(n.get("type") == "heading"
+                               for n in inner_content)
+            if has_headings:
+                # ADF blockquotes cannot contain headings, but panels
+                # can. Quoted headings originate from Jira panels that
+                # were converted to markdown blockquotes on fetch.
+                content.append({
+                    "type": "panel",
+                    "attrs": {"panelType": "info"},
+                    "content": inner_content,
+                })
+            else:
+                content.append({
+                    "type": "blockquote",
+                    "content": inner_content,
+                })
             continue
 
         # Table
@@ -598,7 +611,9 @@ def adf_to_markdown(node, list_depth=0):
 
     if node_type == "panel":
         inner = adf_to_markdown(content, list_depth)
-        return f"> {inner.strip()}\n\n"
+        lines = inner.strip().split("\n")
+        quoted = "\n".join(f"> {line}" for line in lines)
+        return f"{quoted}\n\n"
 
     if node_type == "expand":
         title = attrs.get("title", "")

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -434,90 +434,114 @@ def main():
     # Execute
     results = {}  # rfe_id -> assigned jira key
     submitted_hashes = {}  # assigned_key -> content_hash
+    submit_errors = []  # (rfe_id, error_msg) for entries that failed
     for entry in plan:
         rfe_id = entry["rfe_id"]
         if entry["skip_reason"]:
             print(f"  {rfe_id}: Skipping — {entry['skip_reason']}")
             continue
 
-        if entry["action"] == "Remove labels":
-            remove = entry["remove_labels"]
-            if args.dry_run:
-                print(f"  {rfe_id}: Would remove labels: "
-                      f"{', '.join(remove)}")
-            else:
-                remove_labels(server, user, token, rfe_id, remove)
-                print(f"  {rfe_id}: Removed labels: {', '.join(remove)}")
-            continue
+        try:
+            if entry["action"] == "Remove labels":
+                remove = entry["remove_labels"]
+                if args.dry_run:
+                    print(f"  {rfe_id}: Would remove labels: "
+                          f"{', '.join(remove)}")
+                else:
+                    remove_labels(server, user, token, rfe_id, remove)
+                    print(f"  {rfe_id}: Removed labels: "
+                          f"{', '.join(remove)}")
+                continue
+            if entry["action"] == "Label only":
+                labels = entry["labels"]
+                if args.dry_run:
+                    print(f"  {rfe_id}: Would add labels: "
+                          f"{', '.join(labels)}")
+                else:
+                    add_labels(server, user, token, rfe_id, labels)
+                    print(f"  {rfe_id}: Labels: {', '.join(labels)}")
+                results[rfe_id] = rfe_id
+                _post_needs_attention_comment(
+                    server, user, token, entry, results, args.dry_run)
+                continue
 
-        if entry["action"] == "Label only":
+            # Read and clean artifact content
+            with open(entry["task_path"], encoding="utf-8") as f:
+                raw_content = f.read()
+            cleaned = strip_metadata(raw_content)
+            description_adf = markdown_to_adf(cleaned)
+
+            title = entry["title"]
             labels = entry["labels"]
-            if args.dry_run:
-                print(f"  {rfe_id}: Would add labels: {', '.join(labels)}")
+
+            if entry["is_existing"]:
+                # Update existing ticket (rfe_id is the Jira key)
+                if args.dry_run:
+                    print(f"  {rfe_id}: Would update")
+                else:
+                    update_issue(server, user, token, rfe_id, title,
+                                 description_adf)
+                    print(f"  {rfe_id}: Updated")
+                    if labels:
+                        add_labels(server, user, token, rfe_id, labels)
+                        print(f"           Labels: {', '.join(labels)}")
+                    submitted_hashes[rfe_id] = compute_content_hash(
+                        description_adf)
+                results[rfe_id] = rfe_id
             else:
-                add_labels(server, user, token, rfe_id, labels)
-                print(f"  {rfe_id}: Labels: {', '.join(labels)}")
-            results[rfe_id] = rfe_id
+                # Create new ticket
+                if args.dry_run:
+                    print(f"  {rfe_id}: Would create RHAIRFE ticket: "
+                          f"{title}")
+                    results[rfe_id] = "RHAIRFE-DRY"
+                else:
+                    new_key = create_issue(server, user, token, "RHAIRFE",
+                                           "Feature Request", title,
+                                           description_adf,
+                                           entry["priority"],
+                                           labels=labels)
+                    print(f"  {rfe_id}: Created {new_key}")
+                    if labels:
+                        print(f"           Labels: {', '.join(labels)}")
+                    results[rfe_id] = new_key
+                    submitted_hashes[new_key] = compute_content_hash(
+                        description_adf)
+
+            # Post removed-context Jira comment if applicable
+            yaml_path = find_removed_context_yaml(args.artifacts_dir, rfe_id)
+            if yaml_path:
+                comment_md = _render_jira_comment(yaml_path)
+                target_key = results.get(rfe_id)
+                if not comment_md:
+                    pass  # No postable blocks
+                elif args.dry_run:
+                    print(f"  {rfe_id}: Would post removed-context comment "
+                          f"({len(comment_md)} chars)")
+                elif target_key:
+                    comment_adf = markdown_to_adf(comment_md)
+                    add_comment(server, user, token, target_key, comment_adf)
+                    print(f"  {rfe_id}: Posted removed-context comment")
+
+            # Post needs-attention comment if newly flagged
             _post_needs_attention_comment(
                 server, user, token, entry, results, args.dry_run)
-            continue
 
-        # Read and clean artifact content
-        with open(entry["task_path"], encoding="utf-8") as f:
-            raw_content = f.read()
-        cleaned = strip_metadata(raw_content)
-        description_adf = markdown_to_adf(cleaned)
-
-        title = entry["title"]
-        labels = entry["labels"]
-
-        if entry["is_existing"]:
-            # Update existing ticket (rfe_id is the Jira key)
-            if args.dry_run:
-                print(f"  {rfe_id}: Would update")
-            else:
-                update_issue(server, user, token, rfe_id, title,
-                             description_adf)
-                print(f"  {rfe_id}: Updated")
-                if labels:
-                    add_labels(server, user, token, rfe_id, labels)
-                    print(f"           Labels: {', '.join(labels)}")
-                submitted_hashes[rfe_id] = compute_content_hash(description_adf)
-            results[rfe_id] = rfe_id
-        else:
-            # Create new ticket
-            if args.dry_run:
-                print(f"  {rfe_id}: Would create RHAIRFE ticket: {title}")
-                results[rfe_id] = "RHAIRFE-DRY"
-            else:
-                new_key = create_issue(server, user, token, "RHAIRFE",
-                                       "Feature Request", title,
-                                       description_adf, entry["priority"],
-                                       labels=labels)
-                print(f"  {rfe_id}: Created {new_key}")
-                if labels:
-                    print(f"           Labels: {', '.join(labels)}")
-                results[rfe_id] = new_key
-                submitted_hashes[new_key] = compute_content_hash(description_adf)
-
-        # Post removed-context Jira comment if applicable
-        yaml_path = find_removed_context_yaml(args.artifacts_dir, rfe_id)
-        if yaml_path:
-            comment_md = _render_jira_comment(yaml_path)
-            target_key = results.get(rfe_id)
-            if not comment_md:
-                pass  # No postable blocks
-            elif args.dry_run:
-                print(f"  {rfe_id}: Would post removed-context comment "
-                      f"({len(comment_md)} chars)")
-            elif target_key:
-                comment_adf = markdown_to_adf(comment_md)
-                add_comment(server, user, token, target_key, comment_adf)
-                print(f"  {rfe_id}: Posted removed-context comment")
-
-        # Post needs-attention comment if newly flagged
-        _post_needs_attention_comment(
-            server, user, token, entry, results, args.dry_run)
+        except Exception as exc:
+            msg = str(exc)
+            print(f"  {rfe_id}: ERROR — {msg}", file=sys.stderr)
+            submit_errors.append((rfe_id, msg))
+            # Mark in review frontmatter so the report picks it up
+            review_path = find_review_file(args.artifacts_dir, rfe_id)
+            if review_path:
+                try:
+                    update_frontmatter(review_path, {
+                        "needs_attention": True,
+                        "needs_attention_reason":
+                            f"Submit failed: {msg}",
+                        "error": f"submit_failed: {msg}",
+                    }, "rfe-review")
+                except Exception:
+                    pass  # best-effort
 
     print()
 
@@ -557,6 +581,12 @@ def main():
     rebuild_index(args.artifacts_dir)
     print(f"Done. Index rebuilt at {args.artifacts_dir}/rfes.md")
 
+    if submit_errors:
+        print(f"\n{len(submit_errors)} RFE(s) failed during submit:",
+              file=sys.stderr)
+        for eid, emsg in submit_errors:
+            print(f"  {eid}: {emsg}", file=sys.stderr)
+
     # Generate reports if requested
     if args.generate_report:
         script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -589,6 +619,9 @@ def main():
         if result.returncode != 0:
             print(f"Warning: HTML report generation failed: "
                   f"{result.stderr}", file=sys.stderr)
+
+    if submit_errors:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_markdown_to_adf.py
+++ b/tests/test_markdown_to_adf.py
@@ -14,7 +14,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
-from jira_utils import markdown_to_adf
+from jira_utils import adf_to_markdown, markdown_to_adf
 
 
 # ── Timeout helper ──────────────────────────────────────────────────────────
@@ -147,12 +147,36 @@ class TestCIFailurePatterns:
         assert len(result["content"]) == 4  # 3 empty headings + 1 paragraph
 
     def test_malformed_heading_in_blockquote(self):
-        """Blockquote prefix stripping can produce malformed headings."""
+        """Blockquote with headings (even malformed) becomes a panel."""
         md = "> ### \n> **Some text**"
+        result = markdown_to_adf(md)
+        node = result["content"][0]
+        assert node["type"] == "panel"
+        assert len(node["content"]) >= 1
+
+    def test_heading_in_blockquote_becomes_panel(self):
+        """Blockquote with headings becomes an ADF panel (not blockquote).
+
+        ADF blockquotes cannot contain headings (Jira returns HTTP 400).
+        Quoted headings originate from Jira panels converted to markdown
+        blockquotes on fetch, so they round-trip back as panels.
+        Regression: RHAIRFE-584 in 20260405-012640 run.
+        """
+        md = "> ### **Problem**\n> \n> Description here.\n\nText after."
+        result = markdown_to_adf(md)
+        panel = result["content"][0]
+        assert panel["type"] == "panel"
+        assert panel["attrs"]["panelType"] == "info"
+        # Heading preserved as a real heading inside the panel
+        assert panel["content"][0]["type"] == "heading"
+        assert panel["content"][0]["attrs"]["level"] == 3
+
+    def test_plain_blockquote_stays_blockquote(self):
+        """Blockquote without headings stays as a blockquote."""
+        md = "> Some quoted text.\n> More text."
         result = markdown_to_adf(md)
         bq = result["content"][0]
         assert bq["type"] == "blockquote"
-        assert len(bq["content"]) >= 1
 
     def test_full_document_with_malformed_headings(self):
         """Simulates a full RFE with the problematic pattern throughout."""
@@ -177,6 +201,60 @@ class TestCIFailurePatterns:
         assert "heading" in types
         assert "paragraph" in types
         assert "bulletList" in types
+
+
+# ── Panel round-trip tests ────────────────────────────────────────────────
+
+class TestPanelRoundTrip:
+    """Verify ADF panel → markdown → ADF survives the fetch/edit/submit cycle."""
+
+    def test_multiline_panel_all_lines_quoted(self):
+        """adf_to_markdown must prefix every line with '> ', not just the first."""
+        panel_adf = {
+            "type": "doc", "version": 1,
+            "content": [{
+                "type": "panel",
+                "attrs": {"panelType": "info"},
+                "content": [
+                    {"type": "heading", "attrs": {"level": 3},
+                     "content": [{"type": "text", "text": "Problem",
+                                  "marks": [{"type": "strong"}]}]},
+                    {"type": "paragraph",
+                     "content": [{"type": "text",
+                                  "text": "Description here."}]},
+                ],
+            }],
+        }
+        md = adf_to_markdown(panel_adf)
+        # Every non-empty line should be quoted
+        for line in md.strip().split("\n"):
+            if line.strip():
+                assert line.startswith("> "), \
+                    f"Line not quoted: {line!r}"
+
+    def test_panel_round_trip_preserves_headings(self):
+        """Panel with headings round-trips: panel → markdown → panel."""
+        panel_adf = {
+            "type": "doc", "version": 1,
+            "content": [{
+                "type": "panel",
+                "attrs": {"panelType": "info"},
+                "content": [
+                    {"type": "heading", "attrs": {"level": 3},
+                     "content": [{"type": "text", "text": "Problem",
+                                  "marks": [{"type": "strong"}]}]},
+                    {"type": "paragraph",
+                     "content": [{"type": "text",
+                                  "text": "Description here."}]},
+                ],
+            }],
+        }
+        md = adf_to_markdown(panel_adf)
+        result = markdown_to_adf(md)
+        node = result["content"][0]
+        assert node["type"] == "panel"
+        assert node["content"][0]["type"] == "heading"
+        assert node["content"][1]["type"] == "paragraph"
 
 
 # ── Safety net tests ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **ADF panel round-trip**: Jira panels get converted to markdown blockquotes (`> ...`) on fetch. The `markdown_to_adf` converter was producing invalid ADF by putting headings inside `blockquote` nodes (not allowed by ADF spec). Now detects headings and emits a `panel` node instead, preserving the original structure. Also fixes the `adf_to_markdown` panel handler to prefix every line with `> ` (was only prefixing the first line, causing multi-line panel content to spill out).
- **Submit error resilience**: A single Jira API error (e.g. HTTP 400) was crashing the entire submit run, skipping all remaining RFEs, report generation, and the post-submit results push. Now wraps each entry in try/except, flags failures as `needs_attention` in review frontmatter, continues processing, and exits with code 1 on partial failure.

**Note:** The CI `.gitlab-ci.yml` also needs a fix to capture submit's exit code and always run the post-submit push — otherwise exit code 1 still prevents the final results push.

## Test plan
- [x] New test: blockquote with headings becomes ADF panel
- [x] New test: plain blockquote stays as blockquote
- [x] Updated test: malformed heading in blockquote
- [x] Full test suite: 237 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)