### PR TITLE
Fix --reprocess to compose with --jql in snapshot_fetch

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -28,9 +28,9 @@ python3 scripts/pipeline_state.py init [--batch-size N] [--headless] [--announce
 python3 scripts/snapshot_fetch.py fetch "<query>" --ids-file tmp/pipeline-all-ids.txt --changed-file tmp/pipeline-changed-ids.txt [--limit N] [--data-dir "<path>"] [--reprocess]
 ```
 
-Print `[AUTOFIX] JQL: <jql>` from stderr output.
+Print `[AUTOFIX] JQL: <jql>` from stderr output. Pass `--reprocess` if set.
 
-**Reprocess mode** (`--reprocess`, no `--jql`):
+**Reprocess-only mode** (`--reprocess` without `--jql`):
 
 ```bash
 python3 scripts/snapshot_fetch.py fetch --reprocess --ids-file tmp/pipeline-all-ids.txt --changed-file tmp/pipeline-changed-ids.txt

--- a/scripts/snapshot_fetch.py
+++ b/scripts/snapshot_fetch.py
@@ -293,8 +293,10 @@ def update_snapshot_hashes(hashes, snapshot_dir=None, mark_processed=None):
 
 def cmd_fetch(args):
     """Fetch all issues, diff against previous snapshot, write ID files."""
-    # --reprocess: skip Jira, reuse prior IDs, mark all as changed
-    if getattr(args, "reprocess", False):
+    reprocess = getattr(args, "reprocess", False)
+
+    # --reprocess without --jql: skip Jira, reuse prior IDs, all changed
+    if reprocess and not args.jql:
         if not os.path.exists(args.ids_file):
             print("Error: No prior IDs found. Run with --jql or "
                   "explicit IDs first.", file=sys.stderr)
@@ -305,7 +307,6 @@ def cmd_fetch(args):
         print(f"CHANGED={len(all_ids)}")
         print(f"NEW=0")
         print(f"UNCHANGED=0")
-        print(f"REPROCESS=true", file=sys.stderr)
         return
 
     if not args.jql:
@@ -414,13 +415,14 @@ def cmd_fetch(args):
 
     # Write ID files for downstream scripts
     write_id_file(args.ids_file, all_ids)
-    write_id_file(args.changed_file, out_changed)
+    # --reprocess: treat all as changed so check_resume processes everything
+    changed_out = all_ids if reprocess else out_changed
+    write_id_file(args.changed_file, changed_out)
 
-    # Output counts only — IDs are in files
     print(f"TOTAL={len(all_ids)}")
-    print(f"CHANGED={len(out_changed)}")
+    print(f"CHANGED={len(changed_out)}")
     print(f"NEW={len(out_new)}")
-    print(f"UNCHANGED={len(all_ids) - len(out_changed) - len(out_new)}")
+    print(f"UNCHANGED={len(all_ids) - len(changed_out) - len(out_new)}")
 
 
 def main():

--- a/tests/test_snapshot_fetch.py
+++ b/tests/test_snapshot_fetch.py
@@ -480,33 +480,35 @@ class TestWriteIdFile:
 
 
 class TestReprocess:
-    def test_reprocess_copies_all_ids_to_changed(self, tmp_path):
-        """--reprocess reads prior IDs and writes all as changed."""
+    def test_reprocess_without_jql_copies_all_to_changed(self, tmp_path):
+        """--reprocess without --jql reuses prior IDs, all marked changed."""
         ids_file = str(tmp_path / "all-ids.txt")
         changed_file = str(tmp_path / "changed-ids.txt")
         write_id_file(ids_file, ["RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"])
 
         import argparse
         args = argparse.Namespace(
-            reprocess=True, ids_file=ids_file, changed_file=changed_file)
+            reprocess=True, jql=None,
+            ids_file=ids_file, changed_file=changed_file)
         cmd_fetch(args)
 
         assert read_id_file(changed_file) == [
             "RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"]
 
-    def test_reprocess_fails_without_prior_ids(self, tmp_path):
+    def test_reprocess_without_jql_fails_without_prior_ids(self, tmp_path):
         """--reprocess with no prior IDs file exits with error."""
         ids_file = str(tmp_path / "missing.txt")
         changed_file = str(tmp_path / "changed-ids.txt")
 
         import argparse
         args = argparse.Namespace(
-            reprocess=True, ids_file=ids_file, changed_file=changed_file)
+            reprocess=True, jql=None,
+            ids_file=ids_file, changed_file=changed_file)
         with pytest.raises(SystemExit) as exc_info:
             cmd_fetch(args)
         assert exc_info.value.code == 1
 
-    def test_reprocess_preserves_ids_file(self, tmp_path):
+    def test_reprocess_without_jql_preserves_ids_file(self, tmp_path):
         """--reprocess does not modify the original IDs file."""
         ids_file = str(tmp_path / "all-ids.txt")
         changed_file = str(tmp_path / "changed-ids.txt")
@@ -514,7 +516,8 @@ class TestReprocess:
 
         import argparse
         args = argparse.Namespace(
-            reprocess=True, ids_file=ids_file, changed_file=changed_file)
+            reprocess=True, jql=None,
+            ids_file=ids_file, changed_file=changed_file)
         cmd_fetch(args)
 
         assert read_id_file(ids_file) == ["RHAIRFE-1", "RHAIRFE-2"]


### PR DESCRIPTION
## Summary

- `--reprocess` with `--jql` now does the Jira fetch normally but writes all IDs to the changed file, so `check_resume` processes everything
- Previously `--reprocess` always skipped Jira, which failed when both flags were passed together (no prior IDs on first run), causing the LLM to improvise a two-call workaround
- Removed noisy `REPROCESS=true` stderr — the flag silently changes what goes in the changed file, no special output

## Test plan

- [x] `pytest tests/test_snapshot_fetch.py` — 38 tests pass
- [x] `pytest tests/` — full suite 344 tests pass
- [x] Manual smoke test: `--reprocess` without `--jql` produces clean stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)