### PR TITLE
Fix auto_revised false positive and record split-child snapshot hashes

### DIFF
--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -179,6 +179,12 @@ If the script reports files differ and frontmatter shows `auto_revised=false`, f
 python3 scripts/frontmatter.py set artifacts/rfe-reviews/<ID>-review.md auto_revised=true
 ```
 
+If the script reports files are identical and frontmatter shows `auto_revised=true`, fix it:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/rfe-reviews/<ID>-review.md auto_revised=false
+```
+
 ## Review Step 4: Re-assess if Revised (max 2 cycles)
 
 Re-read ID list from disk:

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -257,6 +257,41 @@ def main():
                 sys.exit(result.returncode)
             print()
 
+    # Collect and persist content hashes for split children so the snapshot
+    # records them.  split_submit.py creates child tickets but doesn't update
+    # the snapshot, so without this the children appear as "new" on the next
+    # run.  Persisted immediately so no downstream code path can skip them.
+    if split_parents and not args.dry_run:
+        try:
+            split_child_hashes = {}
+            post_split_tasks = scan_task_files(args.artifacts_dir)
+            for path, data in post_split_tasks:
+                if data.get("parent_key") and \
+                        data.get("status") == "Submitted":
+                    rfe_id = data.get("rfe_id", "")
+                    if rfe_id.startswith("RHAIRFE-"):
+                        with open(path, encoding="utf-8") as f:
+                            raw = f.read()
+                        cleaned = strip_metadata(raw)
+                        desc_adf = markdown_to_adf(cleaned)
+                        split_child_hashes[rfe_id] = compute_content_hash(
+                            desc_adf)
+            if split_child_hashes:
+                snap_dir = os.path.join(args.artifacts_dir,
+                                        "auto-fix-runs")
+                updated = update_snapshot_hashes(
+                    split_child_hashes, snap_dir)
+                if updated:
+                    print(f"  Updated snapshot with "
+                          f"{len(split_child_hashes)} split-child "
+                          f"hashes: {updated}")
+                else:
+                    print("  Warning: no snapshot found for split-child "
+                          f"hashes", file=sys.stderr)
+        except Exception as exc:
+            print(f"  Warning: failed to record split-child hashes "
+                  f"in snapshot: {exc}", file=sys.stderr)
+
     # --- Phase 2: Submit regular (non-split) RFEs ---
     # Re-scan after splits may have renamed files
     tasks = scan_task_files(args.artifacts_dir)
@@ -572,7 +607,7 @@ def main():
     print()
 
     # Update snapshot with post-submit hashes so the next fetch
-    # doesn't re-flag our own changes
+    # doesn't re-flag our own changes.
     if (submitted_hashes or mark_processed_ids) and not args.dry_run:
         snap_dir = os.path.join(args.artifacts_dir, "auto-fix-runs")
         updated = update_snapshot_hashes(submitted_hashes, snap_dir,

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -839,3 +839,120 @@ class TestReplayIdempotency:
         assert r2.returncode == 0, r2.stderr
         assert "Labels" not in r2.stdout
         assert "Updated" not in r2.stdout
+
+
+class TestSplitChildSnapshot:
+    """Split children's content hashes must be recorded in the snapshot."""
+
+    PARENT_TASK = (
+        "---\nrfe_id: RHAIRFE-1000\ntitle: Parent RFE\n"
+        "priority: Major\nstatus: Archived\n---\n\nParent content.\n"
+    )
+    CHILD_TASK_TPL = (
+        "---\nrfe_id: RFE-{num:03d}\ntitle: Child RFE {num}\n"
+        "priority: Major\nstatus: Ready\n"
+        "parent_key: RHAIRFE-1000\n---\n\nChild {num} content.\n"
+    )
+
+    def _seed_snapshot(self, art_dir, issues):
+        snap_dir = os.path.join(art_dir, "auto-fix-runs")
+        os.makedirs(snap_dir, exist_ok=True)
+        snap = {
+            "query_timestamp": "2026-04-01T00:00:00Z",
+            "timestamp": "2026-04-01T00:00:01Z",
+            "issues": issues,
+        }
+        path = os.path.join(snap_dir,
+                            "issue-snapshot-20260401-000000.yaml")
+        with open(path, "w") as f:
+            yaml.dump(snap, f, default_flow_style=False, sort_keys=False)
+        return path
+
+    def _setup_split(self, art_dir, jira, num_children=2):
+        """Set up a split parent with children and a seeded snapshot."""
+        jira.create("RHAIRFE-1000", "Parent RFE", "Parent content.")
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1000.md",
+               "Parent content.")
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
+        for i in range(1, num_children + 1):
+            _write(f"{art_dir}/rfe-tasks/RFE-{i:03d}.md",
+                   self.CHILD_TASK_TPL.format(num=i))
+        return self._seed_snapshot(art_dir, {"RHAIRFE-1000": "parent-hash"})
+
+    def test_split_child_hashes_in_snapshot(self, art_dir, jira):
+        """Split children's hashes appear in the snapshot after submit."""
+        snap_path = self._setup_split(art_dir, jira)
+
+        # Add a regular RFE so Phase 2 also runs
+        _write(f"{art_dir}/rfe-tasks/RFE-099.md",
+               TASK_FM.format(rfe_id="RFE-099"))
+        _write(f"{art_dir}/rfe-reviews/RFE-099-review.md",
+               _review("RFE-099"))
+
+        r = _run_submit(art_dir, jira.url)
+        assert r.returncode == 0, r.stderr
+        assert "split-child hashes" in r.stdout
+
+        with open(snap_path) as f:
+            data = yaml.safe_load(f)
+
+        # Find the child keys (RHAIRFE-NNNN created by split_submit.py)
+        all_issues = jira.search("project = RHAIRFE")
+        child_keys = sorted([i["key"] for i in all_issues
+                             if i["key"] != "RHAIRFE-1000"])
+        # At least the 2 split children + 1 regular RFE
+        assert len(child_keys) >= 3
+
+        # Each split child must have a valid hash in the snapshot
+        split_child_entries = {
+            k: v for k, v in data["issues"].items()
+            if k != "RHAIRFE-1000" and isinstance(v, dict)
+            and len(v.get("hash", "")) == 64
+        }
+        assert len(split_child_entries) >= 2
+        for key, entry in split_child_entries.items():
+            assert entry["processed"] is True
+
+    def test_splits_only_early_return(self, art_dir, jira):
+        """Splits-only run (no regular RFEs) completes and records hashes."""
+        snap_path = self._setup_split(art_dir, jira)
+
+        r = _run_submit(art_dir, jira.url)
+        assert r.returncode == 0, r.stderr
+        assert "split-child hashes" in r.stdout
+        assert "Done. Index rebuilt" in r.stdout
+
+        with open(snap_path) as f:
+            data = yaml.safe_load(f)
+
+        # Split children must have valid hashes
+        child_entries = {
+            k: v for k, v in data["issues"].items()
+            if k != "RHAIRFE-1000" and isinstance(v, dict)
+        }
+        assert len(child_entries) >= 2
+        for key, entry in child_entries.items():
+            assert len(entry["hash"]) == 64, f"{key} hash should be SHA256"
+            assert entry["processed"] is True
+
+    def test_dry_run_skips_split_child_hashes(self, art_dir, jira):
+        """Dry-run must not update the snapshot with split-child hashes."""
+        snap_path = self._setup_split(art_dir, jira)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": jira.url,
+            "JIRA_USER": "admin",
+            "JIRA_TOKEN": "admin",
+        }
+        r = subprocess.run(
+            [sys.executable, SCRIPT, "--artifacts-dir", art_dir,
+             "--dry-run"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+
+        # Snapshot must be completely untouched
+        with open(snap_path) as f:
+            data = yaml.safe_load(f)
+        assert data["issues"] == {"RHAIRFE-1000": "parent-hash"}


### PR DESCRIPTION
## Summary
- **auto_revised false positive**: Revise agents sometimes set `auto_revised=true` without changing the task file. The post-processing step only corrected false negatives, not false positives. This caused `collect_recommendations --reassess` to flag all falsely-marked IDs, triggering full wasted reassessment cycles. Fix: reset `auto_revised=false` when files are identical.
- **Split-child snapshot hashes**: Split children created by `split_submit.py` were not recorded in the issue snapshot, causing them to appear as "new" on subsequent runs. Fix: collect and persist their content hashes immediately after Phase 1 completes, before any early-return path can skip them.

## Evidence
- **False positive**: Job [13792728866](https://gitlab.com/redhat/rhel-ai/agentic-ci/rfe-autofixer/-/jobs/13792728866) -- 36 revise agents ran, none changed files, but frontmatter showed `auto_revised=True`, triggering a full wasted reassessment cycle.
- **Split-child**: RHAIRFE-1759 appeared as "new" on a subsequent run because its hash was never recorded in the snapshot.

## Test plan
- [x] Step 4e references "same as Review Step 3.5" so the auto_revised fix applies to reassessment revise cycles too
- [ ] Verify on next CI run that wasted reassessment cycles no longer occur
- [x] Integration test: split children hashes appear in snapshot after submit
- [x] Integration test: splits-only early return completes and records hashes
- [x] Integration test: dry-run skips split-child hash collection
- [x] Full test suite passes (30/30)

Generated with [Claude Code](https://claude.com/claude-code)