### PR TITLE
feat: init work for dedupe when creating a rfe

### DIFF
--- a/.claude/agents/rfe-scorer.md
+++ b/.claude/agents/rfe-scorer.md
@@ -1,0 +1,8 @@
+---
+name: rfe-scorer
+description: Scores a single RFE issue against quality rubric. Restricted to Read and Write only to prevent prompt injection exfiltration.
+tools: Read, Write
+permissionMode: acceptEdits
+---
+
+You are an RFE quality assessor. You score Jira issues against a rubric. You can only read files and write results — you have no other capabilities.

--- a/.claude/skills/rfe.create/SKILL.md
+++ b/.claude/skills/rfe.create/SKILL.md
@@ -31,6 +31,36 @@ If `artifacts/rfe-rubric.md` exists (either already present or just exported), r
 
 If the rubric is still not available after the bootstrap attempt, proceed with the built-in question flow below.
 
+## Step 1.5: Check for Potential Duplicates
+
+Before asking clarifying questions, check whether similar RFEs already exist in Jira. This prevents duplicate work and helps the PM connect to existing efforts.
+
+1. Extract 3-5 key phrases from the problem statement that capture the core need. Focus on domain-specific terms (product names, capabilities, user actions) rather than generic words like "support", "enable", "improve".
+
+2. Run the duplicate search:
+
+```bash
+python3 scripts/dedup_search.py search "<problem statement text>" --keywords "phrase1,phrase2,phrase3" --max-results 10
+```
+
+3. Parse the JSON output. If matches were found:
+
+   **Interactive mode**: Present the top 5 matches as a table:
+
+   | Key | Summary | Link |
+   |-----|---------|------|
+   | RFE-1234 | Example summary | [View](https://...) |
+
+   Then ask the user:
+   > "I found existing RFEs that may overlap with your idea. Do any of these already cover what you need? (yes/no/not sure)"
+
+   - If **yes**: Ask which one(s). Suggest they comment on the existing RFE instead of creating a new one. Offer to continue creating a new RFE anyway if they want.
+   - If **no** or **not sure**: Continue to Step 2.
+
+   **Headless mode (`--headless`)**: Log the matches to stderr but do not block. Proceed directly to Step 3.
+
+4. If the search fails (error in JSON output) or returns no matches, proceed silently to Step 2. Never block RFE creation due to a search failure.
+
 ## Step 2: Clarifying Questions
 
 Before generating RFEs, ask the PM clarifying questions to fill gaps. Ask 2-5 questions maximum — only ask what you cannot reasonably infer from the input. Focus on:

--- a/.claude/skills/rfe.create/SKILL.md
+++ b/.claude/skills/rfe.create/SKILL.md
@@ -35,15 +35,41 @@ If the rubric is still not available after the bootstrap attempt, proceed with t
 
 Before asking clarifying questions, check whether similar RFEs already exist in Jira. This prevents duplicate work and helps the PM connect to existing efforts.
 
-1. Extract 3-5 key phrases from the problem statement that capture the core need. Focus on domain-specific terms (product names, capabilities, user actions) rather than generic words like "support", "enable", "improve".
+> **Design reference**: see `docs/duplicate-detection.md` for the full design (two-tier cache, opt-in build rationale, `source` output values, known gaps). The skill instructions below are the operational flow — the design doc explains *why*.
 
-2. Run the duplicate search:
+1. Extract 3-5 key phrases from the problem statement that capture the core need. Focus on domain-specific terms (product names, capabilities, user actions) rather than generic words like "support", "enable", "improve". (`--keywords` is optional — the script has a stopword-filtered fallback — but explicit phrases produce much better matches.)
 
-```bash
-python3 scripts/dedup_search.py search "<problem statement text>" --keywords "phrase1,phrase2,phrase3" --max-results 10
-```
+2. **Choose a search mode.** The duplicate search uses a local cache of open RFE summaries for speed. Building that cache from scratch paginates the full Jira project and can take 10+ seconds on large projects, so we let the user opt in:
 
-3. Parse the JSON output. If matches were found:
+   First, probe cache state:
+
+   ```bash
+   python3 scripts/dedup_search.py cache-info --json
+   ```
+
+   - **Headless mode (`--headless`)**: skip the probe. Always pass `--headless --recent-only` to the search in step 3 so CI never blocks on a full cache build.
+   - **Interactive mode, cache is "fresh"** (per the JSON `fresh: true` field): silently use it. Skip the opt-in prompt.
+   - **Interactive mode, cache is missing or stale**: ask the user via `AskUserQuestion`:
+     > "I can build a local cache of open RFEs for duplicate detection. First-time build takes a moment but makes future checks instant.
+     > - **Build full cache** (recommended)
+     > - **Just check recent issues** (fast, only catches duplicates created in the last 30 days)"
+     - If **Build full cache**: run step 3 with no extra flag.
+     - If **Just check recent issues**: run step 3 with `--recent-only`.
+
+3. Run the duplicate search:
+
+   ```bash
+   # Interactive, user opted to build the cache
+   python3 scripts/dedup_search.py search "<problem statement text>" --keywords "phrase1,phrase2,phrase3" --max-results 10
+
+   # Interactive, user opted for fast recent-only
+   python3 scripts/dedup_search.py search "..." --keywords "..." --max-results 10 --recent-only
+
+   # Headless / CI
+   python3 scripts/dedup_search.py search "..." --keywords "..." --max-results 10 --headless --recent-only
+   ```
+
+4. Parse the JSON output. If matches were found:
 
    **Interactive mode**: Present the top 5 matches as a table:
 
@@ -59,7 +85,7 @@ python3 scripts/dedup_search.py search "<problem statement text>" --keywords "ph
 
    **Headless mode (`--headless`)**: Log the matches to stderr but do not block. Proceed directly to Step 3.
 
-4. If the search fails (error in JSON output) or returns no matches, proceed silently to Step 2. Never block RFE creation due to a search failure.
+5. If the search fails (error in JSON output) or returns no matches, proceed silently to Step 2. Never block RFE creation due to a search failure.
 
 ## Step 2: Clarifying Questions
 

--- a/docs/duplicate-detection.md
+++ b/docs/duplicate-detection.md
@@ -1,0 +1,174 @@
+# Duplicate Detection for New RFEs
+
+## Problem
+
+`/rfe.create` helps PMs turn ideas into RFEs, but without any duplicate
+check an organization quickly accumulates near-identical tickets — the
+same request worded slightly differently by three different people. We
+want to surface potential overlaps before the PM invests time answering
+clarifying questions.
+
+Two tensions shaped the design:
+
+1. **Recall vs. latency**: the most thorough check would fetch every
+   open RFE and score it against the new problem statement. That's
+   minutes of pagination on a project with thousands of issues, which
+   wrecks the `/rfe.create` UX where the conversation is supposed to
+   start immediately.
+
+2. **Server load**: Jira's `text ~` operator works but is slow and rate-
+   sensitive; running it against the full project on every `/rfe.create`
+   invocation is wasteful.
+
+## Solution
+
+A two-tier lookup with a locally cached summary index:
+
+1. **Tier 1 — local cache**: A JSON file at `tmp/dedup-cache.json`
+   stores `{issue_key: summary}` for every open RFE. Substring keyword
+   matching runs in-process — no network round trip.
+
+2. **Tier 2 — JQL fallback**: If the cache returns fewer than 3 hits
+   (or the cache is bypassed entirely), fall back to Jira's `text ~`
+   operator for a single targeted search.
+
+The cache has a 4-hour TTL. When it's missing or stale, `search()`
+rebuilds it by paginating `project = RHAIRFE AND statusCategory != Done`.
+That rebuild is the expensive operation we need to be careful about.
+
+## Opt-in Cache Build
+
+A full rebuild can take 10+ seconds on a large project. Silently
+blocking for that long before the PM sees the first clarifying question
+would regress the `/rfe.create` UX, so the cache build is **opt-in** in
+interactive mode and **skipped entirely** in headless mode.
+
+The opt-in happens at the skill layer (`.claude/skills/rfe.create/SKILL.md`,
+Step 1.5), not inside the Python script — `dedup_search.py` is invoked
+as a subprocess and has no meaningful stdin for `AskUserQuestion`.
+
+| Mode | Cache state | Behavior |
+|------|-------------|----------|
+| Interactive | Fresh | Silent use of cache. No prompt. |
+| Interactive | Stale | Silent refresh (user already opted in previously). |
+| Interactive | Missing | Prompt: "Build full cache (recommended)" vs. "Just check recent issues". |
+| Headless | Fresh | Silent use. |
+| Headless | Stale or missing | Skip refresh. Fall through to narrow JQL scoped to `created >= -30d`. |
+
+The narrow JQL path trades recall (only catches duplicates created in
+the last 30 days) for speed (no pagination, one API call). That's the
+right tradeoff for CI — a `/rfe.speedrun --headless` run should never
+wait a minute to build a dedup cache.
+
+Whenever an implicit cache build does happen, `_ensure_fresh_cache`
+prints a `"Building duplicate-detection cache..."` or
+`"Refreshing duplicate-detection cache..."` message to stderr so the
+user isn't left staring at nothing.
+
+## CLI Surface
+
+```bash
+# Interactive default: cache-backed search, build cache if needed
+python3 scripts/dedup_search.py search "<text>" --keywords "kw1,kw2"
+
+# User declined the cache build: skip cache entirely
+python3 scripts/dedup_search.py search "<text>" --keywords "kw1,kw2" --recent-only
+
+# Headless / CI: use cache if fresh, else narrow JQL — never build
+python3 scripts/dedup_search.py search "<text>" --keywords "kw1,kw2" --headless
+
+# Headless + no cache available: explicitly recent-only
+python3 scripts/dedup_search.py search "<text>" --keywords "kw1,kw2" --headless --recent-only
+
+# Probe cache state (used by the skill to decide whether to prompt)
+python3 scripts/dedup_search.py cache-info --json
+
+# Explicit manual refresh
+python3 scripts/dedup_search.py refresh-cache [--force]
+```
+
+`--keywords` is optional — a stopword-filtered fallback extractor runs
+when it's omitted. The skill always passes explicit keywords because
+LLM-extracted phrases produce much better matches than raw token splits,
+but the fallback keeps the tool usable on its own.
+
+## Files
+
+```
+tmp/
+  dedup-cache.json   # {key: summary} index of open RFEs with refreshed_at + server
+```
+
+Cache schema:
+
+```json
+{
+  "refreshed_at": "2026-04-15T12:00:00+00:00",
+  "server": "https://your-site.atlassian.net",
+  "issue_count": 342,
+  "issues": {
+    "RHAIRFE-1595": "Add widget export to PDF format",
+    "RHAIRFE-1596": "..."
+  }
+}
+```
+
+The `server` field guards against a cache built against one Jira
+instance being reused after `JIRA_SERVER` changes. `_cache_is_fresh`
+invalidates the cache if the stored server doesn't match the caller's.
+
+## Output Format
+
+`search` returns JSON:
+
+```json
+{
+  "source": "cache | cache+jira | jira | jira-recent | none",
+  "cache_age_hours": 1.3,
+  "keywords_used": ["kw1", "kw2"],
+  "matches": [
+    {"key": "RHAIRFE-1595", "summary": "...", "url": "https://.../browse/RHAIRFE-1595"}
+  ],
+  "error": null
+}
+```
+
+`source` values:
+- `cache` — all results from local cache, no JQL call made
+- `cache+jira` — cache had some hits, JQL added more
+- `jira` — cache had no hits, JQL-only
+- `jira-recent` — `--recent-only` path; cache bypassed
+- `none` — empty input
+
+`error` is populated for `no_credentials` and
+`no_credentials_using_stale_cache` — never `null` for "no matches
+found" (that's just an empty `matches` list).
+
+## Known Gaps (Tracked, Not Yet Implemented)
+
+- **Incremental cache refresh.** Currently every TTL-expiry triggers a
+  full rebuild. The cache already stores `refreshed_at`, so a future
+  revision can fetch only issues with `updated >= <last_refresh>` plus
+  a second query for closures (`statusCategory = Done AND updated >=
+  <last_refresh>`) to evict them. Expected to drop a minute-long
+  refresh to seconds on large projects.
+- **Periodic full reconciliation.** Once incremental refresh lands,
+  run a full rebuild every 24 hours regardless to catch drift from
+  missed events (label-only changes, permission shifts, etc.).
+
+## Design Invariants
+
+Before modifying `scripts/dedup_search.py`, preserve these:
+
+1. **Never block `/rfe.create` on a silent cache build.** If a build
+   is about to happen implicitly, it must either print a stderr
+   notice (interactive) or be suppressed via `--headless`.
+2. **The cache is advisory, not a source of truth.** `search()` must
+   tolerate a missing, stale, or corrupt cache gracefully — returning
+   a structured error is always preferable to raising.
+3. **`_cache_is_fresh` stays pure.** It takes `cache` and an optional
+   `server`; it does not read `os.environ`. Callers that need the
+   server read it once and pass it in.
+4. **`--headless` must never prompt, pause, or paginate.** A CI run
+   with no cache should complete in one API call (the narrow JQL
+   path), not fifty.

--- a/scripts/dedup_search.py
+++ b/scripts/dedup_search.py
@@ -178,14 +178,49 @@ def _search_cache(cache, keywords, max_results):
     return scored[:max_results]
 
 
-def _escape_jql_keyword(kw):
-    """Escape JQL special characters in a keyword for use inside quotes."""
-    # Backslash must be escaped first to avoid double-escaping
-    kw = kw.replace("\\", "\\\\")
-    kw = kw.replace('"', '\\"')
-    for ch in "{}[]()+-&|!^~*?:":
-        kw = kw.replace(ch, f"\\{ch}")
-    return kw
+_LUCENE_SPECIALS = '+-&|!(){}[]^"~*?:/'
+
+
+def _lucene_escape(term):
+    """Escape Lucene-syntax metacharacters in a single term."""
+    # Backslash first so we don't double-escape the ones we add below
+    term = term.replace("\\", "\\\\")
+    for ch in _LUCENE_SPECIALS:
+        term = term.replace(ch, f"\\{ch}")
+    return term
+
+
+def _jql_string_escape(s):
+    """Escape a string for embedding inside a JQL double-quoted string."""
+    # Only \ and " need escaping at the JQL string layer
+    s = s.replace("\\", "\\\\")
+    s = s.replace('"', '\\"')
+    return s
+
+
+def _build_text_query_jql(keywords):
+    """Build a JQL-embeddable `text ~ "..."` clause from keywords.
+
+    Single-word keywords become bare Lucene terms. Multi-word keywords
+    become Lucene phrase queries (wrapped in Lucene double quotes). The
+    whole Lucene expression is then escaped for the outer JQL string.
+
+    Returns e.g. `text ~ "mlflow OR \\"model registry\\""`.
+    """
+    parts = []
+    for kw in keywords:
+        kw = kw.strip()
+        if not kw:
+            continue
+        escaped = _lucene_escape(kw)
+        if " " in kw:
+            parts.append(f'"{escaped}"')  # Lucene phrase query
+        else:
+            parts.append(escaped)
+    if not parts:
+        return None
+    lucene_expr = " OR ".join(parts)
+    return f'text ~ "{_jql_string_escape(lucene_expr)}"'
 
 
 def _search_jql(server, user, token, keywords, max_results, recent_days=None):
@@ -198,15 +233,11 @@ def _search_jql(server, user, token, keywords, max_results, recent_days=None):
     if not all([server, user, token]):
         return []
 
-    # Build text query: "kw1 OR kw2 OR kw3"
-    escaped = []
-    for kw in keywords:
-        # Escape JQL special characters in keyword
-        clean = _escape_jql_keyword(kw)
-        escaped.append(f'"{clean}"')
-    text_query = " OR ".join(escaped)
+    text_clause = _build_text_query_jql(keywords)
+    if text_clause is None:
+        return []
 
-    jql = f'{JQL_BASE} AND text ~ "{text_query}"'
+    jql = f'{JQL_BASE} AND {text_clause}'
     if recent_days:
         jql += f' AND created >= -{int(recent_days)}d'
     jql_encoded = urllib.parse.quote(jql, safe="")

--- a/scripts/dedup_search.py
+++ b/scripts/dedup_search.py
@@ -31,6 +31,23 @@ CACHE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 CACHE_TTL_HOURS = 4
 JQL_BASE = "project = RHAIRFE AND statusCategory != Done"
 
+_STOPWORDS = frozenset({
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "can", "shall", "to", "of", "in", "for",
+    "on", "with", "at", "by", "from", "as", "into", "through", "during",
+    "before", "after", "above", "below", "between", "out", "off", "over",
+    "under", "again", "further", "then", "once", "and", "but", "or",
+    "nor", "not", "so", "yet", "both", "either", "neither", "each",
+    "every", "all", "any", "few", "more", "most", "other", "some", "such",
+    "no", "only", "own", "same", "than", "too", "very", "just", "because",
+    "if", "when", "where", "how", "what", "which", "who", "whom", "this",
+    "that", "these", "those", "i", "me", "my", "we", "our", "you", "your",
+    "he", "him", "his", "she", "her", "it", "its", "they", "them", "their",
+    "want", "need", "like", "use", "using", "support", "enable", "allow",
+    "make", "get", "set", "add", "new", "also", "about",
+})
+
 
 # ─── Cache Management ────────────────────────────────────────────────────────
 
@@ -71,12 +88,11 @@ def _cache_age_hours(cache):
         return None
 
 
-def _cache_is_fresh(cache):
-    """Check if cache is fresh (within TTL) and matches current server."""
+def _cache_is_fresh(cache, server=None):
+    """Check if cache is fresh (within TTL) and matches given server."""
     age = _cache_age_hours(cache)
     if age is None or age > CACHE_TTL_HOURS:
         return False
-    server, _, _ = require_env()
     if server and cache.get("server") != server:
         return False
     return True
@@ -122,7 +138,7 @@ def refresh_cache(server, user, token):
 def _ensure_fresh_cache(server, user, token):
     """Return a fresh cache, refreshing if needed."""
     cache = _load_cache()
-    if _cache_is_fresh(cache):
+    if _cache_is_fresh(cache, server):
         return cache
     # Stale or missing — need credentials to refresh
     if not all([server, user, token]):
@@ -152,6 +168,16 @@ def _search_cache(cache, keywords, max_results):
     return scored[:max_results]
 
 
+def _escape_jql_keyword(kw):
+    """Escape JQL special characters in a keyword for use inside quotes."""
+    # Backslash must be escaped first to avoid double-escaping
+    kw = kw.replace("\\", "\\\\")
+    kw = kw.replace('"', '\\"')
+    for ch in "{}[]()+-&|!^~*?:":
+        kw = kw.replace(ch, f"\\{ch}")
+    return kw
+
+
 def _search_jql(server, user, token, keywords, max_results):
     """Search Jira via JQL text operator. Returns list of (key, summary)."""
     if not all([server, user, token]):
@@ -161,7 +187,7 @@ def _search_jql(server, user, token, keywords, max_results):
     escaped = []
     for kw in keywords:
         # Escape JQL special characters in keyword
-        clean = kw.replace('"', '\\"')
+        clean = _escape_jql_keyword(kw)
         escaped.append(f'"{clean}"')
     text_query = " OR ".join(escaped)
 
@@ -257,7 +283,7 @@ def cmd_refresh_cache(args):
               file=sys.stderr)
         sys.exit(1)
     cache = _load_cache()
-    if not args.force and _cache_is_fresh(cache):
+    if not args.force and _cache_is_fresh(cache, server):
         age = _cache_age_hours(cache)
         print(f"Cache is fresh ({age}h old, TTL={CACHE_TTL_HOURS}h). "
               f"Use --force to override.", file=sys.stderr)
@@ -271,34 +297,32 @@ def cmd_cache_info(args):
         print("No cache found.")
         return
     age = _cache_age_hours(cache)
-    fresh = _cache_is_fresh(cache)
-    print(f"Cache file: {CACHE_PATH}")
-    print(f"Refreshed: {cache.get('refreshed_at', 'unknown')}")
-    print(f"Age: {age}h (TTL: {CACHE_TTL_HOURS}h, {'fresh' if fresh else 'stale'})")
-    print(f"Server: {cache.get('server', 'unknown')}")
-    print(f"Issues: {cache.get('issue_count', 0)}")
+    server, _, _ = require_env()
+    fresh = _cache_is_fresh(cache, server)
+    info = {
+        "cache_file": CACHE_PATH,
+        "refreshed_at": cache.get("refreshed_at", "unknown"),
+        "age_hours": age,
+        "ttl_hours": CACHE_TTL_HOURS,
+        "fresh": fresh,
+        "server": cache.get("server", "unknown"),
+        "issue_count": cache.get("issue_count", 0),
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(info, indent=2))
+    else:
+        print(f"Cache file: {info['cache_file']}")
+        print(f"Refreshed: {info['refreshed_at']}")
+        print(f"Age: {info['age_hours']}h (TTL: {info['ttl_hours']}h, "
+              f"{'fresh' if info['fresh'] else 'stale'})")
+        print(f"Server: {info['server']}")
+        print(f"Issues: {info['issue_count']}")
 
 
 def _extract_fallback_keywords(text):
     """Basic keyword extraction when LLM doesn't provide --keywords."""
-    stopwords = {
-        "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
-        "have", "has", "had", "do", "does", "did", "will", "would", "could",
-        "should", "may", "might", "can", "shall", "to", "of", "in", "for",
-        "on", "with", "at", "by", "from", "as", "into", "through", "during",
-        "before", "after", "above", "below", "between", "out", "off", "over",
-        "under", "again", "further", "then", "once", "and", "but", "or",
-        "nor", "not", "so", "yet", "both", "either", "neither", "each",
-        "every", "all", "any", "few", "more", "most", "other", "some", "such",
-        "no", "only", "own", "same", "than", "too", "very", "just", "because",
-        "if", "when", "where", "how", "what", "which", "who", "whom", "this",
-        "that", "these", "those", "i", "me", "my", "we", "our", "you", "your",
-        "he", "him", "his", "she", "her", "it", "its", "they", "them", "their",
-        "want", "need", "like", "use", "using", "support", "enable", "allow",
-        "make", "get", "set", "add", "new", "also", "about",
-    }
     words = text.lower().split()
-    candidates = [w for w in words if w not in stopwords and len(w) > 2]
+    candidates = [w for w in words if w not in _STOPWORDS and len(w) > 2]
     # Deduplicate preserving order
     seen = set()
     unique = []
@@ -331,6 +355,8 @@ def main():
 
     # cache-info
     p_info = sub.add_parser("cache-info", help="Show cache status")
+    p_info.add_argument("--json", action="store_true",
+                        help="Output as JSON for scripting")
     p_info.set_defaults(func=cmd_cache_info)
 
     args = parser.parse_args()

--- a/scripts/dedup_search.py
+++ b/scripts/dedup_search.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Search for potential duplicate RFEs in Jira.
+
+Maintains a local YAML cache of RFE summaries for fast lookups,
+with JQL text search as fallback.
+
+Usage:
+    python3 scripts/dedup_search.py search "problem text" --keywords "kw1,kw2" [--max-results 10]
+    python3 scripts/dedup_search.py refresh-cache [--force]
+    python3 scripts/dedup_search.py cache-info
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.parse
+from datetime import datetime, timezone
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+# Add parent directory so we can import jira_utils
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from jira_utils import require_env, api_call_with_retry
+
+CACHE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          "..", "tmp", "dedup-cache.yaml")
+CACHE_TTL_HOURS = 4
+JQL_BASE = "project = RHAIRFE AND statusCategory != Done"
+
+
+# ─── Cache Management ────────────────────────────────────────────────────────
+
+def _load_cache():
+    """Load cache from disk. Returns dict or None if unavailable/corrupt."""
+    if yaml is None:
+        return None
+    try:
+        with open(CACHE_PATH, "r") as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict) or "issues" not in data:
+            return None
+        return data
+    except (FileNotFoundError, yaml.YAMLError, OSError):
+        return None
+
+
+def _save_cache(data):
+    """Write cache to disk."""
+    os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
+    if yaml is None:
+        return
+    with open(CACHE_PATH, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+
+
+def _cache_age_hours(cache):
+    """Return cache age in hours, or None if unknown."""
+    if not cache or "refreshed_at" not in cache:
+        return None
+    try:
+        refreshed = datetime.fromisoformat(cache["refreshed_at"])
+        if refreshed.tzinfo is None:
+            refreshed = refreshed.replace(tzinfo=timezone.utc)
+        age = (datetime.now(timezone.utc) - refreshed).total_seconds() / 3600
+        return round(age, 2)
+    except (ValueError, TypeError):
+        return None
+
+
+def _cache_is_fresh(cache):
+    """Check if cache is fresh (within TTL) and matches current server."""
+    age = _cache_age_hours(cache)
+    if age is None or age > CACHE_TTL_HOURS:
+        return False
+    server, _, _ = require_env()
+    if server and cache.get("server") != server:
+        return False
+    return True
+
+
+def refresh_cache(server, user, token):
+    """Fetch all open RFE summaries and write to cache."""
+    issues = {}
+    page_size = 100
+    next_page_token = None
+
+    while True:
+        jql = urllib.parse.quote(JQL_BASE, safe="")
+        path = (f"/search/jql?jql={jql}"
+                f"&maxResults={page_size}&fields=key,summary")
+        if next_page_token:
+            path += f"&nextPageToken={urllib.parse.quote(next_page_token, safe='')}"
+        data = api_call_with_retry(server, path, user, token)
+
+        for issue in data.get("issues", []):
+            key = issue["key"]
+            summary = issue.get("fields", {}).get("summary", "")
+            issues[key] = summary
+
+        if not data.get("issues") or data.get("isLast", True):
+            break
+
+        next_page_token = data.get("nextPageToken")
+        if not next_page_token:
+            break
+
+    cache = {
+        "refreshed_at": datetime.now(timezone.utc).isoformat(),
+        "server": server,
+        "issue_count": len(issues),
+        "issues": issues,
+    }
+    _save_cache(cache)
+    print(f"Cache refreshed: {len(issues)} issues", file=sys.stderr)
+    return cache
+
+
+def _ensure_fresh_cache(server, user, token):
+    """Return a fresh cache, refreshing if needed."""
+    cache = _load_cache()
+    if _cache_is_fresh(cache):
+        return cache
+    # Stale or missing — need credentials to refresh
+    if not all([server, user, token]):
+        return cache  # Return stale cache (or None) if no creds
+    try:
+        return refresh_cache(server, user, token)
+    except Exception as e:
+        print(f"Cache refresh failed: {e}", file=sys.stderr)
+        return cache  # Fall back to stale cache
+
+
+# ─── Search ───────────────────────────────────────────────────────────────────
+
+def _search_cache(cache, keywords, max_results):
+    """Search local cache by keyword substring matching. Returns matches."""
+    if not cache or not cache.get("issues"):
+        return []
+
+    scored = []
+    for key, summary in cache["issues"].items():
+        summary_lower = summary.lower()
+        hits = sum(1 for kw in keywords if kw.lower() in summary_lower)
+        if hits > 0:
+            scored.append((hits, key, summary))
+
+    scored.sort(key=lambda x: (-x[0], x[1]))
+    return scored[:max_results]
+
+
+def _search_jql(server, user, token, keywords, max_results):
+    """Search Jira via JQL text operator. Returns list of (key, summary)."""
+    if not all([server, user, token]):
+        return []
+
+    # Build text query: "kw1 OR kw2 OR kw3"
+    escaped = []
+    for kw in keywords:
+        # Escape JQL special characters in keyword
+        clean = kw.replace('"', '\\"')
+        escaped.append(f'"{clean}"')
+    text_query = " OR ".join(escaped)
+
+    jql = f'{JQL_BASE} AND text ~ "{text_query}"'
+    jql_encoded = urllib.parse.quote(jql, safe="")
+    path = (f"/search/jql?jql={jql_encoded}&maxResults={max_results}"
+            f"&fields=key,summary")
+
+    try:
+        data = api_call_with_retry(server, path, user, token)
+        results = []
+        for issue in data.get("issues", []):
+            key = issue["key"]
+            summary = issue.get("fields", {}).get("summary", "")
+            results.append((key, summary))
+        return results
+    except Exception as e:
+        print(f"JQL search failed: {e}", file=sys.stderr)
+        return []
+
+
+def search(text, keywords, max_results=10):
+    """Run two-tier duplicate search. Returns JSON-serializable dict."""
+    server, user, token = require_env()
+    has_creds = all([server, user, token])
+
+    if not text.strip() and not keywords:
+        return {"source": "none", "cache_age_hours": None,
+                "keywords_used": [], "matches": [], "error": None}
+
+    # Ensure cache is fresh
+    cache = _ensure_fresh_cache(server, user, token)
+    age = _cache_age_hours(cache)
+
+    # Tier 1: local cache search
+    cache_results = _search_cache(cache, keywords, max_results)
+    source = "cache"
+
+    # Tier 2: JQL fallback if cache results are sparse
+    jql_results = []
+    if has_creds and len(cache_results) < 3:
+        jql_results = _search_jql(server, user, token, keywords, max_results)
+        source = "cache+jira" if cache_results else "jira"
+
+    # Merge and deduplicate
+    seen = set()
+    matches = []
+
+    # Cache results first (scored by keyword hits)
+    for hits, key, summary in cache_results:
+        if key not in seen:
+            seen.add(key)
+            url = f"{server}/browse/{key}" if server else ""
+            matches.append({"key": key, "summary": summary, "url": url})
+
+    # Then JQL results
+    for key, summary in jql_results:
+        if key not in seen:
+            seen.add(key)
+            url = f"{server}/browse/{key}" if server else ""
+            matches.append({"key": key, "summary": summary, "url": url})
+
+    matches = matches[:max_results]
+
+    error = None
+    if not has_creds and not cache:
+        error = "no_credentials"
+    elif not has_creds and cache:
+        error = "no_credentials_using_stale_cache"
+
+    return {
+        "source": source,
+        "cache_age_hours": age,
+        "keywords_used": keywords,
+        "matches": matches,
+        "error": error,
+    }
+
+
+# ─── CLI ──────────────────────────────────────────────────────────────────────
+
+def cmd_search(args):
+    keywords = [k.strip() for k in args.keywords.split(",") if k.strip()] \
+        if args.keywords else _extract_fallback_keywords(args.text)
+    result = search(args.text, keywords, args.max_results)
+    print(json.dumps(result, indent=2))
+
+
+def cmd_refresh_cache(args):
+    server, user, token = require_env()
+    if not all([server, user, token]):
+        print("Error: JIRA_SERVER, JIRA_USER, and JIRA_TOKEN must be set",
+              file=sys.stderr)
+        sys.exit(1)
+    cache = _load_cache()
+    if not args.force and _cache_is_fresh(cache):
+        age = _cache_age_hours(cache)
+        print(f"Cache is fresh ({age}h old, TTL={CACHE_TTL_HOURS}h). "
+              f"Use --force to override.", file=sys.stderr)
+        return
+    refresh_cache(server, user, token)
+
+
+def cmd_cache_info(args):
+    cache = _load_cache()
+    if not cache:
+        print("No cache found.")
+        return
+    age = _cache_age_hours(cache)
+    fresh = _cache_is_fresh(cache)
+    print(f"Cache file: {CACHE_PATH}")
+    print(f"Refreshed: {cache.get('refreshed_at', 'unknown')}")
+    print(f"Age: {age}h (TTL: {CACHE_TTL_HOURS}h, {'fresh' if fresh else 'stale'})")
+    print(f"Server: {cache.get('server', 'unknown')}")
+    print(f"Issues: {cache.get('issue_count', 0)}")
+
+
+def _extract_fallback_keywords(text):
+    """Basic keyword extraction when LLM doesn't provide --keywords."""
+    stopwords = {
+        "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+        "have", "has", "had", "do", "does", "did", "will", "would", "could",
+        "should", "may", "might", "can", "shall", "to", "of", "in", "for",
+        "on", "with", "at", "by", "from", "as", "into", "through", "during",
+        "before", "after", "above", "below", "between", "out", "off", "over",
+        "under", "again", "further", "then", "once", "and", "but", "or",
+        "nor", "not", "so", "yet", "both", "either", "neither", "each",
+        "every", "all", "any", "few", "more", "most", "other", "some", "such",
+        "no", "only", "own", "same", "than", "too", "very", "just", "because",
+        "if", "when", "where", "how", "what", "which", "who", "whom", "this",
+        "that", "these", "those", "i", "me", "my", "we", "our", "you", "your",
+        "he", "him", "his", "she", "her", "it", "its", "they", "them", "their",
+        "want", "need", "like", "use", "using", "support", "enable", "allow",
+        "make", "get", "set", "add", "new", "also", "about",
+    }
+    words = text.lower().split()
+    candidates = [w for w in words if w not in stopwords and len(w) > 2]
+    # Deduplicate preserving order
+    seen = set()
+    unique = []
+    for w in candidates:
+        if w not in seen:
+            seen.add(w)
+            unique.append(w)
+    return unique[:5]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Search for potential duplicate RFEs in Jira.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # search
+    p_search = sub.add_parser("search", help="Search for duplicates")
+    p_search.add_argument("text", help="Problem statement text")
+    p_search.add_argument("--keywords",
+                          help="Comma-separated key phrases (LLM-extracted)")
+    p_search.add_argument("--max-results", type=int, default=10,
+                          help="Maximum matches to return")
+    p_search.set_defaults(func=cmd_search)
+
+    # refresh-cache
+    p_refresh = sub.add_parser("refresh-cache", help="Refresh the local cache")
+    p_refresh.add_argument("--force", action="store_true",
+                           help="Ignore TTL and force refresh")
+    p_refresh.set_defaults(func=cmd_refresh_cache)
+
+    # cache-info
+    p_info = sub.add_parser("cache-info", help="Show cache status")
+    p_info.set_defaults(func=cmd_cache_info)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dedup_search.py
+++ b/scripts/dedup_search.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 """Search for potential duplicate RFEs in Jira.
 
-Maintains a local YAML cache of RFE summaries for fast lookups,
+Maintains a local JSON cache of RFE summaries for fast lookups,
 with JQL text search as fallback.
 
 Usage:
     python3 scripts/dedup_search.py search "problem text" --keywords "kw1,kw2" [--max-results 10]
+    python3 scripts/dedup_search.py search "..." --keywords "..." --headless      # CI: never block on cache build
+    python3 scripts/dedup_search.py search "..." --keywords "..." --recent-only   # Skip cache, narrow JQL only
     python3 scripts/dedup_search.py refresh-cache [--force]
-    python3 scripts/dedup_search.py cache-info
+    python3 scripts/dedup_search.py cache-info [--json]
 """
 
 import argparse
@@ -17,19 +19,15 @@ import sys
 import urllib.parse
 from datetime import datetime, timezone
 
-try:
-    import yaml
-except ImportError:
-    yaml = None
-
 # Add parent directory so we can import jira_utils
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from jira_utils import require_env, api_call_with_retry
 
 CACHE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                          "..", "tmp", "dedup-cache.yaml")
+                          "..", "tmp", "dedup-cache.json")
 CACHE_TTL_HOURS = 4
 JQL_BASE = "project = RHAIRFE AND statusCategory != Done"
+RECENT_ONLY_DAYS = 30
 
 _STOPWORDS = frozenset({
     "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
@@ -53,25 +51,21 @@ _STOPWORDS = frozenset({
 
 def _load_cache():
     """Load cache from disk. Returns dict or None if unavailable/corrupt."""
-    if yaml is None:
-        return None
     try:
         with open(CACHE_PATH, "r") as f:
-            data = yaml.safe_load(f)
+            data = json.load(f)
         if not isinstance(data, dict) or "issues" not in data:
             return None
         return data
-    except (FileNotFoundError, yaml.YAMLError, OSError):
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
         return None
 
 
 def _save_cache(data):
     """Write cache to disk."""
     os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
-    if yaml is None:
-        return
     with open(CACHE_PATH, "w") as f:
-        yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+        json.dump(data, f, ensure_ascii=False, indent=2)
 
 
 def _cache_age_hours(cache):
@@ -135,14 +129,29 @@ def refresh_cache(server, user, token):
     return cache
 
 
-def _ensure_fresh_cache(server, user, token):
-    """Return a fresh cache, refreshing if needed."""
+def _ensure_fresh_cache(server, user, token, allow_build=True):
+    """Return a fresh cache, refreshing if needed.
+
+    If allow_build is False, never trigger a build — return the existing
+    cache (possibly stale or None) as-is. This is used by headless callers
+    that can't afford to block on a full rebuild.
+    """
     cache = _load_cache()
     if _cache_is_fresh(cache, server):
         return cache
+    if not allow_build:
+        return cache  # Caller opted out of blocking build
     # Stale or missing — need credentials to refresh
     if not all([server, user, token]):
         return cache  # Return stale cache (or None) if no creds
+    # Let the user know why there's a pause
+    if cache is None:
+        print("Building duplicate-detection cache (first run, "
+              "this may take a moment)...", file=sys.stderr)
+    else:
+        age = _cache_age_hours(cache)
+        print(f"Refreshing duplicate-detection cache "
+              f"(last built {age}h ago)...", file=sys.stderr)
     try:
         return refresh_cache(server, user, token)
     except Exception as e:
@@ -157,10 +166,11 @@ def _search_cache(cache, keywords, max_results):
     if not cache or not cache.get("issues"):
         return []
 
+    keywords_lower = [kw.lower() for kw in keywords]
     scored = []
     for key, summary in cache["issues"].items():
         summary_lower = summary.lower()
-        hits = sum(1 for kw in keywords if kw.lower() in summary_lower)
+        hits = sum(1 for kw in keywords_lower if kw in summary_lower)
         if hits > 0:
             scored.append((hits, key, summary))
 
@@ -178,8 +188,13 @@ def _escape_jql_keyword(kw):
     return kw
 
 
-def _search_jql(server, user, token, keywords, max_results):
-    """Search Jira via JQL text operator. Returns list of (key, summary)."""
+def _search_jql(server, user, token, keywords, max_results, recent_days=None):
+    """Search Jira via JQL text operator. Returns list of (key, summary).
+
+    If recent_days is set, scope the query to issues created within that
+    window (e.g. 30) — used for fast "recent-only" searches that skip the
+    cache entirely.
+    """
     if not all([server, user, token]):
         return []
 
@@ -192,6 +207,8 @@ def _search_jql(server, user, token, keywords, max_results):
     text_query = " OR ".join(escaped)
 
     jql = f'{JQL_BASE} AND text ~ "{text_query}"'
+    if recent_days:
+        jql += f' AND created >= -{int(recent_days)}d'
     jql_encoded = urllib.parse.quote(jql, safe="")
     path = (f"/search/jql?jql={jql_encoded}&maxResults={max_results}"
             f"&fields=key,summary")
@@ -209,8 +226,16 @@ def _search_jql(server, user, token, keywords, max_results):
         return []
 
 
-def search(text, keywords, max_results=10):
-    """Run two-tier duplicate search. Returns JSON-serializable dict."""
+def search(text, keywords, max_results=10, headless=False, recent_only=False):
+    """Run two-tier duplicate search. Returns JSON-serializable dict.
+
+    headless:     never trigger a blocking cache build. If the cache is
+                  missing or stale, fall straight to a scoped JQL query.
+                  Intended for CI / non-interactive callers.
+    recent_only:  bypass the cache entirely and run a narrow JQL scoped to
+                  recently-created issues. Fast, but only catches recent
+                  duplicates. Useful when the user declines a cache build.
+    """
     server, user, token = require_env()
     has_creds = all([server, user, token])
 
@@ -218,18 +243,44 @@ def search(text, keywords, max_results=10):
         return {"source": "none", "cache_age_hours": None,
                 "keywords_used": [], "matches": [], "error": None}
 
-    # Ensure cache is fresh
-    cache = _ensure_fresh_cache(server, user, token)
+    # Recent-only: skip the cache entirely
+    if recent_only:
+        jql_results = _search_jql(server, user, token, keywords, max_results,
+                                  recent_days=RECENT_ONLY_DAYS) if has_creds else []
+        matches = []
+        seen = set()
+        for key, summary in jql_results:
+            if key not in seen:
+                seen.add(key)
+                url = f"{server}/browse/{key}" if server else ""
+                matches.append({"key": key, "summary": summary, "url": url})
+        matches = matches[:max_results]
+        return {
+            "source": "jira-recent",
+            "cache_age_hours": None,
+            "keywords_used": keywords,
+            "matches": matches,
+            "error": None if has_creds else "no_credentials",
+        }
+
+    # Normal path: cache + JQL fallback.
+    # In headless mode, don't trigger a blocking cache build.
+    cache = _ensure_fresh_cache(server, user, token,
+                                allow_build=not headless)
     age = _cache_age_hours(cache)
 
     # Tier 1: local cache search
     cache_results = _search_cache(cache, keywords, max_results)
     source = "cache"
 
-    # Tier 2: JQL fallback if cache results are sparse
+    # Tier 2: JQL fallback if cache results are sparse.
+    # In headless mode without a usable cache, narrow the JQL to recent
+    # issues so we don't fan out to a slow unbounded text search.
     jql_results = []
     if has_creds and len(cache_results) < 3:
-        jql_results = _search_jql(server, user, token, keywords, max_results)
+        recent_days = RECENT_ONLY_DAYS if (headless and not cache) else None
+        jql_results = _search_jql(server, user, token, keywords, max_results,
+                                  recent_days=recent_days)
         source = "cache+jira" if cache_results else "jira"
 
     # Merge and deduplicate
@@ -272,7 +323,8 @@ def search(text, keywords, max_results=10):
 def cmd_search(args):
     keywords = [k.strip() for k in args.keywords.split(",") if k.strip()] \
         if args.keywords else _extract_fallback_keywords(args.text)
-    result = search(args.text, keywords, args.max_results)
+    result = search(args.text, keywords, args.max_results,
+                    headless=args.headless, recent_only=args.recent_only)
     print(json.dumps(result, indent=2))
 
 
@@ -342,9 +394,20 @@ def main():
     p_search = sub.add_parser("search", help="Search for duplicates")
     p_search.add_argument("text", help="Problem statement text")
     p_search.add_argument("--keywords",
-                          help="Comma-separated key phrases (LLM-extracted)")
+                          help="Comma-separated key phrases (LLM-extracted). "
+                               "Optional — a simple stopword-filtered fallback "
+                               "is used if omitted.")
     p_search.add_argument("--max-results", type=int, default=10,
                           help="Maximum matches to return")
+    p_search.add_argument("--headless", action="store_true",
+                          help="Never trigger a blocking cache build. If the "
+                               "cache is missing/stale, fall through to a "
+                               "narrow JQL query scoped to recent issues.")
+    p_search.add_argument("--recent-only", action="store_true",
+                          help="Skip the cache entirely and run a targeted "
+                               f"JQL scoped to issues created in the last "
+                               f"{RECENT_ONLY_DAYS} days. Fast, but only "
+                               f"catches recent duplicates.")
     p_search.set_defaults(func=cmd_search)
 
     # refresh-cache

--- a/tests/test_dedup_search.py
+++ b/tests/test_dedup_search.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Tests for scripts/dedup_search.py — cache management, keyword matching,
+search logic, and graceful failure modes."""
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone, timedelta
+
+import pytest
+import yaml
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from dedup_search import (
+    _cache_age_hours,
+    _cache_is_fresh,
+    _extract_fallback_keywords,
+    _load_cache,
+    _save_cache,
+    _search_cache,
+    CACHE_TTL_HOURS,
+)
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts",
+                      "dedup_search.py")
+
+
+def run_dedup(*args, env_override=None):
+    """Run dedup_search.py and return (stdout, stderr, returncode)."""
+    env = os.environ.copy()
+    if env_override:
+        env.update(env_override)
+    result = subprocess.run(
+        ["python3", SCRIPT, *args],
+        capture_output=True, text=True, env=env,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+@pytest.fixture
+def tmp_dir(tmp_path, monkeypatch):
+    """Run tests from a temp directory to isolate cache files."""
+    orig = os.getcwd()
+    os.chdir(tmp_path)
+    # Point CACHE_PATH to temp dir
+    import dedup_search
+    monkeypatch.setattr(dedup_search, "CACHE_PATH",
+                        str(tmp_path / "tmp" / "dedup-cache.yaml"))
+    yield tmp_path
+    os.chdir(orig)
+
+
+@pytest.fixture
+def sample_cache(tmp_dir):
+    """Write a fresh sample cache and return its path."""
+    import dedup_search
+    cache = {
+        "refreshed_at": datetime.now(timezone.utc).isoformat(),
+        "server": os.environ.get("JIRA_SERVER", "https://test.atlassian.net"),
+        "issue_count": 5,
+        "issues": {
+            "TEST-100": "Add widget export to PDF format",
+            "TEST-101": "Improve search performance for large datasets",
+            "TEST-102": "Widget import and export guided wizard",
+            "TEST-103": "Automated batch processing for reports",
+            "TEST-104": "Dashboard for viewing export results",
+        },
+    }
+    _save_cache(cache)
+    return cache
+
+
+# ─── Cache Age ────────────────────────────────────────────────────────────────
+
+class TestCacheAge:
+    def test_fresh_cache(self):
+        cache = {"refreshed_at": datetime.now(timezone.utc).isoformat()}
+        age = _cache_age_hours(cache)
+        assert age is not None
+        assert age < 0.1  # Just created
+
+    def test_stale_cache(self):
+        old = datetime.now(timezone.utc) - timedelta(hours=5)
+        cache = {"refreshed_at": old.isoformat()}
+        age = _cache_age_hours(cache)
+        assert age >= 4.9
+
+    def test_missing_timestamp(self):
+        assert _cache_age_hours({}) is None
+        assert _cache_age_hours(None) is None
+
+    def test_corrupt_timestamp(self):
+        assert _cache_age_hours({"refreshed_at": "not-a-date"}) is None
+
+
+class TestCacheFreshness:
+    def test_fresh(self, monkeypatch):
+        monkeypatch.setenv("JIRA_SERVER", "https://test.atlassian.net")
+        cache = {
+            "refreshed_at": datetime.now(timezone.utc).isoformat(),
+            "server": "https://test.atlassian.net",
+            "issues": {},
+        }
+        assert _cache_is_fresh(cache) is True
+
+    def test_stale(self, monkeypatch):
+        monkeypatch.setenv("JIRA_SERVER", "https://test.atlassian.net")
+        old = datetime.now(timezone.utc) - timedelta(hours=5)
+        cache = {
+            "refreshed_at": old.isoformat(),
+            "server": "https://test.atlassian.net",
+            "issues": {},
+        }
+        assert _cache_is_fresh(cache) is False
+
+    def test_server_mismatch(self, monkeypatch):
+        monkeypatch.setenv("JIRA_SERVER", "https://other.atlassian.net")
+        cache = {
+            "refreshed_at": datetime.now(timezone.utc).isoformat(),
+            "server": "https://test.atlassian.net",
+            "issues": {},
+        }
+        assert _cache_is_fresh(cache) is False
+
+    def test_none_cache(self):
+        assert _cache_is_fresh(None) is False
+
+
+# ─── Cache Load/Save ──────────────────────────────────────────────────────────
+
+class TestCacheIO:
+    def test_roundtrip(self, tmp_dir):
+        data = {
+            "refreshed_at": "2026-04-09T14:00:00+00:00",
+            "server": "https://test.atlassian.net",
+            "issue_count": 2,
+            "issues": {
+                "TEST-100": "Test issue one",
+                "TEST-101": "Test issue two",
+            },
+        }
+        _save_cache(data)
+        loaded = _load_cache()
+        assert loaded["issue_count"] == 2
+        assert loaded["issues"]["TEST-100"] == "Test issue one"
+
+    def test_load_missing(self, tmp_dir):
+        assert _load_cache() is None
+
+    def test_load_corrupt(self, tmp_dir):
+        import dedup_search
+        os.makedirs(os.path.dirname(dedup_search.CACHE_PATH), exist_ok=True)
+        with open(dedup_search.CACHE_PATH, "w") as f:
+            f.write("{{invalid yaml::")
+        assert _load_cache() is None
+
+
+# ─── Keyword Matching ─────────────────────────────────────────────────────────
+
+class TestSearchCache:
+    def test_single_keyword(self, sample_cache):
+        results = _search_cache(sample_cache, ["PDF"], 10)
+        assert len(results) == 1
+        assert results[0][1] == "TEST-100"
+
+    def test_case_insensitive(self, sample_cache):
+        results = _search_cache(sample_cache, ["pdf"], 10)
+        assert len(results) == 1
+
+    def test_multiple_keywords(self, sample_cache):
+        results = _search_cache(sample_cache, ["wizard", "export"], 10)
+        # "wizard" matches only 102; "export" matches 100, 102, 104
+        # TEST-102 should rank highest (2 hits)
+        assert results[0][1] == "TEST-102"
+        assert results[0][0] == 2  # hit count
+
+    def test_no_matches(self, sample_cache):
+        results = _search_cache(sample_cache, ["nonexistent"], 10)
+        assert results == []
+
+    def test_max_results(self, sample_cache):
+        results = _search_cache(sample_cache, ["export"], 2)
+        assert len(results) == 2
+
+    def test_empty_cache(self):
+        assert _search_cache(None, ["test"], 10) == []
+        assert _search_cache({"issues": {}}, ["test"], 10) == []
+
+    def test_empty_keywords(self, sample_cache):
+        results = _search_cache(sample_cache, [], 10)
+        assert results == []
+
+
+# ─── Fallback Keyword Extraction ──────────────────────────────────────────────
+
+class TestFallbackKeywords:
+    def test_extracts_meaningful_words(self):
+        kws = _extract_fallback_keywords(
+            "I want RHOAI AI Hub to have model fine-tuning")
+        assert "rhoai" in kws
+        assert "hub" in kws
+        assert "fine-tuning" in kws
+        # Stopwords removed
+        assert "want" not in kws
+        assert "to" not in kws
+        assert "have" not in kws
+
+    def test_max_five(self):
+        kws = _extract_fallback_keywords(
+            "alpha bravo charlie delta echo foxtrot golf hotel")
+        assert len(kws) <= 5
+
+    def test_deduplication(self):
+        kws = _extract_fallback_keywords("model model model serving serving")
+        assert kws.count("model") == 1
+        assert kws.count("serving") == 1
+
+    def test_empty_input(self):
+        assert _extract_fallback_keywords("") == []
+        assert _extract_fallback_keywords("the a an is") == []
+
+
+# ─── CLI Integration ──────────────────────────────────────────────────────────
+
+class TestCLI:
+    def test_search_no_creds(self, tmp_dir):
+        """Search without credentials returns graceful error."""
+        env = {
+            "JIRA_SERVER": "",
+            "JIRA_USER": "",
+            "JIRA_TOKEN": "",
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": os.environ.get("HOME", ""),
+        }
+        out, err, rc = run_dedup(
+            "search", "model fine-tuning", "--keywords", "model,fine-tuning",
+            env_override=env)
+        assert rc == 0
+        result = json.loads(out)
+        assert result["error"] is not None
+        assert isinstance(result["matches"], list)
+
+    def test_cache_info_runs(self):
+        """cache-info runs without error."""
+        out, _, rc = run_dedup("cache-info")
+        assert rc == 0
+        # Output is either "No cache found." or cache stats — both valid
+        assert "cache" in out.lower() or "Cache" in out
+
+    def test_load_missing_cache(self, tmp_dir):
+        """In-process: _load_cache returns None when no cache file exists."""
+        assert _load_cache() is None

--- a/tests/test_dedup_search.py
+++ b/tests/test_dedup_search.py
@@ -15,11 +15,13 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 from unittest.mock import patch, MagicMock
 
 from dedup_search import (
+    _build_text_query_jql,
     _cache_age_hours,
     _cache_is_fresh,
-    _escape_jql_keyword,
     _extract_fallback_keywords,
+    _jql_string_escape,
     _load_cache,
+    _lucene_escape,
     _save_cache,
     _search_cache,
     _search_jql,
@@ -264,29 +266,128 @@ class TestCLI:
         assert _load_cache() is None
 
 
-# ─── JQL Escaping ────────────────────────────────────────────────────────────
+# ─── JQL / Lucene Escaping ───────────────────────────────────────────────────
 
-class TestEscapeJqlKeyword:
-    def test_plain_keyword(self):
-        assert _escape_jql_keyword("model") == "model"
-
-    def test_double_quotes(self):
-        assert _escape_jql_keyword('say "hello"') == 'say \\"hello\\"'
-
-    def test_backslash(self):
-        assert _escape_jql_keyword("path\\to") == "path\\\\to"
-
-    def test_braces_and_brackets(self):
-        assert _escape_jql_keyword("a{b}[c]") == "a\\{b\\}\\[c\\]"
+class TestLuceneEscape:
+    def test_plain_term(self):
+        assert _lucene_escape("model") == "model"
 
     def test_special_chars(self):
-        result = _escape_jql_keyword("a+b-c*d?e:")
-        assert result == "a\\+b\\-c\\*d\\?e\\:"
+        # All Lucene specials get a backslash prefix
+        assert _lucene_escape("a+b") == "a\\+b"
+        assert _lucene_escape("a(b)") == "a\\(b\\)"
+        assert _lucene_escape("a:b") == "a\\:b"
 
-    def test_combined(self):
-        # Backslash + quotes + brackets
-        result = _escape_jql_keyword('x\\y"z[w]')
-        assert result == 'x\\\\y\\"z\\[w\\]'
+    def test_backslash_first(self):
+        # Literal backslash must be escaped BEFORE we add more escapes
+        # (otherwise we'd double-escape our own escapes)
+        assert _lucene_escape("a\\b") == "a\\\\b"
+
+    def test_quote(self):
+        assert _lucene_escape('a"b') == 'a\\"b'
+
+
+class TestJqlStringEscape:
+    def test_plain(self):
+        assert _jql_string_escape("hello") == "hello"
+
+    def test_quote_and_backslash(self):
+        # JQL string layer: only \ and " need escaping
+        assert _jql_string_escape('a"b') == 'a\\"b'
+        assert _jql_string_escape("a\\b") == "a\\\\b"
+
+    def test_lucene_specials_untouched(self):
+        # Lucene specials are NOT JQL specials; pass through
+        assert _jql_string_escape("a+b") == "a+b"
+        assert _jql_string_escape("a(b)") == "a(b)"
+
+
+class TestBuildTextQueryJql:
+    """Regression tests — the previous implementation double-wrapped keywords
+    in quotes, producing malformed JQL like `text ~ ""a" OR "b""`."""
+
+    def test_single_word_keywords(self):
+        # Bug reproducer: this was producing `text ~ ""mlflow" OR "registry"…"`
+        clause = _build_text_query_jql(
+            ["mlflow", "registry", "sync", "integration"])
+        # No nested double quotes
+        assert '""' not in clause
+        # Single-word terms are bare, not phrase-quoted
+        assert clause == 'text ~ "mlflow OR registry OR sync OR integration"'
+
+    def test_multi_word_phrase(self):
+        # Multi-word keywords become Lucene phrases; JQL escapes the
+        # surrounding Lucene quotes as \"
+        clause = _build_text_query_jql(["model registry"])
+        assert clause == 'text ~ "\\"model registry\\""'
+
+    def test_mixed_single_and_phrase(self):
+        clause = _build_text_query_jql(["mlflow", "model registry"])
+        assert clause == 'text ~ "mlflow OR \\"model registry\\""'
+
+    def test_empty_keyword_stripped(self):
+        # Empty / whitespace-only entries are skipped (defensive — callers
+        # already strip, but don't trust the arg)
+        clause = _build_text_query_jql(["mlflow", "", "  "])
+        assert clause == 'text ~ "mlflow"'
+
+    def test_all_empty_returns_none(self):
+        assert _build_text_query_jql([]) is None
+        assert _build_text_query_jql(["", "  "]) is None
+
+    def test_lucene_specials_escaped(self):
+        # `+` is a Lucene metachar → becomes `\+` in Lucene, then `\\+`
+        # after JQL escapes the backslash.
+        clause = _build_text_query_jql(["a+b"])
+        assert clause == 'text ~ "a\\\\+b"'
+
+    def test_embedded_quote_in_phrase(self):
+        # A `"` inside a phrase: Lucene-escape to `\"`, then JQL-escape
+        # each backslash and quote.
+        clause = _build_text_query_jql(['say "hi"'])
+        # Lucene layer: `say \"hi\"` wrapped as `"say \"hi\""`
+        # JQL layer: every `\` → `\\`, every `"` → `\"`
+        # Final: text ~ "\"say \\\"hi\\\"\""
+        assert clause == 'text ~ "\\"say \\\\\\"hi\\\\\\"\\""'
+
+
+class TestSearchJqlEndToEnd:
+    """End-to-end validation that the URL sent to Jira contains syntactically
+    valid JQL (no double-quote collisions)."""
+
+    @patch("dedup_search.api_call_with_retry")
+    def test_generated_jql_is_parseable(self, mock_api):
+        """Regression for the 'Expecting OR/AND but got mlflow' HTTP 400."""
+        mock_api.return_value = {"issues": []}
+        _search_jql("https://s", "u", "t",
+                    ["mlflow", "registry", "sync", "integration"], 10)
+        call_path = mock_api.call_args[0][1]
+        decoded_jql = urllib.parse.unquote(
+            call_path.split("jql=", 1)[1].split("&", 1)[0])
+        # The decoded JQL must NOT contain the broken `""term"` pattern
+        assert '""' not in decoded_jql, \
+            f"Malformed JQL — nested empty quotes: {decoded_jql!r}"
+        # Sanity check the overall shape
+        assert decoded_jql.startswith(
+            'project = RHAIRFE AND statusCategory != Done AND text ~ ')
+        assert "mlflow" in decoded_jql
+        assert " OR " in decoded_jql
+
+    @patch("dedup_search.api_call_with_retry")
+    def test_generated_jql_with_phrase(self, mock_api):
+        mock_api.return_value = {"issues": []}
+        _search_jql("https://s", "u", "t",
+                    ["mlflow", "model registry"], 10)
+        call_path = mock_api.call_args[0][1]
+        decoded_jql = urllib.parse.unquote(
+            call_path.split("jql=", 1)[1].split("&", 1)[0])
+        # The phrase should survive as an escaped Lucene phrase
+        assert '\\"model registry\\"' in decoded_jql
+        # Whole JQL should be the expected exact form
+        assert decoded_jql == (
+            'project = RHAIRFE AND statusCategory != Done AND '
+            'text ~ "mlflow OR \\"model registry\\""'
+        )
 
 
 # ─── _search_jql (mocked HTTP) ──────────────────────────────────────────────

--- a/tests/test_dedup_search.py
+++ b/tests/test_dedup_search.py
@@ -12,13 +12,18 @@ import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
+from unittest.mock import patch, MagicMock
+
 from dedup_search import (
     _cache_age_hours,
     _cache_is_fresh,
+    _escape_jql_keyword,
     _extract_fallback_keywords,
     _load_cache,
     _save_cache,
     _search_cache,
+    _search_jql,
+    search,
     CACHE_TTL_HOURS,
 )
 
@@ -95,33 +100,39 @@ class TestCacheAge:
 
 
 class TestCacheFreshness:
-    def test_fresh(self, monkeypatch):
-        monkeypatch.setenv("JIRA_SERVER", "https://test.atlassian.net")
+    def test_fresh(self):
         cache = {
             "refreshed_at": datetime.now(timezone.utc).isoformat(),
             "server": "https://test.atlassian.net",
             "issues": {},
         }
+        assert _cache_is_fresh(cache, "https://test.atlassian.net") is True
+
+    def test_fresh_no_server(self):
+        cache = {
+            "refreshed_at": datetime.now(timezone.utc).isoformat(),
+            "server": "https://test.atlassian.net",
+            "issues": {},
+        }
+        # No server passed — skip server check
         assert _cache_is_fresh(cache) is True
 
-    def test_stale(self, monkeypatch):
-        monkeypatch.setenv("JIRA_SERVER", "https://test.atlassian.net")
+    def test_stale(self):
         old = datetime.now(timezone.utc) - timedelta(hours=5)
         cache = {
             "refreshed_at": old.isoformat(),
             "server": "https://test.atlassian.net",
             "issues": {},
         }
-        assert _cache_is_fresh(cache) is False
+        assert _cache_is_fresh(cache, "https://test.atlassian.net") is False
 
-    def test_server_mismatch(self, monkeypatch):
-        monkeypatch.setenv("JIRA_SERVER", "https://other.atlassian.net")
+    def test_server_mismatch(self):
         cache = {
             "refreshed_at": datetime.now(timezone.utc).isoformat(),
             "server": "https://test.atlassian.net",
             "issues": {},
         }
-        assert _cache_is_fresh(cache) is False
+        assert _cache_is_fresh(cache, "https://other.atlassian.net") is False
 
     def test_none_cache(self):
         assert _cache_is_fresh(None) is False
@@ -251,3 +262,178 @@ class TestCLI:
     def test_load_missing_cache(self, tmp_dir):
         """In-process: _load_cache returns None when no cache file exists."""
         assert _load_cache() is None
+
+
+# ─── JQL Escaping ────────────────────────────────────────────────────────────
+
+class TestEscapeJqlKeyword:
+    def test_plain_keyword(self):
+        assert _escape_jql_keyword("model") == "model"
+
+    def test_double_quotes(self):
+        assert _escape_jql_keyword('say "hello"') == 'say \\"hello\\"'
+
+    def test_backslash(self):
+        assert _escape_jql_keyword("path\\to") == "path\\\\to"
+
+    def test_braces_and_brackets(self):
+        assert _escape_jql_keyword("a{b}[c]") == "a\\{b\\}\\[c\\]"
+
+    def test_special_chars(self):
+        result = _escape_jql_keyword("a+b-c*d?e:")
+        assert result == "a\\+b\\-c\\*d\\?e\\:"
+
+    def test_combined(self):
+        # Backslash + quotes + brackets
+        result = _escape_jql_keyword('x\\y"z[w]')
+        assert result == 'x\\\\y\\"z\\[w\\]'
+
+
+# ─── _search_jql (mocked HTTP) ──────────────────────────────────────────────
+
+class TestSearchJql:
+    def _mock_api(self, issues):
+        """Return a mock that simulates api_call_with_retry."""
+        return MagicMock(return_value={
+            "issues": [{"key": k, "fields": {"summary": s}}
+                       for k, s in issues],
+        })
+
+    @patch("dedup_search.api_call_with_retry")
+    def test_returns_results(self, mock_api):
+        mock_api.return_value = {
+            "issues": [
+                {"key": "RHAIRFE-100", "fields": {"summary": "Model serving"}},
+                {"key": "RHAIRFE-101", "fields": {"summary": "Model training"}},
+            ],
+        }
+        results = _search_jql("https://s", "u", "t", ["model"], 10)
+        assert len(results) == 2
+        assert results[0] == ("RHAIRFE-100", "Model serving")
+        mock_api.assert_called_once()
+
+    @patch("dedup_search.api_call_with_retry")
+    def test_escapes_keywords_in_jql(self, mock_api):
+        mock_api.return_value = {"issues": []}
+        _search_jql("https://s", "u", "t", ['say "hi"', "a\\b"], 5)
+        call_path = mock_api.call_args[0][1]
+        # Keywords should be escaped in the encoded JQL
+        assert "say" in call_path
+        mock_api.assert_called_once()
+
+    def test_no_creds_returns_empty(self):
+        assert _search_jql("", "", "", ["model"], 10) == []
+
+    @patch("dedup_search.api_call_with_retry", side_effect=Exception("timeout"))
+    def test_api_error_returns_empty(self, mock_api):
+        results = _search_jql("https://s", "u", "t", ["model"], 10)
+        assert results == []
+
+
+# ─── search() (mocked internals) ────────────────────────────────────────────
+
+class TestSearch:
+    """Tests for the top-level search() function with mocked dependencies."""
+
+    @patch("dedup_search.require_env",
+           return_value=("https://s", "u", "t"))
+    @patch("dedup_search._ensure_fresh_cache")
+    @patch("dedup_search._search_jql", return_value=[])
+    def test_cache_only_when_enough_results(self, mock_jql, mock_cache, mock_env):
+        """When cache has >= 3 results, JQL is not called."""
+        mock_cache.return_value = {
+            "refreshed_at": datetime.now(timezone.utc).isoformat(),
+            "server": "https://s",
+            "issues": {
+                "T-1": "model serving infra",
+                "T-2": "model training pipeline",
+                "T-3": "model registry integration",
+                "T-4": "model monitoring dashboard",
+            },
+        }
+        result = search("model stuff", ["model"], max_results=10)
+        assert result["source"] == "cache"
+        assert len(result["matches"]) == 4
+        mock_jql.assert_not_called()
+
+    @patch("dedup_search.require_env",
+           return_value=("https://s", "u", "t"))
+    @patch("dedup_search._ensure_fresh_cache")
+    @patch("dedup_search._search_jql")
+    def test_jql_fallback_when_sparse_cache(self, mock_jql, mock_cache, mock_env):
+        """When cache has < 3 results, JQL fallback is triggered."""
+        mock_cache.return_value = {
+            "refreshed_at": datetime.now(timezone.utc).isoformat(),
+            "server": "https://s",
+            "issues": {
+                "T-1": "model serving infra",
+            },
+        }
+        mock_jql.return_value = [
+            ("T-50", "model fine-tuning"),
+            ("T-1", "model serving infra"),  # duplicate of cache
+        ]
+        result = search("model stuff", ["model"], max_results=10)
+        assert result["source"] == "cache+jira"
+        mock_jql.assert_called_once()
+        # T-1 should appear once (deduped)
+        keys = [m["key"] for m in result["matches"]]
+        assert keys.count("T-1") == 1
+        assert "T-50" in keys
+
+    @patch("dedup_search.require_env",
+           return_value=("https://s", "u", "t"))
+    @patch("dedup_search._ensure_fresh_cache")
+    @patch("dedup_search._search_jql")
+    def test_jql_only_when_no_cache_results(self, mock_jql, mock_cache, mock_env):
+        """When cache has 0 results, source is 'jira' not 'cache+jira'."""
+        mock_cache.return_value = {
+            "refreshed_at": datetime.now(timezone.utc).isoformat(),
+            "server": "https://s",
+            "issues": {},
+        }
+        mock_jql.return_value = [("T-50", "model fine-tuning")]
+        result = search("model", ["model"], max_results=10)
+        assert result["source"] == "jira"
+
+    @patch("dedup_search.require_env", return_value=("", "", ""))
+    @patch("dedup_search._ensure_fresh_cache", return_value=None)
+    def test_no_creds_no_cache(self, mock_cache, mock_env):
+        result = search("model", ["model"])
+        assert result["error"] == "no_credentials"
+        assert result["matches"] == []
+
+    @patch("dedup_search.require_env", return_value=("", "", ""))
+    @patch("dedup_search._ensure_fresh_cache")
+    def test_no_creds_stale_cache(self, mock_cache, mock_env):
+        mock_cache.return_value = {
+            "refreshed_at": datetime.now(timezone.utc).isoformat(),
+            "server": "https://s",
+            "issues": {"T-1": "model serving"},
+        }
+        result = search("model", ["model"])
+        assert result["error"] == "no_credentials_using_stale_cache"
+        assert len(result["matches"]) == 1
+
+    @patch("dedup_search.require_env",
+           return_value=("https://s", "u", "t"))
+    def test_empty_input(self, mock_env):
+        result = search("", [])
+        assert result["source"] == "none"
+        assert result["matches"] == []
+        assert result["error"] is None
+
+    @patch("dedup_search.require_env",
+           return_value=("https://s", "u", "t"))
+    @patch("dedup_search._ensure_fresh_cache")
+    @patch("dedup_search._search_jql", return_value=[])
+    def test_max_results_respected(self, mock_jql, mock_cache, mock_env):
+        """Matches list is capped at max_results."""
+        issues = {f"T-{i}": f"model variant {i}" for i in range(20)}
+        mock_cache.return_value = {
+            "refreshed_at": datetime.now(timezone.utc).isoformat(),
+            "server": "https://s",
+            "issues": issues,
+        }
+        result = search("model", ["model"], max_results=5)
+        assert len(result["matches"]) == 5

--- a/tests/test_dedup_search.py
+++ b/tests/test_dedup_search.py
@@ -5,10 +5,10 @@ import json
 import os
 import subprocess
 import sys
+import urllib.parse
 from datetime import datetime, timezone, timedelta
 
 import pytest
-import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
@@ -51,7 +51,7 @@ def tmp_dir(tmp_path, monkeypatch):
     # Point CACHE_PATH to temp dir
     import dedup_search
     monkeypatch.setattr(dedup_search, "CACHE_PATH",
-                        str(tmp_path / "tmp" / "dedup-cache.yaml"))
+                        str(tmp_path / "tmp" / "dedup-cache.json"))
     yield tmp_path
     os.chdir(orig)
 
@@ -163,7 +163,7 @@ class TestCacheIO:
         import dedup_search
         os.makedirs(os.path.dirname(dedup_search.CACHE_PATH), exist_ok=True)
         with open(dedup_search.CACHE_PATH, "w") as f:
-            f.write("{{invalid yaml::")
+            f.write("{{invalid json::")
         assert _load_cache() is None
 
 
@@ -437,3 +437,96 @@ class TestSearch:
         }
         result = search("model", ["model"], max_results=5)
         assert len(result["matches"]) == 5
+
+
+# ─── --headless and --recent-only modes ──────────────────────────────────────
+
+class TestHeadlessMode:
+    @patch("dedup_search.require_env",
+           return_value=("https://s", "u", "t"))
+    @patch("dedup_search.refresh_cache")
+    @patch("dedup_search._load_cache", return_value=None)
+    @patch("dedup_search._search_jql")
+    def test_headless_skips_cache_build(self, mock_jql, mock_load,
+                                         mock_refresh, mock_env):
+        """Headless mode must never call refresh_cache, even if cache missing."""
+        mock_jql.return_value = [("T-50", "model fine-tuning")]
+        result = search("model", ["model"], headless=True)
+        mock_refresh.assert_not_called()
+        # Should have fallen through to JQL with recent_days set
+        assert mock_jql.called
+        kwargs = mock_jql.call_args.kwargs
+        # recent_days should be set when headless with no cache
+        assert kwargs.get("recent_days") == 30
+        assert result["source"] == "jira"
+        assert len(result["matches"]) == 1
+
+    @patch("dedup_search.require_env",
+           return_value=("https://s", "u", "t"))
+    @patch("dedup_search.refresh_cache")
+    @patch("dedup_search._load_cache")
+    @patch("dedup_search._search_jql", return_value=[])
+    def test_headless_uses_fresh_cache(self, mock_jql, mock_load,
+                                        mock_refresh, mock_env):
+        """Headless mode uses a fresh cache normally — no refresh, no narrowed JQL."""
+        mock_load.return_value = {
+            "refreshed_at": datetime.now(timezone.utc).isoformat(),
+            "server": "https://s",
+            "issues": {
+                "T-1": "model serving",
+                "T-2": "model training",
+                "T-3": "model registry",
+                "T-4": "model monitoring",
+            },
+        }
+        result = search("model", ["model"], headless=True)
+        mock_refresh.assert_not_called()
+        mock_jql.assert_not_called()  # 4 cache hits → no fallback
+        assert result["source"] == "cache"
+
+
+class TestRecentOnlyMode:
+    @patch("dedup_search.require_env",
+           return_value=("https://s", "u", "t"))
+    @patch("dedup_search._ensure_fresh_cache")
+    @patch("dedup_search._search_jql")
+    def test_recent_only_bypasses_cache(self, mock_jql, mock_cache, mock_env):
+        """--recent-only must skip _ensure_fresh_cache entirely."""
+        mock_jql.return_value = [("T-99", "recent model RFE")]
+        result = search("model", ["model"], recent_only=True)
+        mock_cache.assert_not_called()
+        mock_jql.assert_called_once()
+        kwargs = mock_jql.call_args.kwargs
+        assert kwargs.get("recent_days") == 30
+        assert result["source"] == "jira-recent"
+        assert result["cache_age_hours"] is None
+        assert len(result["matches"]) == 1
+
+    @patch("dedup_search.require_env", return_value=("", "", ""))
+    @patch("dedup_search._ensure_fresh_cache")
+    def test_recent_only_no_creds(self, mock_cache, mock_env):
+        """--recent-only with no credentials returns structured error, no crash."""
+        result = search("model", ["model"], recent_only=True)
+        mock_cache.assert_not_called()
+        assert result["source"] == "jira-recent"
+        assert result["error"] == "no_credentials"
+        assert result["matches"] == []
+
+
+class TestSearchJqlRecentDays:
+    @patch("dedup_search.api_call_with_retry")
+    def test_recent_days_appended_to_jql(self, mock_api):
+        mock_api.return_value = {"issues": []}
+        _search_jql("https://s", "u", "t", ["model"], 10, recent_days=30)
+        call_path = mock_api.call_args[0][1]
+        # JQL gets URL-encoded, so look for the encoded form of "created >= -30d"
+        decoded = urllib.parse.unquote(call_path)
+        assert "created >= -30d" in decoded
+
+    @patch("dedup_search.api_call_with_retry")
+    def test_recent_days_omitted_by_default(self, mock_api):
+        mock_api.return_value = {"issues": []}
+        _search_jql("https://s", "u", "t", ["model"], 10)
+        call_path = mock_api.call_args[0][1]
+        decoded = urllib.parse.unquote(call_path)
+        assert "created" not in decoded


### PR DESCRIPTION
### Description:  Add duplicate detection to /rfe.create                                                                          
                                                                                                                  
  When a user runs /rfe.create, the skill now checks for existing RFEs that may overlap with the new idea before  
  asking clarifying questions. This prevents duplicate work and surfaces related efforts early.
                                                                                                                  
  How it works:                                             
  - Extracts key phrases from the problem statement                                                               
  - Searches a local cache of open RFE summaries (refreshed every 4 hours on-demand based on TTL)
  - Falls back to JQL text search if cache results are sparse                                                     
  - Presents potential duplicates as a table with links      
  - User decides: connect to existing RFE or proceed with creation                                                
  - Non-blocking: if search fails or returns nothing, creation continues normally