### PR TITLE
Add --batch mode to check_revised.py to fix auto_revised flag

### DIFF
--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -161,28 +161,10 @@ python3 scripts/check_review_progress.py --phase revise --id-file tmp/rfe-poll-r
 
 Sleep for the `NEXT_POLL` seconds reported by the script before polling again. Wait for all to complete.
 
-**Post-processing: fix auto_revised flag.** The revise agent may run out of budget before setting `auto_revised=true`. After all agents complete, re-read the revised ID list from the poll file (compression may have lost them during agent execution):
+**Post-processing: fix auto_revised flag.** The revise agent may run out of budget before setting `auto_revised=true`. After all agents complete, run the batch check which compares originals to task files and sets the flag directly in review frontmatter:
 
 ```bash
-python3 scripts/state.py read-ids tmp/rfe-poll-revise.txt
-```
-
-For each revised ID, verify the flag is correct:
-
-```bash
-python3 scripts/check_revised.py artifacts/rfe-originals/<ID>.md artifacts/rfe-tasks/<ID>.md
-```
-
-If the script reports files differ and frontmatter shows `auto_revised=false`, fix it:
-
-```bash
-python3 scripts/frontmatter.py set artifacts/rfe-reviews/<ID>-review.md auto_revised=true
-```
-
-If the script reports files are identical and frontmatter shows `auto_revised=true`, fix it:
-
-```bash
-python3 scripts/frontmatter.py set artifacts/rfe-reviews/<ID>-review.md auto_revised=false
+python3 scripts/check_revised.py --batch $(python3 scripts/state.py read-ids tmp/rfe-poll-revise.txt)
 ```
 
 ## Review Step 4: Re-assess if Revised (max 2 cycles)
@@ -295,7 +277,11 @@ python3 scripts/preserve_review_state.py restore <all_reassess_IDs_from_file>
 python3 scripts/filter_for_revision.py <all_reassess_IDs_from_file>
 ```
 
-Launch revise agents for the IDs returned (if any). Wait for all to complete, run post-processing auto_revised flag fix (same as Review Step 3.5).
+Launch revise agents for the IDs returned (if any). Wait for all to complete, then run the batch auto_revised flag fix:
+
+```bash
+python3 scripts/check_revised.py --batch $(python3 scripts/state.py read-ids tmp/review-reassess-ids.txt)
+```
 
 After cycle 2, stop regardless of results.
 

--- a/scripts/check_revised.py
+++ b/scripts/check_revised.py
@@ -1,14 +1,24 @@
 """Check if an RFE task file was revised compared to its original.
 
-Compares file content (excluding YAML frontmatter) and reports whether
-the files differ. Used by the review orchestrator to fix the revised flag
-when the revise agent runs out of budget before setting it.
+Modes:
+  Single-pair:  check_revised.py <original> <task>
+    Prints REVISED=true/false.  Used by orchestrator for one-off checks.
+
+  Batch:  check_revised.py --batch [ID ...]
+    Scans originals vs tasks for every ID (or all if none given),
+    sets auto_revised in review frontmatter directly.  No LLM loop needed.
 
 Usage:
     python3 scripts/check_revised.py artifacts/rfe-originals/ID.md artifacts/rfe-tasks/ID.md
+    python3 scripts/check_revised.py --batch
+    python3 scripts/check_revised.py --batch RHAIRFE-1504 RHAIRFE-1510
 """
 
+import os
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from artifact_utils import find_review_file, read_frontmatter, update_frontmatter
 
 
 def strip_frontmatter(text):
@@ -22,24 +32,70 @@ def strip_frontmatter(text):
     return text
 
 
-def main():
-    if len(sys.argv) != 3:
-        print("Usage: check_revised.py <original_file> <task_file>", file=sys.stderr)
-        sys.exit(2)
-
-    original_path = sys.argv[1]
-    task_path = sys.argv[2]
-
+def check_pair(original_path, task_path):
+    """Return True if body content differs, False if same, None if file missing."""
     try:
         with open(original_path) as f:
             original = strip_frontmatter(f.read())
         with open(task_path) as f:
             task = strip_frontmatter(f.read())
-    except FileNotFoundError as e:
-        print(f"FILE_MISSING={e.filename}")
-        sys.exit(1)
+    except FileNotFoundError:
+        return None
+    return original.strip() != task.strip()
 
-    if original.strip() != task.strip():
+
+def batch_mode(ids, artifacts_dir="artifacts"):
+    """Compare originals to tasks and set auto_revised in review frontmatter."""
+    originals_dir = os.path.join(artifacts_dir, "rfe-originals")
+    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
+
+    # If no IDs given, discover from originals dir
+    if not ids:
+        ids = [os.path.splitext(f)[0]
+               for f in os.listdir(originals_dir)
+               if f.endswith(".md")]
+
+    changed = 0
+    for rfe_id in sorted(ids):
+        original = os.path.join(originals_dir, f"{rfe_id}.md")
+        task = os.path.join(tasks_dir, f"{rfe_id}.md")
+        review = find_review_file(artifacts_dir, rfe_id)
+        if not review:
+            continue
+
+        revised = check_pair(original, task)
+        if revised is None:
+            continue
+
+        data, _ = read_frontmatter(review)
+        current = data.get("auto_revised", False)
+        if revised != current:
+            update_frontmatter(review, {"auto_revised": revised}, "rfe-review")
+            changed += 1
+            print(f"{rfe_id}: auto_revised {current} -> {revised}")
+        else:
+            print(f"{rfe_id}: auto_revised={current} (correct)")
+
+    print(f"UPDATED={changed}")
+
+
+def main():
+    if "--batch" in sys.argv:
+        args = [a for a in sys.argv[1:] if a != "--batch"]
+        batch_mode(args)
+        return
+
+    if len(sys.argv) != 3:
+        print("Usage: check_revised.py <original> <task>", file=sys.stderr)
+        print("       check_revised.py --batch [ID ...]", file=sys.stderr)
+        sys.exit(2)
+
+    revised = check_pair(sys.argv[1], sys.argv[2])
+    if revised is None:
+        missing = sys.argv[1] if not os.path.exists(sys.argv[1]) else sys.argv[2]
+        print(f"FILE_MISSING={missing}")
+        sys.exit(1)
+    if revised:
         print("REVISED=true")
     else:
         print("REVISED=false")

--- a/tests/test_check_revised.py
+++ b/tests/test_check_revised.py
@@ -83,3 +83,122 @@ class TestCheckRevised:
             capture_output=True, text=True,
         )
         assert result.returncode == 2
+
+
+REVIEW_TEMPLATE = """\
+---
+rfe_id: {rfe_id}
+score: 7
+pass: false
+recommendation: revise
+feasibility: feasible
+auto_revised: {auto_revised}
+needs_attention: false
+scores:
+  what: 2
+  why: 1
+  open_to_how: 2
+  not_a_task: 2
+  right_sized: 0
+---
+Review body here.
+"""
+
+
+def _setup_batch(tmp_path, rfe_id, original_body, task_body, auto_revised=False):
+    """Create originals, tasks, and review dirs with test content."""
+    originals = tmp_path / "artifacts" / "rfe-originals"
+    tasks = tmp_path / "artifacts" / "rfe-tasks"
+    reviews = tmp_path / "artifacts" / "rfe-reviews"
+    originals.mkdir(parents=True, exist_ok=True)
+    tasks.mkdir(parents=True, exist_ok=True)
+    reviews.mkdir(parents=True, exist_ok=True)
+
+    (originals / f"{rfe_id}.md").write_text(original_body)
+    (tasks / f"{rfe_id}.md").write_text(
+        f"---\nrfe_id: {rfe_id}\ntitle: Test\npriority: Normal\nstatus: Draft\n---\n{task_body}"
+    )
+    (reviews / f"{rfe_id}-review.md").write_text(
+        REVIEW_TEMPLATE.format(rfe_id=rfe_id, auto_revised=str(auto_revised).lower())
+    )
+
+
+class TestBatchMode:
+    def test_sets_auto_revised_true_when_content_differs(self, tmp_path):
+        _setup_batch(tmp_path, "RHAIRFE-1001", "Original text.", "Revised text.",
+                     auto_revised=False)
+        result = subprocess.run(
+            ["python3", SCRIPT, "--batch", "RHAIRFE-1001"],
+            capture_output=True, text=True,
+            cwd=tmp_path,
+            env={**os.environ, "PYTHONPATH": os.path.dirname(SCRIPT)},
+        )
+        assert result.returncode == 0
+        assert "RHAIRFE-1001: auto_revised False -> True" in result.stdout
+        assert "UPDATED=1" in result.stdout
+        # Verify frontmatter was actually changed
+        review = (tmp_path / "artifacts" / "rfe-reviews" / "RHAIRFE-1001-review.md").read_text()
+        assert "auto_revised: true" in review
+
+    def test_sets_auto_revised_false_when_content_identical(self, tmp_path):
+        _setup_batch(tmp_path, "RHAIRFE-1002", "Same content.", "Same content.",
+                     auto_revised=True)
+        result = subprocess.run(
+            ["python3", SCRIPT, "--batch", "RHAIRFE-1002"],
+            capture_output=True, text=True,
+            cwd=tmp_path,
+            env={**os.environ, "PYTHONPATH": os.path.dirname(SCRIPT)},
+        )
+        assert result.returncode == 0
+        assert "RHAIRFE-1002: auto_revised True -> False" in result.stdout
+        assert "UPDATED=1" in result.stdout
+        review = (tmp_path / "artifacts" / "rfe-reviews" / "RHAIRFE-1002-review.md").read_text()
+        assert "auto_revised: false" in review
+
+    def test_no_update_when_flag_already_correct(self, tmp_path):
+        _setup_batch(tmp_path, "RHAIRFE-1003", "Original.", "Revised.",
+                     auto_revised=True)
+        result = subprocess.run(
+            ["python3", SCRIPT, "--batch", "RHAIRFE-1003"],
+            capture_output=True, text=True,
+            cwd=tmp_path,
+            env={**os.environ, "PYTHONPATH": os.path.dirname(SCRIPT)},
+        )
+        assert result.returncode == 0
+        assert "auto_revised=True (correct)" in result.stdout
+        assert "UPDATED=0" in result.stdout
+
+    def test_discovers_ids_when_none_given(self, tmp_path):
+        _setup_batch(tmp_path, "RHAIRFE-1004", "Original.", "Changed.",
+                     auto_revised=False)
+        _setup_batch(tmp_path, "RHAIRFE-1005", "Same.", "Same.",
+                     auto_revised=False)
+        result = subprocess.run(
+            ["python3", SCRIPT, "--batch"],
+            capture_output=True, text=True,
+            cwd=tmp_path,
+            env={**os.environ, "PYTHONPATH": os.path.dirname(SCRIPT)},
+        )
+        assert result.returncode == 0
+        assert "RHAIRFE-1004: auto_revised False -> True" in result.stdout
+        assert "RHAIRFE-1005: auto_revised=False (correct)" in result.stdout
+        assert "UPDATED=1" in result.stdout
+
+    def test_skips_missing_review_file(self, tmp_path):
+        """If an original+task exist but no review file, skip without error."""
+        originals = tmp_path / "artifacts" / "rfe-originals"
+        tasks = tmp_path / "artifacts" / "rfe-tasks"
+        reviews = tmp_path / "artifacts" / "rfe-reviews"
+        originals.mkdir(parents=True)
+        tasks.mkdir(parents=True)
+        reviews.mkdir(parents=True)
+        (originals / "RHAIRFE-1006.md").write_text("Original.")
+        (tasks / "RHAIRFE-1006.md").write_text("---\nrfe_id: RHAIRFE-1006\ntitle: T\npriority: Normal\nstatus: Draft\n---\nChanged.")
+        result = subprocess.run(
+            ["python3", SCRIPT, "--batch", "RHAIRFE-1006"],
+            capture_output=True, text=True,
+            cwd=tmp_path,
+            env={**os.environ, "PYTHONPATH": os.path.dirname(SCRIPT)},
+        )
+        assert result.returncode == 0
+        assert "UPDATED=0" in result.stdout


### PR DESCRIPTION
## Summary
- Adds `--batch` mode to `check_revised.py` that compares originals to task files and sets `auto_revised` directly in review frontmatter — replacing the fragile per-ID LLM loop
- Updates `rfe.review` SKILL.md (Steps 3.5 and 4e) to use the single `--batch` call
- Adds 5 tests for batch mode; all 12 tests pass

## Problem
In the 20260409-131404 CI run, only 3 out of 25 revised RFEs had `auto_revised: true` set correctly. This caused `--revised-only` HTML reports to be missing 22 detail pages for RFEs with significant score improvements (e.g. 2→7, 3→9).

The flag has two chances to be set:
1. **Revise agent** (Step 3 of revise-agent.md) — frequently exhausts budget before reaching the frontmatter update
2. **Orchestrator safety net** (rfe.review Step 3.5) — requires the LLM to loop through every ID, run `check_revised.py`, parse output, and call `frontmatter.py set`. Context compression during agent polling causes this loop to be skipped or truncated.

## Fix
`check_revised.py --batch [ID ...]` does the full compare-and-update in one deterministic script call. No LLM loop needed.

## Test plan
- [x] All 7 existing single-pair tests pass unchanged
- [x] 5 new batch mode tests: sets true, sets false, no-op when correct, auto-discovers IDs, skips missing review files

🤖 Generated with [Claude Code](https://claude.com/claude-code)