### PR TITLE
Fix submit for children of locally-created split parents

### DIFF
--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -173,6 +173,26 @@ def main():
                          and data["rfe_id"] in child_parent_keys}
     split_parents = list(split_parent_data.keys())
 
+    # Build parent ancestry map to identify descendants of Jira split
+    # parents at any depth (handles re-splits where grandchildren point
+    # to local intermediary parents like RFE-017 → RHAIRFE-1234).
+    _parent_of = {}  # rfe_id -> parent_key
+    for _, data in tasks:
+        pk = data.get("parent_key")
+        if pk:
+            _parent_of[data["rfe_id"]] = pk
+
+    def _has_jira_ancestor(rfe_id):
+        """True if rfe_id descends from any RHAIRFE parent."""
+        seen = set()
+        pk = _parent_of.get(rfe_id)
+        while pk and pk not in seen:
+            if pk.startswith("RHAIRFE-"):
+                return True
+            seen.add(pk)
+            pk = _parent_of.get(pk)
+        return False
+
     if split_parents:
         print(f"Phase 1: Submitting {len(split_parents)} split parent(s)\n")
         script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -296,16 +316,20 @@ def main():
     # Re-scan after splits may have renamed files
     tasks = scan_task_files(args.artifacts_dir)
 
-    # Filter to non-archived, non-submitted RFEs without a parent (split
-    # children were already handled by split_submit.py in Phase 1).
+    # Filter to non-archived, non-submitted RFEs.  Any descendant of a
+    # Jira split parent (RHAIRFE-*) was already handled by split_submit.py
+    # in Phase 1 — this includes grandchildren from re-splits whose
+    # immediate parent is a local ID (e.g. RFE-017 → RHAIRFE-1234).
+    # Children of purely local parents (RFE-NNN with no RHAIRFE ancestor)
+    # go through Phase 2 as regular creates.
     # Filtering Submitted makes replay safe: already-submitted entries are
     # skipped, preventing duplicate Jira creates.
     submittable = [(path, data) for path, data in tasks
                    if data.get("status") not in ("Archived", "Submitted")
-                   and not data.get("parent_key")]
+                   and not _has_jira_ancestor(data["rfe_id"])]
     any_submitted = any(data.get("status") == "Submitted"
                         for _, data in tasks
-                        if not data.get("parent_key"))
+                        if not _has_jira_ancestor(data["rfe_id"]))
     if not submittable:
         if split_parents or any_submitted:
             # Splits-only run, or replay where Phase 2 already completed

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -188,6 +188,77 @@ class TestSkipLogic:
         assert "No submittable" in stderr or "No RFE task" in stderr
 
 
+    def test_children_of_local_parent_submitted(self, art_dir):
+        """Children of local RFE-NNN parent → included in Phase 2 as creates."""
+        # Archived local parent
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               TASK_FM.format(rfe_id="RFE-001").replace(
+                   "status: Ready", "status: Archived"))
+        # Children with local parent_key
+        for i, child_id in enumerate(["RFE-002", "RFE-003"], start=2):
+            _write(f"{art_dir}/rfe-tasks/{child_id}.md",
+                   TASK_FM.format(rfe_id=child_id).replace(
+                       "status: Ready", "status: Ready\nparent_key: RFE-001"))
+            _write(f"{art_dir}/rfe-reviews/{child_id}-review.md",
+                   REVIEW_FM.format(rfe_id=child_id, auto_revised="false"))
+
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert "Would create" in stdout
+        assert "RFE-002" in stdout
+        assert "RFE-003" in stdout
+
+    def test_children_of_jira_parent_excluded(self, art_dir):
+        """Children of RHAIRFE parent → excluded from Phase 2 (Phase 1 handles)."""
+        # Child with Jira parent_key
+        _write(f"{art_dir}/rfe-tasks/RFE-002.md",
+               TASK_FM.format(rfe_id="RFE-002").replace(
+                   "status: Ready", "status: Ready\nparent_key: RHAIRFE-1234"))
+        _write(f"{art_dir}/rfe-reviews/RFE-002-review.md",
+               REVIEW_FM.format(rfe_id="RFE-002", auto_revised="false"))
+
+        stdout, stderr, rc = _run_submit(art_dir)
+        assert rc == 1
+        assert "No submittable" in stderr or "No RFE task" in stderr
+
+    def test_grandchildren_of_jira_parent_excluded(self, art_dir):
+        """Grandchildren via local intermediary → excluded from Phase 2.
+
+        Tests Phase 2 filtering only: the RHAIRFE parent task file is
+        omitted so Phase 1 has no split parents to run.  The ancestor
+        chain in frontmatter (RFE-011 → RFE-010 → RHAIRFE-1234) is
+        enough for _has_jira_ancestor to exclude the grandchildren.
+        A standalone RFE-020 is included so Phase 2 has work to do.
+        """
+        # Archived local intermediary whose parent_key traces to Jira
+        _write(f"{art_dir}/rfe-tasks/RFE-010.md",
+               TASK_FM.format(rfe_id="RFE-010").replace(
+                   "status: Ready",
+                   "status: Archived\nparent_key: RHAIRFE-1234"))
+        # Grandchildren — parent_key points to local intermediary
+        for child_id in ["RFE-011", "RFE-012"]:
+            _write(f"{art_dir}/rfe-tasks/{child_id}.md",
+                   TASK_FM.format(rfe_id=child_id).replace(
+                       "status: Ready",
+                       "status: Ready\nparent_key: RFE-010"))
+            _write(f"{art_dir}/rfe-reviews/{child_id}-review.md",
+                   REVIEW_FM.format(rfe_id=child_id, auto_revised="false"))
+        # Standalone RFE so Phase 2 runs (rc == 0)
+        _write(f"{art_dir}/rfe-tasks/RFE-020.md",
+               TASK_FM.format(rfe_id="RFE-020"))
+        _write(f"{art_dir}/rfe-reviews/RFE-020-review.md",
+               REVIEW_FM.format(rfe_id="RFE-020", auto_revised="false"))
+
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        # Standalone RFE submitted normally
+        assert "RFE-020" in stdout and "Would create" in stdout
+        # Grandchildren excluded from Phase 2 plan
+        plan_section = stdout.split("Submission plan:")[1]
+        assert "RFE-011" not in plan_section
+        assert "RFE-012" not in plan_section
+
+
 class TestAutoRevisedLabel:
     def test_auto_revised_label_applied(self, art_dir):
         """auto_revised=true → rfe-creator-auto-revised label."""


### PR DESCRIPTION
## Summary
- When `/rfe.split` decomposes a locally-created RFE (RFE-NNN) before submission to Jira, the children were silently excluded from submission — Phase 1 skipped the parent (not RHAIRFE-*) and Phase 2 excluded all children with `parent_key` set
- Added `_has_jira_ancestor()` to walk the parent chain, so only descendants of Jira parents are excluded from Phase 2 — children of purely local parents now go through as regular creates
- Handles re-splits correctly: grandchildren whose immediate parent is a local intermediary (RFE-017) but whose root ancestor is RHAIRFE-1234 are still excluded from Phase 2 (split_submit.py handles the full tree)

## Test plan
- [x] `test_children_of_local_parent_submitted` — children of RFE-001 get "Would create"
- [x] `test_children_of_jira_parent_excluded` — children of RHAIRFE-1234 excluded from Phase 2
- [x] `test_grandchildren_of_jira_parent_excluded` — grandchildren through local intermediary excluded from Phase 2, handled by Phase 1 tree walk
- [x] All 21 tests pass, including 5 split_submit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)