### PR TITLE
Fix rfe.speedrun Phase 1 deleting batch-created RFEs

### DIFF
--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -57,7 +57,7 @@ For each entry, invoke `/rfe.create` as an inline Skill:
 /rfe.create --headless [--priority <priority>] [--labels <labels>] <prompt>
 ```
 
-Collect all created RFE IDs from the output.
+Collect all created RFE IDs from the output. **Never delete, rename, or re-create RFE task files during Phase 1** — quality issues are addressed in Phase 2 (Auto-fix). Each batch entry must produce exactly one RFE with a stable ID.
 
 **Mode B (Existing RFE)**: Skip Phase 1. The Jira key(s) from arguments become the processing list.
 


### PR DESCRIPTION
## Summary

- Add explicit guardrail to rfe.speedrun Phase 1: never delete, rename, or re-create RFE task files during the create phase
- Quality issues are handled in Phase 2 (Auto-fix), not Phase 1

## Problem

During batch evaluation with 20 test cases, the LLM read all 5 created RFEs in the first batch, then deleted `RFE-003.md` before proceeding. Since `next_rfe_id.py` allocates IDs sequentially, the gap was never filled — the next batch started at `RFE-006`, and case-003 had no output.

This breaks the case-to-output mapping in batch mode: each batch entry at index N is expected to produce `RFE-{N:03d}`, and any deletion creates a permanent gap.

### Root cause

The Phase 1 instructions say "For each entry, invoke `/rfe.create`" and "Collect all created RFE IDs" — but don't prevent the LLM from quality-checking and deleting RFEs it just created. The LLM read `artifact_utils.py` (a helper script), judged RFE-003 as problematic, and deleted it before moving on.

### Fix

Added to Phase 1 instructions:
> **Never delete, rename, or re-create RFE task files during Phase 1** — quality issues are addressed in Phase 2 (Auto-fix). Each batch entry must produce exactly one RFE with a stable ID.

## Test plan

- [ ] Run `/rfe.speedrun --headless --dry-run --input batch.yaml` with 20 entries
- [ ] Verify all 20 `RFE-001.md` through `RFE-020.md` files exist after Phase 1
- [ ] Verify no RFE task files are deleted during the create phase

Found via agent-eval-harness evaluation run (`2026-04-07-opus-v3`): 19/20 cases passed, case-003 failed all judges due to missing output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)