### PR TITLE
Fix JQL to include issues with no labels

### DIFF
--- a/docs/snapshot-incremental-fetch.md
+++ b/docs/snapshot-incremental-fetch.md
@@ -323,7 +323,7 @@ desired processing outcome:
 
 ```
 (<user-jql>) AND statusCategory != Done
-             AND labels not in (rfe-creator-ignore)
+             AND (labels not in (rfe-creator-ignore) OR labels is EMPTY)
 ```
 
 These filters are "hard" because an issue matching them should always be

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -286,7 +286,7 @@ def main():
 
     # Step 2: Fetch all current issues with hard filters
     jql = (f"({args.jql}) AND statusCategory != Done "
-           f"AND labels not in (rfe-creator-ignore)")
+           f"AND (labels not in (rfe-creator-ignore) OR labels is EMPTY)")
     print(f"JQL: {jql}", file=sys.stderr)
 
     current = fetch_all_issues(server, user, token, jql)

--- a/scripts/jql_query.py
+++ b/scripts/jql_query.py
@@ -72,7 +72,7 @@ def main():
               file=sys.stderr)
         sys.exit(1)
 
-    jql = f"({args.jql}) AND statusCategory != Done AND labels not in (rfe-creator-ignore, rfe-creator-autofix-rubric-pass)"
+    jql = f"({args.jql}) AND statusCategory != Done AND (labels not in (rfe-creator-ignore, rfe-creator-autofix-rubric-pass) OR labels is EMPTY)"
     print(f"JQL={jql}", file=sys.stderr)
     search_issues(server, user, token, jql, args.limit)
 

--- a/scripts/snapshot_fetch.py
+++ b/scripts/snapshot_fetch.py
@@ -312,8 +312,10 @@ def cmd_fetch(args):
         print("Previous snapshot: none (first run)", file=sys.stderr)
 
     # Hard filters only
+    # NOTE: "labels not in (X)" excludes issues with NO labels at all in Jira,
+    # so we must also include "labels is EMPTY" to catch unlabeled issues.
     jql = (f"({args.jql}) AND statusCategory != Done "
-           f"AND labels not in (rfe-creator-ignore)")
+           f"AND (labels not in (rfe-creator-ignore) OR labels is EMPTY)")
     print(f"JQL={jql}", file=sys.stderr)
 
     query_timestamp = datetime.now(timezone.utc).strftime(


### PR DESCRIPTION
## Summary
- Jira's `labels not in (X)` operator silently excludes issues where the labels field is empty/null, not just issues with the excluded label
- This caused all unlabeled issues to be dropped from auto-fix runs
- Adds `OR labels is EMPTY` to all hard filter JQL in `snapshot_fetch.py`, `bootstrap_snapshot.py`, `jql_query.py`, and the design docs

## Test plan
- [ ] Run `snapshot_fetch.py` with the fixed JQL and confirm unlabeled issues now appear in results
- [ ] Verify issues with `rfe-creator-ignore` label are still excluded
- [ ] Trigger a CI auto-fix run and confirm the issue count increases to include previously-missing unlabeled issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)