### PR TITLE
Propagate Jira parent link to children during split submission

### DIFF
--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -123,7 +123,8 @@ def add_comment(server, user, token, issue_key, body_adf):
 
 
 def create_issue(server, user, token, project, issue_type, summary,
-                 description_adf, priority, labels=None, components=None):
+                 description_adf, priority, labels=None, components=None,
+                 parent_key=None):
     """POST /rest/api/3/issue — returns the created issue key."""
     body = {
         "fields": {
@@ -138,6 +139,8 @@ def create_issue(server, user, token, project, issue_type, summary,
         body["fields"]["labels"] = labels
     if components:
         body["fields"]["components"] = [{"name": c} for c in components]
+    if parent_key:
+        body["fields"]["parent"] = {"key": parent_key}
     result = api_call_with_retry(server, "/issue", user, token, body=body)
     return result["key"]
 

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -85,6 +85,7 @@ class SubmissionState:
         self.total_children = 0
         self.parent_components = []  # inherited by children
         self.parent_labels = []      # non-automation labels inherited
+        self.parent_parent_key = None  # Jira parent (e.g. RHAISTRAT) inherited
 
 
 def discover_state(server, user, token, parent_key, expected_children):
@@ -115,9 +116,10 @@ def discover_state(server, user, token, parent_key, expected_children):
             state.phase2_done[idx] = created_key
             continue
 
-    # 2. Check issue links, components, and labels
+    # 2. Check issue links, components, labels, and Jira parent
     issue = get_issue(server, user, token, parent_key,
-                      ["issuelinks", "status", "components", "labels"])
+                      ["issuelinks", "status", "components", "labels",
+                       "parent"])
     for link in issue.get("fields", {}).get("issuelinks", []):
         if link.get("type", {}).get("name") != "Issue split":
             continue
@@ -139,6 +141,9 @@ def discover_state(server, user, token, parent_key, expected_children):
         l for l in issue.get("fields", {}).get("labels", [])
         if not l.startswith("rfe-creator-")
     ]
+    jira_parent = issue.get("fields", {}).get("parent")
+    if jira_parent:
+        state.parent_parent_key = jira_parent.get("key")
 
     # 3. Check parent status
     status_cat = (issue.get("fields", {}).get("status", {})
@@ -222,20 +227,25 @@ def phase2_create_link(server, user, token, parent_key, children, state,
             if state.parent_components:
                 print(f"           Components: "
                       f"{', '.join(state.parent_components)}")
+            if state.parent_parent_key:
+                print(f"           Parent: {state.parent_parent_key}")
             print(f"           Would link to {parent_key} via 'Issue split'")
             if attn_reason:
                 print(f"           Would post needs-attention comment")
             state.phase2_done[idx] = "RHAIRFE-DRY"
             continue
 
-        # 1. Create ticket with labels and inherited components
+        # 1. Create ticket with labels, inherited components, and parent
         child_key = create_issue(server, user, token, "RHAIRFE",
                                  "Feature Request", title, description_adf,
                                  priority, labels=labels,
-                                 components=state.parent_components)
+                                 components=state.parent_components,
+                                 parent_key=state.parent_parent_key)
         print(f"  Phase 2: Created {child_key} for child {idx}/{total}: "
               f"{title}")
         print(f"           Labels: {', '.join(labels)}")
+        if state.parent_parent_key:
+            print(f"           Parent: {state.parent_parent_key}")
 
         # 2. Link to parent
         create_issue_link(server, user, token, "Issue split",

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -726,6 +726,94 @@ class TestSplitFieldInheritance:
             assert "AI Safety" in components
 
 
+    def test_children_inherit_jira_parent(self, art_dir, jira):
+        """Split children inherit the Jira parent link (e.g. RHAISTRAT)."""
+        # Create RHAISTRAT parent, then RHAIRFE with epic_link to set parent
+        jira.request("POST", "/api/admin/import", {"issues": [
+            {"key": "RHAISTRAT-100", "summary": "Strategy Feature",
+             "project": "RHAISTRAT", "issue_type": "Feature",
+             "description": "Strategy content."},
+            {"key": "RHAIRFE-2000", "summary": "Parent RFE",
+             "project": "RHAIRFE", "issue_type": "Feature Request",
+             "description": "Parent content.",
+             "epic_link": "RHAISTRAT-100"},
+        ]})
+
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-2000.md",
+               "Parent content.")
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-2000.md",
+               "---\nrfe_id: RHAIRFE-2000\ntitle: Parent RFE\n"
+               "priority: Major\nstatus: Archived\n---\n\nParent content.\n")
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               "---\nrfe_id: RFE-001\ntitle: Child RFE 1\n"
+               "priority: Major\nstatus: Ready\n"
+               "parent_key: RHAIRFE-2000\n---\n\nChild 1 content.\n")
+        _write(f"{art_dir}/rfe-tasks/RFE-002.md",
+               "---\nrfe_id: RFE-002\ntitle: Child RFE 2\n"
+               "priority: Major\nstatus: Ready\n"
+               "parent_key: RHAIRFE-2000\n---\n\nChild 2 content.\n")
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": jira.url,
+            "JIRA_USER": "admin",
+            "JIRA_TOKEN": "admin",
+        }
+        r = subprocess.run(
+            [sys.executable, self.SPLIT_SCRIPT, "RHAIRFE-2000",
+             "--artifacts-dir", art_dir],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+
+        # Find the created children
+        issues = jira.search("project = RHAIRFE",
+                             fields="key,parent")
+        children = [i for i in issues
+                    if i["key"] not in ("RHAIRFE-2000",)]
+        assert len(children) == 2
+
+        for child in children:
+            child_detail = jira.get(child["key"])
+            parent = child_detail["fields"].get("parent")
+            assert parent is not None, (
+                f"{child['key']} should inherit parent RHAISTRAT-100")
+            assert parent["key"] == "RHAISTRAT-100"
+
+    def test_no_parent_when_parent_has_none(self, art_dir, jira):
+        """Children don't get a parent field if the split parent has none."""
+        jira.create("RHAIRFE-3000", "Parent No Strat", "Content.")
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-3000.md", "Content.")
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-3000.md",
+               "---\nrfe_id: RHAIRFE-3000\ntitle: Parent No Strat\n"
+               "priority: Major\nstatus: Archived\n---\n\nContent.\n")
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               "---\nrfe_id: RFE-001\ntitle: Child RFE 1\n"
+               "priority: Major\nstatus: Ready\n"
+               "parent_key: RHAIRFE-3000\n---\n\nChild content.\n")
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": jira.url,
+            "JIRA_USER": "admin",
+            "JIRA_TOKEN": "admin",
+        }
+        r = subprocess.run(
+            [sys.executable, self.SPLIT_SCRIPT, "RHAIRFE-3000",
+             "--artifacts-dir", art_dir],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 0, r.stderr
+
+        issues = jira.search("project = RHAIRFE", fields="key,parent")
+        children = [i for i in issues if i["key"] != "RHAIRFE-3000"]
+        assert len(children) == 1
+
+        child_detail = jira.get(children[0]["key"])
+        parent = child_detail["fields"].get("parent")
+        assert parent is None, "Child should not have a parent field"
+
+
 class TestReplayIdempotency:
     """Submit replay must be safe: no duplicate creates, no re-updates."""
 


### PR DESCRIPTION
## Summary
- When an RFE has a Jira parent (e.g. a strategy issue), split children now inherit that parent link
- Adds optional `parent_key` param to `create_issue()` in `jira_utils.py`
- `split_submit.py` fetches the parent's `parent` field during `discover_state()` and passes it through during child creation

## Test plan
- [x] 2 new integration tests against jira-emulator (parent inherited, no parent when none exists)
- [x] All 32 integration tests pass
- [x] Verified against real Jira: created a test issue with a parent, confirmed field set correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)