### PR TITLE
Fix default artifacts path to use CWD instead of __file__

### DIFF
--- a/scripts/generate_review_pdf.py
+++ b/scripts/generate_review_pdf.py
@@ -12,7 +12,7 @@ import yaml
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from artifact_utils import find_artifact_file_including_archived, read_frontmatter
 
-DEFAULT_ARTIFACTS = os.path.join(os.path.dirname(__file__), '..', 'artifacts')
+DEFAULT_ARTIFACTS = os.path.join(os.getcwd(), 'artifacts')
 
 def get_revision_history(body):
     """Extract revision history section from review body."""

--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -12,8 +12,7 @@ import yaml
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from artifact_utils import find_review_file, read_frontmatter, scan_task_files
 
-DEFAULT_ARTIFACTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                    "..", "artifacts")
+DEFAULT_ARTIFACTS_DIR = os.path.join(os.getcwd(), "artifacts")
 SCORE_FIELDS = ["what", "why", "open_to_how", "not_a_task", "right_sized"]
 
 


### PR DESCRIPTION
## Summary

- Fix `generate_run_report.py` and `generate_review_pdf.py` to use `os.getcwd()` instead of `os.path.dirname(__file__)` for the default artifacts directory

## Problem

Both scripts resolve the default `artifacts/` path relative to `__file__`. When `scripts/` is symlinked into a different working directory (e.g., by the eval harness workspace), Python resolves `__file__` through the symlink back to the **project root**. This causes:

- YAML run reports written to the project's `artifacts/auto-fix-runs/` instead of the workspace's
- HTML review reports reading stale/empty review files from the project root, producing reports filled with zeros

Both scripts are always invoked from the project or workspace root via `python3 scripts/generate_*.py`, so `os.getcwd()` is the correct base path.

## Test plan

- [ ] Run `rfe.speedrun` normally (no symlinks) — verify reports still written to `artifacts/auto-fix-runs/`
- [ ] Run via eval harness workspace (symlinked `scripts/`) — verify reports written to workspace `artifacts/`, not project root

Found via agent-eval-harness evaluation: `run_report_exists` judge scored 0% in v3 (report written to wrong dir), 100% in v5 after this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)