### PR TITLE
Fix snapshot poisoning and add caller-based return breadcrumbs

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -122,7 +122,7 @@ Output: `[AUTOFIX] Batch N/M: K IDs`
 Invoke `/rfe.review` as an inline Skill, using IDs from the batch file:
 
 ```
-/rfe.review --headless <batch_IDs_from_file>
+/rfe.review --headless --caller autofix <batch_IDs_from_file>
 ```
 
 This runs the full review pipeline (fetch, assess, feasibility, review, revise, re-assess if needed). Wait for it to complete.

--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -11,12 +11,13 @@ You are an RFE review orchestrator. Your job is to coordinate reviews and revisi
 
 Parse `$ARGUMENTS` for flags and IDs:
 - Strip `--headless` flag if present (suppresses end-of-run summary)
+- Strip `--caller <name>` flag if present (identifies calling skill for headless return)
 - Remaining arguments are one or more space-separated RFE IDs (RHAIRFE-NNNN or RFE-NNN)
 
 Persist parsed flags (survives context compression):
 
 ```bash
-python3 scripts/state.py init tmp/review-config.yaml headless=<true/false>
+python3 scripts/state.py init tmp/review-config.yaml headless=<true/false> caller=<autofix|split|none>
 ```
 
 Persist all IDs to disk (survives context compression):
@@ -306,7 +307,18 @@ Re-read flags (in case context was compressed):
 python3 scripts/state.py read tmp/review-config.yaml
 ```
 
-**If `headless: true`**: The review phase is complete, but the overall pipeline is NOT finished. Do not output a summary — the calling orchestrator handles all reporting. **Yield execution to the calling skill's next step immediately.**
+**If `headless: true`**: Output the text "rfe.review step completed." then run:
+
+```bash
+python3 scripts/state.py read tmp/review-config.yaml
+python3 scripts/state.py read tmp/autofix-config.yaml 2>/dev/null; python3 scripts/state.py read tmp/split-config.yaml 2>/dev/null; true
+```
+
+Check the `caller` field above:
+- **`autofix`**: Returning to **Step 3b: Collect Results** of `/rfe.auto-fix`. Re-read batch IDs from `tmp/autofix-batch-N-ids.txt` (where N = `current_batch` from `tmp/autofix-config.yaml`). If the autofix config is not visible, re-read `/rfe.auto-fix` SKILL.md for the full batch loop.
+- **`split`**: Returning to **Split Step 3: Right-sizing Self-Correction** of `/rfe.split`. Re-read parent IDs from `tmp/split-all-ids.txt`. If the split config is not visible, re-read `/rfe.split` SKILL.md for the full flow.
+
+Do not summarize or stop.
 
 **If interactive (no `--headless`)**: Re-read ID list and present summary:
 

--- a/.claude/skills/rfe.split/SKILL.md
+++ b/.claude/skills/rfe.split/SKILL.md
@@ -79,7 +79,7 @@ Parse the output to get all child RFE IDs. If any parent has zero children despi
 If there are children to review, invoke `/rfe.review` as an inline Skill, passing `--headless` through if present:
 
 ```
-/rfe.review [--headless] <child_ID_1> <child_ID_2> ...
+/rfe.review [--headless] --caller split <child_ID_1> <child_ID_2> ...
 ```
 
 This triggers the full agent delegation review pipeline on all children.
@@ -117,7 +117,7 @@ If any child scores below 2/2 on `scores.right_sized`:
 1. **Re-split**: Launch a split agent for the offending child (same prompt as Split Step 1)
 2. **Wait** for the agent to complete
 3. **Collect new children**: `python3 scripts/collect_children.py <re-split_ID>`
-4. **Review new children**: Invoke `/rfe.review [--headless] <new_child_IDs>`
+4. **Review new children**: Invoke `/rfe.review [--headless] --caller split <new_child_IDs>`
 5. **Check again**: Read right-sized scores for new children
 
 After each cycle, increment the counter on disk:
@@ -144,7 +144,13 @@ Re-read flags (in case context was compressed):
 python3 scripts/state.py read tmp/split-config.yaml
 ```
 
-**If `headless: true`**: The split phase is complete, but the overall pipeline is NOT finished. Do not output a summary — the calling orchestrator handles all reporting. **Yield execution to the calling skill's next step immediately.**
+**If `headless: true`**: Output the text "rfe.split step on current iteration of rfe.auto-fix batch loop completed." then run:
+
+```bash
+python3 scripts/state.py read tmp/autofix-config.yaml 2>/dev/null; true
+```
+
+Returning to **Step 3d: Between-Batch Summary** of `/rfe.auto-fix`. Re-read the batch IDs from `tmp/autofix-batch-N-ids.txt` (where N = `current_batch` from the config above). If the autofix config is not visible, re-read `/rfe.auto-fix` SKILL.md for the full batch loop. Do not summarize or stop.
 
 **If interactive (no `--headless`)**: Present the final state for each parent ID:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Skills that only work with local artifacts (`/rfe.create`) do not require Jira a
 
 ## Snapshot System
 
-Before modifying `scripts/snapshot_fetch.py`, `scripts/bootstrap_snapshot.py`, or `scripts/submit.py` (snapshot-related code), read `docs/snapshot-incremental-fetch.md` — especially the **Design Invariants** section. Changes must preserve all six invariants.
+Before modifying `scripts/snapshot_fetch.py`, `scripts/bootstrap_snapshot.py`, or `scripts/submit.py` (snapshot-related code), read `docs/snapshot-incremental-fetch.md` — especially the **Design Invariants** section. Changes must preserve all invariants.
 
 ## Architecture Context
 

--- a/docs/snapshot-incremental-fetch.md
+++ b/docs/snapshot-incremental-fetch.md
@@ -57,8 +57,16 @@ query_timestamp: "2026-04-02T19:54:36Z"
 timestamp: "2026-04-02T19:54:37Z"
 bootstrapped_from: "20260402-195436"   # only present on bootstrap snapshots
 issues:
-  RHAIRFE-1234: "a1b2c3..."
-  RHAIRFE-5678: "d4e5f6..."
+  # Current format (dict with processed flag)
+  RHAIRFE-1234:
+    hash: "a1b2c3..."
+    processed: true
+  RHAIRFE-5678:
+    hash: "d4e5f6..."
+    processed: false
+
+  # Legacy format (plain string, still readable — treated as processed: true)
+  RHAIRFE-9999: "g7h8i9..."
 ```
 
 ## Content Hashing Pipeline
@@ -183,19 +191,69 @@ Issues never selected remain absent and stay NEW until selected.
 ## Diffing Logic
 
 `diff_snapshots(current_issues, previous_data)` compares each issue's
-current content hash against the previous snapshot:
+current content hash against the previous snapshot. The `processed` flag
+determines whether a previous entry counts as "seen":
 
-- **UNCHANGED** (hash matches): issue's description hasn't changed since
-  last selected. Included in output after changed/new issues. When a
-  limit is set, unchanged issues fill remaining capacity.
-- **CHANGED** (hash differs): issue was previously selected but its
-  description has been modified since. Gets priority ordering and
-  bypasses `check_resume`.
-- **NEW** (not in previous snapshot): issue has never been selected.
-  Gets priority ordering but goes through normal `check_resume`.
+- **UNCHANGED** (`processed: true` + hash matches): issue's description
+  hasn't changed since last processed. Included in output after
+  changed/new issues. When a limit is set, unchanged issues fill
+  remaining capacity.
+- **CHANGED** (`processed: true` + hash differs): issue was previously
+  processed but its description has been modified since. Gets priority
+  ordering and bypasses `check_resume`.
+- **NEW** (not in previous snapshot, OR `processed: false`): issue has
+  never been processed, or was selected but the pipeline didn't complete
+  for it. Gets priority ordering but goes through normal `check_resume`.
 - **In previous but not current**: issue left scope (closed, filtered).
   Retained in the snapshot as an inert entry (no pruning) so that if
   reopened with an edited description, it surfaces as CHANGED.
+
+## Processed Flag
+
+The `processed` flag tracks whether the pipeline has completed for an
+issue — meaning it was reviewed and either submitted to Jira, explicitly
+rejected, or determined to need no changes. Without this flag, issues
+selected but never fully processed (e.g., due to a skipped batch or
+pipeline failure) would appear as UNCHANGED on the next run, silently
+skipping them.
+
+### State Transitions
+
+| Current state | Event | New state |
+|--------------|-------|-----------|
+| `processed: true` + hash unchanged | Fetch selects issue | stays `true` |
+| `processed: true` + hash changed | Fetch selects issue | reset to `false` |
+| `processed: false` | Fetch selects issue | stays `false` |
+| New ID (not in snapshot) | Fetch selects issue | starts `false` |
+| `processed: false` | `submit.py` completes | set to `true` |
+
+Key rule: `processed: true` can only reset to `false` when the content
+hash changes. Only `submit.py` (via `update_snapshot_hashes`) sets
+`processed: true`.
+
+### What Counts as "Processed"
+
+`submit.py` marks an issue as processed through two paths:
+
+1. **`submitted_hashes`** — issues whose content was written to Jira
+   (Update or Create). The snapshot entry gets both a new hash and
+   `processed: true`.
+
+2. **`mark_processed`** — issues that completed the pipeline without
+   Jira content writes. The snapshot entry keeps its existing hash and
+   gets `processed: true`. This covers:
+   - **No changes needed** — reviewed, content identical to what's in Jira
+   - **Rejected** — reviewed, intentionally rejected (`pass: false`)
+   - **Label only** — reviewed, only label changes applied
+   - **Remove labels** — rejected, old autofix labels cleaned up
+
+### What Stays Unprocessed
+
+Issues remain `processed: false` (and re-surface as NEW) when:
+- Jira API failure during submit
+- Review produced `pass: false` and issue was not in the submit plan
+- Batch was skipped entirely (no review file exists)
+- Jira conflict detected (content changed between fetch and submit)
 
 ### Selection and Limit
 
@@ -211,10 +269,19 @@ When `submit.py` updates or creates an issue in Jira, the description
 in Jira changes. Without intervention, the next fetch would see a hash
 mismatch and flag the issue as "changed" — re-processing our own work.
 
-After all Jira writes succeed, `submit.py` updates the current
-snapshot's issue hashes with the post-submit content hashes. This way
-the snapshot reflects what Jira now has, and the next fetch correctly
-treats these issues as unchanged.
+After all Jira writes succeed, `submit.py` calls
+`update_snapshot_hashes(submitted_hashes, mark_processed=ids)` which
+does two things:
+
+1. **`submitted_hashes`**: For issues whose content was written to Jira,
+   updates the snapshot entry with the post-submit hash and sets
+   `processed: true`. This way the snapshot reflects what Jira now has,
+   and the next fetch correctly treats these issues as unchanged.
+
+2. **`mark_processed`**: For issues that completed the pipeline without
+   content writes (no changes, rejected, label-only, remove-labels),
+   sets `processed: true` without changing the hash. This prevents them
+   from re-surfacing as NEW on the next run.
 
 This also handles newly created issues. Without the post-submit hash,
 a new issue would appear as "new" on the next run. With it in the
@@ -224,21 +291,30 @@ snapshot, the issue is treated as known.
 
 **Job dies during submit (before push):**
 The snapshot was written during fetch but not yet updated with
-post-submit hashes. On the next run, submitted issues show as
-"changed" (hash mismatch) and get re-processed. This is safe but
-redundant — the conflict check in `submit.py` catches identical
-content, and the review pipeline is idempotent.
+post-submit hashes. Selected issues have `processed: false` in the
+snapshot. On the next run, they re-surface as NEW and get re-processed.
+This is safe but redundant — the conflict check in `submit.py` catches
+identical content, and the review pipeline is idempotent.
 
 **Job dies after processing but before submit:**
 Snapshot and reviews were written locally but no Jira writes happened.
 In CI (ephemeral environment), local state is lost — equivalent to
-"dies before fetch." Locally, the snapshot marks issues as seen; next
-run treats them as UNCHANGED and `check_resume` skips them if passing
-reviews exist. Safe but submit must be re-triggered manually.
+"dies before fetch." Locally, the snapshot marks issues with
+`processed: false`; next run treats them as NEW and re-processes them.
+Safe but submit must be re-triggered manually.
 
 **Job dies before fetch completes:**
 Nothing was written. Next run starts from the same snapshot as this
 run. All work is re-done. Safe.
+
+**Batch 2 never runs (context compression loses instructions):**
+The auto-fix pipeline processes issues in batches. If context
+compression drops the batch loop instructions after batch 1, batch 2
+issues are selected in the snapshot (with `processed: false`) but never
+reviewed or submitted. On the next run, these issues re-surface as NEW
+because `processed: false` entries are treated as new regardless of
+hash match. Without the processed flag, they would appear UNCHANGED
+and be silently skipped.
 
 ## Hard Filters
 
@@ -335,16 +411,28 @@ These invariants must hold and should guide future refactors:
 
 4. **NEW issues do not bypass resume check.** Only CHANGED issues
    (hash mismatch) go in the `changed_file` and bypass `check_resume`.
-   NEW issues (not in snapshot) go through normal resume check — if a
-   passing review exists, they're skipped.
+   NEW issues (not in snapshot, or `processed: false`) go through
+   normal resume check — if a passing review exists, they're skipped.
 
 5. **Without a limit, behavior is identical to the old design.** When
    `limit = len(current)`, all issues are selected, all merged — the
    snapshot contains everything.
 
-6. **`update_snapshot_hashes` is additive.** It uses `dict.update()`
-   on the latest snapshot, adding or updating entries. This is
-   compatible with cumulative snapshots.
+6. **`update_snapshot_hashes` is additive.** It writes dict-format
+   entries (`{hash, processed: true}`) to the latest snapshot, adding
+   or updating entries. It also supports `mark_processed` to set
+   `processed: true` on existing entries without changing their hash.
+
+7. **`processed: true` resets to `false` only on hash change.**
+   `cmd_fetch` resets `processed` to `false` when the content hash
+   differs from the snapshot. If the hash matches and `processed` is
+   already `true`, it stays `true`. This ensures that externally
+   edited issues are re-processed even if previously completed.
+
+8. **Only `submit.py` sets `processed: true`.** `cmd_fetch` never
+   sets `processed: true` — it only preserves or resets it.
+   `update_snapshot_hashes` (called by `submit.py`) is the sole path
+   to marking an issue as processed.
 
 ## Known Gaps
 
@@ -357,6 +445,17 @@ These invariants must hold and should guide future refactors:
   to have a passing review from a prior run will be skipped by
   `check_resume`. Same behavior as UNCHANGED with a stale review —
   pre-existing, not specific to this design.
+
+### Resolved
+
+- **Snapshot poisoning (unprocessed IDs appearing UNCHANGED).** Before
+  the `processed` flag, `cmd_fetch` wrote hashes for all selected IDs
+  at fetch time. If the pipeline failed to process some IDs (e.g.,
+  batch 2 skipped due to context compression), those IDs had valid
+  hashes in the snapshot and appeared UNCHANGED on the next run —
+  silently skipped. Fixed by the `processed` flag: IDs start
+  `processed: false` and only become `true` after `submit.py`
+  completes for them.
 
 ## Scripts
 

--- a/scripts/snapshot_fetch.py
+++ b/scripts/snapshot_fetch.py
@@ -200,8 +200,8 @@ def diff_snapshots(current_issues, previous_data):
     """Compare current fetch against previous snapshot.
 
     Returns (changed_keys, new_keys) preserving Jira's fetch order.
-    - changed: hash differs from previous snapshot
-    - new: not in previous snapshot at all
+    - changed: hash differs from previous snapshot (and was previously processed)
+    - new: not in previous snapshot, or previously unprocessed
     """
     if previous_data is None:
         # First run — all issues are "new"
@@ -213,12 +213,24 @@ def diff_snapshots(current_issues, previous_data):
 
     for key, data in current_issues.items():
         current_hash = data["content_hash"]
+        prev_entry = prev_issues.get(key)
 
-        if key not in prev_issues:
+        if prev_entry is None:
             new.append(key)
             continue
 
-        if current_hash != prev_issues[key]:
+        # Handle both old format (plain string) and new format (dict)
+        if isinstance(prev_entry, dict):
+            prev_hash = prev_entry.get("hash")
+            processed = prev_entry.get("processed", True)
+        else:
+            prev_hash = prev_entry
+            processed = True  # old format entries are implicitly processed
+
+        if not processed:
+            # Never successfully processed — treat as new
+            new.append(key)
+        elif current_hash != prev_hash:
             changed.append(key)
 
     return changed, new
@@ -232,11 +244,14 @@ def write_id_file(path, ids):
             f.write(f"{id_}\n")
 
 
-def update_snapshot_hashes(hashes, snapshot_dir=None):
+def update_snapshot_hashes(hashes, snapshot_dir=None, mark_processed=None):
     """Update the latest snapshot with post-submit content hashes.
 
     Called by submit.py after Jira writes so the next fetch sees
     the post-submit state and doesn't re-flag our own changes.
+
+    Also marks additional IDs as processed without changing their hash
+    (e.g., reviewed but no content changes needed).
     """
     snap_dir = snapshot_dir or SNAPSHOT_DIR
     pattern = os.path.join(snap_dir, "issue-snapshot-*.yaml")
@@ -247,7 +262,20 @@ def update_snapshot_hashes(hashes, snapshot_dir=None):
             with open(f, encoding="utf-8") as fh:
                 data = yaml.safe_load(fh)
             if data and isinstance(data.get("issues"), dict):
-                data["issues"].update(hashes)
+                issues = data["issues"]
+                # Update submitted IDs with new hash + processed
+                for key, hash_val in hashes.items():
+                    issues[key] = {"hash": hash_val, "processed": True}
+                # Mark additional IDs as processed (keep existing hash)
+                if mark_processed:
+                    for key in mark_processed:
+                        entry = issues.get(key)
+                        if entry is not None:
+                            if isinstance(entry, dict):
+                                entry["processed"] = True
+                            else:
+                                issues[key] = {"hash": entry,
+                                               "processed": True}
                 with open(f, "w", encoding="utf-8") as fh:
                     yaml.dump(data, fh, default_flow_style=False,
                               sort_keys=False)
@@ -318,7 +346,27 @@ def cmd_fetch(args):
     prev_issues = prev_data.get("issues", {}) if prev_data else {}
     merged_issues = dict(prev_issues)
     for key in all_ids:
-        merged_issues[key] = current[key]["content_hash"]
+        current_hash = current[key]["content_hash"]
+        prev = prev_issues.get(key)
+
+        # Determine processed state using the invariant:
+        # processed=true only stays true if hash unchanged
+        if prev is not None:
+            if isinstance(prev, dict):
+                prev_hash = prev.get("hash")
+                prev_processed = prev.get("processed", True)
+            else:
+                prev_hash = prev
+                prev_processed = True
+
+            if prev_processed and current_hash == prev_hash:
+                processed = True
+            else:
+                processed = False
+        else:
+            processed = False
+
+        merged_issues[key] = {"hash": current_hash, "processed": processed}
 
     os.makedirs(SNAPSHOT_DIR, exist_ok=True)
     snapshot = {

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -440,9 +440,12 @@ def main():
     results = {}  # rfe_id -> assigned jira key
     submitted_hashes = {}  # assigned_key -> content_hash
     submit_errors = []  # (rfe_id, error_msg) for entries that failed
+    mark_processed_ids = []  # IDs where pipeline completed but no Jira content
     for entry in plan:
         rfe_id = entry["rfe_id"]
         if entry["skip_reason"]:
+            if "Jira conflict" not in entry["skip_reason"]:
+                mark_processed_ids.append(rfe_id)
             print(f"  {rfe_id}: Skipping — {entry['skip_reason']}")
             continue
 
@@ -456,6 +459,7 @@ def main():
                     remove_labels(server, user, token, rfe_id, remove)
                     print(f"  {rfe_id}: Removed labels: "
                           f"{', '.join(remove)}")
+                mark_processed_ids.append(rfe_id)
                 continue
             if entry["action"] == "Label only":
                 labels = entry["labels"]
@@ -471,6 +475,7 @@ def main():
                 results[rfe_id] = rfe_id
                 _post_needs_attention_comment(
                     server, user, token, entry, results, args.dry_run)
+                mark_processed_ids.append(rfe_id)
                 continue
 
             # Read and clean artifact content
@@ -545,6 +550,8 @@ def main():
                     rename_to_jira_key(args.artifacts_dir, rfe_id, new_key)
                     print(f"  {rfe_id}: Renamed to {new_key}")
 
+            mark_processed_ids.append(rfe_id)
+
         except Exception as exc:
             msg = str(exc)
             print(f"  {rfe_id}: ERROR — {msg}", file=sys.stderr)
@@ -566,12 +573,14 @@ def main():
 
     # Update snapshot with post-submit hashes so the next fetch
     # doesn't re-flag our own changes
-    if submitted_hashes and not args.dry_run:
+    if (submitted_hashes or mark_processed_ids) and not args.dry_run:
         snap_dir = os.path.join(args.artifacts_dir, "auto-fix-runs")
-        updated = update_snapshot_hashes(submitted_hashes, snap_dir)
+        updated = update_snapshot_hashes(submitted_hashes, snap_dir,
+                                         mark_processed=mark_processed_ids)
         if updated:
             print(f"  Updated snapshot with {len(submitted_hashes)} "
-                  f"post-submit hashes: {updated}")
+                  f"post-submit hashes, {len(mark_processed_ids)} "
+                  f"mark-processed: {updated}")
         else:
             print("  Warning: no snapshot found to update",
                   file=sys.stderr)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,20 @@ def jira(jira_emu):
             jira.create("RHAIRFE-1", "Summary", "Description text")
             # ... run code under test against jira.url ...
     """
-    # Reset all data before each test
+    # Patch emulator seed data to include link types this project needs
+    from jira_emulator.services import seed_service
+    _extra_link_types = [
+        {"name": "Issue split",
+         "inward_description": "is split from",
+         "outward_description": "split to"},
+    ]
+    _orig = seed_service.LINK_TYPES
+    seed_service.LINK_TYPES = _orig + [
+        lt for lt in _extra_link_types
+        if lt["name"] not in {x["name"] for x in _orig}
+    ]
+
+    # Reset all data before each test (re-seeds with patched link types)
     req = urllib.request.Request(
         f"{jira_emu}/api/admin/reset", method="POST", data=b"")
     urllib.request.urlopen(req)

--- a/tests/test_snapshot_fetch.py
+++ b/tests/test_snapshot_fetch.py
@@ -14,6 +14,7 @@ from snapshot_fetch import (
     compute_content_hash,
     diff_snapshots,
     load_snapshot_from_dir,
+    update_snapshot_hashes,
     write_id_file,
 )
 
@@ -184,6 +185,161 @@ class TestDiffSnapshots:
         changed, new = diff_snapshots(current, previous)
         assert changed == ["RHAIRFE-1", "RHAIRFE-3"]
         assert new == ["RHAIRFE-4"]
+
+    # ── New dict format with processed flag ──
+
+    def test_processed_true_same_hash_unchanged(self):
+        """Processed + same hash → not in changed or new (unchanged)."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa", "labels": []},
+        }
+        previous = {"issues": {
+            "RHAIRFE-1": {"hash": "aaa", "processed": True},
+        }}
+        changed, new = diff_snapshots(current, previous)
+        assert changed == []
+        assert new == []
+
+    def test_processed_true_different_hash_changed(self):
+        """Processed + different hash → in changed list."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa-new", "labels": []},
+        }
+        previous = {"issues": {
+            "RHAIRFE-1": {"hash": "aaa", "processed": True},
+        }}
+        changed, new = diff_snapshots(current, previous)
+        assert changed == ["RHAIRFE-1"]
+        assert new == []
+
+    def test_processed_false_treated_as_new(self):
+        """Unprocessed entry → treated as new regardless of hash."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa", "labels": []},
+        }
+        previous = {"issues": {
+            "RHAIRFE-1": {"hash": "aaa", "processed": False},
+        }}
+        changed, new = diff_snapshots(current, previous)
+        assert changed == []
+        assert new == ["RHAIRFE-1"]
+
+    def test_processed_false_different_hash_still_new(self):
+        """Unprocessed + different hash → still treated as new, not changed."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa-new", "labels": []},
+        }
+        previous = {"issues": {
+            "RHAIRFE-1": {"hash": "aaa", "processed": False},
+        }}
+        changed, new = diff_snapshots(current, previous)
+        assert changed == []
+        assert new == ["RHAIRFE-1"]
+
+    def test_mixed_old_and_new_format(self):
+        """Mix of old string format and new dict format in same snapshot."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa", "labels": []},
+            "RHAIRFE-2": {"content_hash": "bbb", "labels": []},
+            "RHAIRFE-3": {"content_hash": "ccc", "labels": []},
+        }
+        previous = {"issues": {
+            "RHAIRFE-1": "aaa",  # old format, implicitly processed
+            "RHAIRFE-2": {"hash": "bbb", "processed": True},  # new, processed
+            "RHAIRFE-3": {"hash": "ccc", "processed": False},  # new, unprocessed
+        }}
+        changed, new = diff_snapshots(current, previous)
+        assert changed == []
+        assert new == ["RHAIRFE-3"]
+
+    def test_dict_missing_processed_defaults_true(self):
+        """Dict entry without processed key → defaults to True."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa", "labels": []},
+        }
+        previous = {"issues": {
+            "RHAIRFE-1": {"hash": "aaa"},  # no processed key
+        }}
+        changed, new = diff_snapshots(current, previous)
+        assert changed == []
+        assert new == []
+
+
+class TestUpdateSnapshotHashes:
+    def _seed(self, tmp_path, issues):
+        snap_dir = str(tmp_path / "snapshots")
+        os.makedirs(snap_dir)
+        snap = {
+            "query_timestamp": "2026-04-01T00:00:00Z",
+            "timestamp": "2026-04-01T00:00:01Z",
+            "issues": issues,
+        }
+        path = os.path.join(snap_dir, "issue-snapshot-20260401-000000.yaml")
+        with open(path, "w") as f:
+            yaml.dump(snap, f, default_flow_style=False, sort_keys=False)
+        return snap_dir, path
+
+    def test_submitted_hashes_written_as_dict(self, tmp_path):
+        """Submitted hashes written in new dict format with processed=True."""
+        snap_dir, path = self._seed(tmp_path, {"K1": "old-hash"})
+        result = update_snapshot_hashes({"K1": "new-hash"}, snap_dir)
+        assert result is not None
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert data["issues"]["K1"] == {"hash": "new-hash", "processed": True}
+
+    def test_mark_processed_preserves_hash(self, tmp_path):
+        """mark_processed sets processed=True without changing hash."""
+        snap_dir, path = self._seed(tmp_path, {
+            "K1": {"hash": "aaa", "processed": False},
+        })
+        result = update_snapshot_hashes({}, snap_dir, mark_processed=["K1"])
+        assert result is not None
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert data["issues"]["K1"] == {"hash": "aaa", "processed": True}
+
+    def test_mark_processed_old_format(self, tmp_path):
+        """mark_processed on old string format → converts to dict."""
+        snap_dir, path = self._seed(tmp_path, {"K1": "aaa"})
+        result = update_snapshot_hashes({}, snap_dir, mark_processed=["K1"])
+        assert result is not None
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert data["issues"]["K1"] == {"hash": "aaa", "processed": True}
+
+    def test_mark_processed_skips_missing_key(self, tmp_path):
+        """mark_processed with key not in snapshot → no error, no change."""
+        snap_dir, path = self._seed(tmp_path, {"K1": "aaa"})
+        result = update_snapshot_hashes(
+            {}, snap_dir, mark_processed=["MISSING"])
+        assert result is not None
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert data["issues"]["K1"] == "aaa"  # untouched
+
+    def test_submitted_and_mark_processed_together(self, tmp_path):
+        """Both hashes and mark_processed in single call."""
+        snap_dir, path = self._seed(tmp_path, {
+            "K1": {"hash": "old", "processed": False},
+            "K2": {"hash": "bbb", "processed": False},
+        })
+        result = update_snapshot_hashes(
+            {"K1": "new-hash"}, snap_dir, mark_processed=["K2"])
+        assert result is not None
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert data["issues"]["K1"] == {"hash": "new-hash", "processed": True}
+        assert data["issues"]["K2"] == {"hash": "bbb", "processed": True}
+
+    def test_empty_hashes_and_no_mark_processed(self, tmp_path):
+        """Empty hashes + no mark_processed → snapshot still written."""
+        snap_dir, path = self._seed(tmp_path, {"K1": "aaa"})
+        result = update_snapshot_hashes({}, snap_dir)
+        assert result is not None
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert data["issues"]["K1"] == "aaa"  # untouched
 
 
 def _make_results_dir(tmp_path, runs):

--- a/tests/test_snapshot_fetch_integration.py
+++ b/tests/test_snapshot_fetch_integration.py
@@ -87,6 +87,11 @@ def _latest_snapshot(work_dirs):
         return yaml.safe_load(f)
 
 
+def _mark_processed(work_dirs, ids):
+    """Simulate pipeline completion: mark selected IDs as processed."""
+    update_snapshot_hashes({}, work_dirs.snapshot_dir, mark_processed=ids)
+
+
 def _seed_snapshot(work_dirs, issues, query_ts="2026-04-01T00:00:00Z"):
     """Write a previous snapshot."""
     snap = {
@@ -139,7 +144,10 @@ class TestCmdFetchFirstRun:
             snap = yaml.safe_load(f)
         assert "RHAIRFE-1" in snap["issues"]
         assert "query_timestamp" in snap
-        assert len(snap["issues"]["RHAIRFE-1"]) == 64
+        entry = snap["issues"]["RHAIRFE-1"]
+        assert isinstance(entry, dict)
+        assert len(entry["hash"]) == 64
+        assert entry["processed"] is False
 
 
 # ── cmd_fetch: Incremental Run ───────────────────────────────────────────────
@@ -296,6 +304,11 @@ class TestMultiRunPipeline:
         assert "TOTAL=2" in stdout1
         assert "NEW=2" in stdout1
 
+        # Run 1: simulate pipeline completing for both IDs
+        update_snapshot_hashes(
+            {}, work_dirs.snapshot_dir,
+            mark_processed=["RHAIRFE-1", "RHAIRFE-2"])
+
         # Run 2: nothing changed — all unchanged, none in changed file
         args2 = _fetch_args(tmp_path)
         stdout2 = _run_fetch(args2)
@@ -315,11 +328,13 @@ class TestMultiRunPipeline:
         # Run 1: fetch all
         _run_fetch(_fetch_args(tmp_path))
 
-        # Run 1: submit revises RHAIRFE-1, updates snapshot
+        # Run 1: submit revises RHAIRFE-1, updates snapshot;
+        # also mark RHAIRFE-2 as processed (reviewed, no changes)
         revised_hash = compute_content_hash(
             _text_to_adf("Auto-revised description."))
         update_snapshot_hashes(
-            {"RHAIRFE-1": revised_hash}, work_dirs.snapshot_dir)
+            {"RHAIRFE-1": revised_hash}, work_dirs.snapshot_dir,
+            mark_processed=["RHAIRFE-2"])
         # Simulate Jira now has the revised description
         jira.request( "PUT", "/rest/api/3/issue/RHAIRFE-1",
                       {"fields": {"description": "Auto-revised description."}})
@@ -335,6 +350,11 @@ class TestMultiRunPipeline:
         assert "TOTAL=2" in stdout2
         assert "CHANGED=1" in stdout2
         assert _read_ids(args2.changed_file) == ["RHAIRFE-1"]
+
+        # Run 2: simulate pipeline completing for both
+        update_snapshot_hashes(
+            {}, work_dirs.snapshot_dir,
+            mark_processed=["RHAIRFE-1", "RHAIRFE-2"])
 
         # Run 3: nothing changed — all unchanged
         args3 = _fetch_args(tmp_path)
@@ -444,11 +464,12 @@ class TestMultiRunPipeline:
         assert "TOTAL=2" in stdout1
         assert "NEW=2" in stdout1
 
-        # Run 1: submit revises RHAIRFE-1
+        # Run 1: submit revises RHAIRFE-1, mark RHAIRFE-2 processed
         revised_hash = compute_content_hash(
             _text_to_adf("Revised issue one."))
         update_snapshot_hashes(
-            {"RHAIRFE-1": revised_hash}, work_dirs.snapshot_dir)
+            {"RHAIRFE-1": revised_hash}, work_dirs.snapshot_dir,
+            mark_processed=["RHAIRFE-2"])
         jira.request( "PUT", "/rest/api/3/issue/RHAIRFE-1",
                       {"fields": {"description": "Revised issue one."}})
 
@@ -529,24 +550,30 @@ class TestCumulativeSnapshot:
         _jira_env(monkeypatch, jira.url)
 
         # Run 1: limit=1, 3 NEW → select 1
-        stdout1 = _run_fetch(_fetch_args(tmp_path, limit=1))
+        args1 = _fetch_args(tmp_path, limit=1)
+        stdout1 = _run_fetch(args1)
         assert "NEW=1" in stdout1
         snap1 = _latest_snapshot(work_dirs)
         assert len(snap1["issues"]) == 1
+        _mark_processed(work_dirs, _read_ids(args1.ids_file))
 
-        # Run 2: prev has 1, 2 still NEW → select 1 NEW (priority)
-        stdout2 = _run_fetch(_fetch_args(tmp_path, limit=1))
+        # Run 2: prev has 1 processed, 2 still NEW → select 1 NEW (priority)
+        args2 = _fetch_args(tmp_path, limit=1)
+        stdout2 = _run_fetch(args2)
         assert "NEW=1" in stdout2
         snap2 = _latest_snapshot(work_dirs)
         assert len(snap2["issues"]) == 2
+        _mark_processed(work_dirs, _read_ids(args2.ids_file))
 
-        # Run 3: prev has 2, 1 still NEW → select 1 NEW
-        stdout3 = _run_fetch(_fetch_args(tmp_path, limit=1))
+        # Run 3: prev has 2 processed, 1 still NEW → select 1 NEW
+        args3 = _fetch_args(tmp_path, limit=1)
+        stdout3 = _run_fetch(args3)
         assert "NEW=1" in stdout3
         snap3 = _latest_snapshot(work_dirs)
         assert len(snap3["issues"]) == 3
+        _mark_processed(work_dirs, _read_ids(args3.ids_file))
 
-        # Run 4: all in snapshot → 0 NEW, 0 CHANGED
+        # Run 4: all in snapshot + processed → 0 NEW, 0 CHANGED
         stdout4 = _run_fetch(_fetch_args(tmp_path, limit=1))
         assert "NEW=0" in stdout4
         assert "CHANGED=0" in stdout4
@@ -562,6 +589,7 @@ class TestCumulativeSnapshot:
         _run_fetch(_fetch_args(tmp_path))
         snap1 = _latest_snapshot(work_dirs)
         assert len(snap1["issues"]) == 2
+        _mark_processed(work_dirs, ["RHAIRFE-1", "RHAIRFE-2"])
 
         # Close RHAIRFE-2
         transitions = jira.request(
@@ -594,11 +622,13 @@ class TestCumulativeSnapshot:
         _run_fetch(args1)
         snap1 = _latest_snapshot(work_dirs)
         assert len(snap1["issues"]) == 2
+        _mark_processed(work_dirs, _read_ids(args1.ids_file))
 
         # Run 2: limit=1, RHAIRFE-3 is NEW (priority), selected
         args2 = _fetch_args(tmp_path, limit=1)
         stdout2 = _run_fetch(args2)
         assert "NEW=1" in stdout2
+        _mark_processed(work_dirs, _read_ids(args2.ids_file))
 
         # Edit RHAIRFE-2 (already in snapshot with stale hash)
         jira.request("PUT", "/rest/api/3/issue/RHAIRFE-2",
@@ -638,24 +668,28 @@ class TestCumulativeSnapshot:
         _run_fetch(_fetch_args(tmp_path))
         snap1 = _latest_snapshot(work_dirs)
         assert len(snap1["issues"]) == 2
-        old_hash_1 = snap1["issues"]["RHAIRFE-1"]
+        old_entry_1 = snap1["issues"]["RHAIRFE-1"]
 
         # Simulate submit: update RHAIRFE-1's description in Jira and
-        # record the post-submit hash in the snapshot
+        # record the post-submit hash in the snapshot;
+        # also mark RHAIRFE-2 as processed (no changes)
         jira.request("PUT", "/rest/api/3/issue/RHAIRFE-1",
                      {"fields": {"description": "Revised by submit."}})
         new_adf = _text_to_adf("Revised by submit.")
         post_submit_hash = compute_content_hash(new_adf)
         update_snapshot_hashes(
             {"RHAIRFE-1": post_submit_hash},
-            snapshot_dir=work_dirs.snapshot_dir)
+            snapshot_dir=work_dirs.snapshot_dir,
+            mark_processed=["RHAIRFE-2"])
 
         # Verify the snapshot was updated in place
         snap_updated = _latest_snapshot(work_dirs)
-        assert snap_updated["issues"]["RHAIRFE-1"] == post_submit_hash
-        assert snap_updated["issues"]["RHAIRFE-1"] != old_hash_1
-        # RHAIRFE-2 untouched
-        assert snap_updated["issues"]["RHAIRFE-2"] == snap1["issues"]["RHAIRFE-2"]
+        entry_1 = snap_updated["issues"]["RHAIRFE-1"]
+        assert entry_1 == {"hash": post_submit_hash, "processed": True}
+        assert entry_1 != old_entry_1
+        # RHAIRFE-2 marked processed, hash preserved
+        entry_2 = snap_updated["issues"]["RHAIRFE-2"]
+        assert entry_2["processed"] is True
 
         # Run 2: RHAIRFE-1 should be UNCHANGED (post-submit hash matches)
         args2 = _fetch_args(tmp_path)

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -350,10 +350,11 @@ class TestRemoveLabels:
         r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
-        # Snapshot should be unchanged (no submitted hashes)
+        # Snapshot hash preserved, but marked processed (pipeline completed)
         with open(snap_path) as f:
             data = yaml.safe_load(f)
-        assert data["issues"]["RHAIRFE-1234"] == "original-hash"
+        entry = data["issues"]["RHAIRFE-1234"]
+        assert entry == {"hash": "original-hash", "processed": True}
 
 
 class TestConflictDetection:
@@ -464,8 +465,10 @@ class TestSnapshotUpdate:
         issues = jira.search("project = RHAIRFE")
         key = issues[0]["key"]
         assert key in data["issues"]
-        assert isinstance(data["issues"][key], str)
-        assert len(data["issues"][key]) == 64  # SHA256 hex
+        entry = data["issues"][key]
+        assert isinstance(entry, dict)
+        assert len(entry["hash"]) == 64  # SHA256 hex
+        assert entry["processed"] is True
         # Other issues in snapshot still present
         assert data["issues"]["RHAIRFE-9000"] == "existing"
 
@@ -487,8 +490,11 @@ class TestSnapshotUpdate:
         with open(snap_path) as f:
             data = yaml.safe_load(f)
         assert "RHAIRFE-1234" in data["issues"]
-        assert len(data["issues"]["RHAIRFE-1234"]) == 64
-        assert data["issues"]["RHAIRFE-1234"] != "old-hash"
+        entry = data["issues"]["RHAIRFE-1234"]
+        assert isinstance(entry, dict)
+        assert len(entry["hash"]) == 64
+        assert entry["hash"] != "old-hash"
+        assert entry["processed"] is True
 
     def test_no_update_when_all_skipped(self, art_dir, jira):
         """All RFEs rejected/skipped → snapshot unchanged."""
@@ -504,7 +510,66 @@ class TestSnapshotUpdate:
 
         with open(snap_path) as f:
             data = yaml.safe_load(f)
-        # Snapshot untouched — still just the original issue
+        # Rejected entries are marked processed (pipeline completed)
+        entry = data["issues"]["RHAIRFE-1234"]
+        assert entry == {"hash": "existing", "processed": True}
+
+    def test_dry_run_does_not_update_snapshot(self, art_dir, jira):
+        """Dry-run must not write processed flags or hashes to snapshot."""
+        snap_path = self._seed_snapshot(art_dir, {"RHAIRFE-1234": "existing"})
+
+        # Set up a passing RFE that would normally be submitted
+        jira.create("RHAIRFE-1234", "Test RFE", "Original.")
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", "Original.")
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n---\nRevised.")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               _review("RHAIRFE-1234"))
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": jira.url,
+            "JIRA_USER": "admin",
+            "JIRA_TOKEN": "admin",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT, "--artifacts-dir", art_dir,
+             "--dry-run"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+
+        # Snapshot must be completely untouched
+        with open(snap_path) as f:
+            data = yaml.safe_load(f)
+        assert data["issues"] == {"RHAIRFE-1234": "existing"}
+
+    def test_dry_run_does_not_mark_processed(self, art_dir, jira):
+        """Dry-run with all-skipped entries must not mark processed."""
+        snap_path = self._seed_snapshot(art_dir, {"RHAIRFE-1234": "existing"})
+
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               TASK_FM.format(rfe_id="RHAIRFE-1234"))
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": jira.url,
+            "JIRA_USER": "admin",
+            "JIRA_TOKEN": "admin",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT, "--artifacts-dir", art_dir,
+             "--dry-run"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+
+        # Snapshot untouched — dry-run must not mark processed
+        with open(snap_path) as f:
+            data = yaml.safe_load(f)
         assert data["issues"] == {"RHAIRFE-1234": "existing"}
 
 


### PR DESCRIPTION
## Summary
- **Snapshot poisoning fix**: Added `processed` flag to snapshot entries. IDs start `processed: false` at fetch time and only become `true` after `submit.py` completes. Unprocessed entries (e.g., from a skipped batch) re-surface as NEW on the next run instead of being silently skipped as UNCHANGED.
- **Return breadcrumbs**: `rfe.review` callers now pass `--caller autofix|split`. Review persists it and uses specific step references in the headless return block, surviving context compression better than the old generic "return to calling skill" text.
- **Documentation**: Updated `docs/snapshot-incremental-fetch.md` with new snapshot format, processed flag state machine, updated failure modes, and 2 new design invariants (7 and 8).

## Test plan
- [x] 82 tests pass (1 pre-existing failure on main: `test_children_inherit_components_and_labels`)
- [x] Unit tests for `diff_snapshots` processed flag handling (7 tests)
- [x] Unit tests for `update_snapshot_hashes` with mark_processed (6 tests)
- [x] Integration tests updated to use mark_processed between simulated pipeline runs
- [x] Dry-run integration tests verify snapshot is not modified
- [x] Backwards compatibility: old string-format snapshot entries treated as `processed: true`
- [x] Synthetic agent tests confirmed Claude correctly parses `--caller`, persists it, and follows the right return path

🤖 Generated with [Claude Code](https://claude.com/claude-code)