### PR TITLE
Add self-governing poll timeout and advance guard

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -109,12 +109,11 @@ Parse YAML for: `type`, `prompt`, `ids_file`, `vars`, `poll_phase`, `post_verify
    b. Poll until wave completes:
 
       ```bash
-      python3 scripts/check_review_progress.py --phase <poll_phase> [--fast-poll if not headless] <wave_IDs>
+      python3 scripts/check_review_progress.py --poll --phase <poll_phase> [--also-phase <p> for each parallel entry's poll_phase] [--fast-poll if not headless] --id-file <ids_file>
       ```
 
-      Parse `NEXT_POLL=` for sleep seconds. Stop when `PENDING=0`.
-
-      If `parallel` entries: also poll each entry's `poll_phase` separately. All polls must complete before the wave is done.
+      Blocks ~90s (sleeps internally), then exits 0 (done) or 3 (pending).
+      On exit 3, re-run the exact same command until exit 0 — this is a required retry, not polling.
 
 4. After all waves: if `post_verify` is set, run it.
 

--- a/design-proposals/plan-a-thin-dispatcher.md
+++ b/design-proposals/plan-a-thin-dispatcher.md
@@ -41,7 +41,12 @@ Agent phases intentionally expose `pre_script` and `post_verify` commands becaus
 
 ### Invariant 5: Dispatch-before-advance
 
-`advance` refuses to proceed for script phases unless `run-phase` was called first. `run-phase` writes a dispatch marker file (`tmp/.dispatch-marker`) on success; `advance` checks the marker exists and matches the current phase, then deletes it. This prevents the LLM from skipping dispatch and hammering `advance` repeatedly after context compaction — the phase sequence would look correct on disk but no scripts would execute. Noop and agent phases are exempt (noop has no dispatch step; agent dispatch is orchestrator-managed). `advance --dry-run` bypasses the check.
+`advance` refuses to proceed unless dispatch is complete:
+
+- **Script phases**: `run-phase` writes a dispatch marker (`tmp/.dispatch-marker`); `advance` checks the marker exists and matches the current phase. This prevents the LLM from skipping dispatch and hammering `advance` repeatedly after context compaction.
+- **Agent phases**: `advance` calls `check_review_progress.check_id()` for the phase's `poll_phase` (and any parallel `poll_phase` entries) against all IDs in `ids_file`. If any ID is still pending, `advance` refuses and prints the exact `check_review_progress.py --poll` command to run. This catches the case where the LLM skips polling entirely or exits before agents complete — `advance` redirects it back to polling.
+
+Noop phases are exempt. `advance --dry-run` bypasses both checks.
 
 **Manual recovery operations** enabled by the state machine:
 - `pipeline_state.py set-phase <PHASE>` — skip a stuck phase or re-run a failed one
@@ -67,7 +72,7 @@ loop:
     while ids remain:
       wave = take next max_concurrent from ids
       for each id in wave: launch background Agent(...)
-      poll with check_review_progress.py until wave done
+      poll with check_review_progress.py --poll until exit 0
     if config.post_verify:
       run config.post_verify   # writes error frontmatter, removes failed IDs from active set
   elif config.type == "script":

--- a/scripts/check_review_progress.py
+++ b/scripts/check_review_progress.py
@@ -1,11 +1,14 @@
 """Phase-aware progress checker for agent polling.
 
 Reports completion status for a list of RFE IDs based on the current phase.
+Supports ``--poll`` mode which sleeps internally so the caller does not need
+to parse ``NEXT_POLL`` values.
 """
 
 import argparse
 import os
 import sys
+import time
 
 import yaml
 
@@ -50,18 +53,88 @@ def check_id(phase, rfe_id):
     return "completed"
 
 
+def _check_phase(phase, ids, fast):
+    """Check one phase and return (completed, errors, pending, total, next_poll)."""
+    completed = 0
+    errors = 0
+    pending_ids = []
+
+    for rfe_id in ids:
+        result = check_id(phase, rfe_id)
+        if result == "completed":
+            completed += 1
+        elif result == "error":
+            errors += 1
+        else:
+            pending_ids.append(rfe_id)
+
+    total = len(ids)
+    pending = len(pending_ids)
+
+    if pending == 0:
+        next_poll = 0
+    elif fast:
+        next_poll = 15
+    elif completed / total >= 0.75:
+        next_poll = 15
+    elif completed / total >= 0.5:
+        next_poll = 30
+    else:
+        next_poll = 60
+
+    return completed, errors, pending, total, next_poll
+
+
+def _format_status(phase, completed, errors, pending, total, next_poll):
+    """Format a status line for one phase."""
+    parts = [f"COMPLETED={completed}/{total}"]
+    if pending:
+        parts.append(f"PENDING={pending}")
+    if errors:
+        parts.append(f"ERRORS={errors}")
+    parts.append(f"NEXT_POLL={next_poll}")
+    return f"{phase}: {', '.join(parts)}"
+
+
+def _detect_fast(explicit_flag):
+    """Return True if fast-poll should be used."""
+    if explicit_flag:
+        return True
+    for cfg in ("tmp/review-config.yaml", "tmp/split-config.yaml",
+                 "tmp/autofix-config.yaml", "tmp/speedrun-config.yaml"):
+        if os.path.exists(cfg):
+            try:
+                with open(cfg) as f:
+                    data = yaml.safe_load(f)
+                if data and data.get("headless") is False:
+                    return True
+            except Exception:
+                pass
+    return False
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Check review pipeline progress by phase")
     parser.add_argument("--phase", required=True,
                         choices=list(PHASE_CHECKS.keys()),
                         help="Pipeline phase to check")
+    parser.add_argument("--also-phase", action="append",
+                        dest="also_phases",
+                        choices=list(PHASE_CHECKS.keys()),
+                        help="Additional phases to check (poll mode)")
     parser.add_argument("--id-file",
                         help="File containing IDs (one per line or "
                              "space-separated)")
     parser.add_argument("--fast-poll", action="store_true",
                         help="Cap poll interval at 15s (interactive mode). "
                              "Auto-enabled when config files show headless=false.")
+    parser.add_argument("--poll", action="store_true",
+                        help="Block until all agents complete, sleeping "
+                             "internally between checks. Exit 0 when done.")
+    parser.add_argument("--max-wait", type=int, default=90,
+                        help="Max seconds to wait in --poll mode before timing out (exit 3). "
+                             "Default 90 (fits within 2-min bash timeout).")
     parser.add_argument("ids", nargs="*", metavar="ID",
                         help="RFE IDs to check")
     args = parser.parse_args()
@@ -74,56 +147,65 @@ def main():
         print("No IDs provided", file=sys.stderr)
         sys.exit(2)
 
-    completed = 0
-    errors = 0
-    pending_ids = []
+    fast = _detect_fast(args.fast_poll)
+    phases = [args.phase] + (args.also_phases or [])
 
-    for rfe_id in ids:
-        result = check_id(args.phase, rfe_id)
-        if result == "completed":
-            completed += 1
-        elif result == "error":
-            errors += 1
-        else:
-            pending_ids.append(rfe_id)
+    if args.max_wait < 0:
+        parser.error("--max-wait must be non-negative")
 
-    total = len(ids)
-    pending = len(pending_ids)
-    parts = [f"COMPLETED={completed}/{total}"]
-    if pending:
-        parts.append(f"PENDING={pending}")
-    if errors:
-        parts.append(f"ERRORS={errors}")
+    if args.poll:
+        # --poll mode: block until all phases show PENDING=0.
+        # Keeps the LLM inside a bash execution so it can't exit early.
+        start = time.monotonic()
+        while True:
+            all_complete = True
+            max_poll = 0
+            for phase in phases:
+                completed, errors, pending, total, next_poll = \
+                    _check_phase(phase, ids, fast)
+                print(_format_status(
+                    phase, completed, errors, pending, total, next_poll),
+                    flush=True)
+                if pending > 0:
+                    all_complete = False
+                max_poll = max(max_poll, next_poll)
 
-    # Auto-detect interactive mode from config files
-    fast = args.fast_poll
-    if not fast:
-        for cfg in ("tmp/review-config.yaml", "tmp/split-config.yaml",
-                     "tmp/autofix-config.yaml", "tmp/speedrun-config.yaml"):
-            if os.path.exists(cfg):
-                try:
-                    with open(cfg) as f:
-                        data = yaml.safe_load(f)
-                    if data and data.get("headless") is False:
-                        fast = True
-                        break
-                except Exception:
-                    pass
+            if all_complete:
+                if len(phases) > 1:
+                    print("All phases complete.")
+                break
 
-    # Suggest next poll interval based on completion ratio
-    if pending == 0:
-        next_poll = 0
-    elif fast:
-        next_poll = 15
-    elif completed / total >= 0.75:
-        next_poll = 15
-    elif completed / total >= 0.5:
-        next_poll = 30
+            elapsed = time.monotonic() - start
+            if args.max_wait > 0 and (elapsed + max_poll) > args.max_wait:
+                # Collect pending IDs for the timeout message
+                pending_ids = set()
+                for phase in phases:
+                    for rfe_id in ids:
+                        if check_id(phase, rfe_id) == "pending":
+                            pending_ids.add(rfe_id)
+                id_list = sorted(pending_ids)
+                if len(id_list) > 5:
+                    id_summary = ' '.join(id_list[:5]) + f' ... and {len(id_list) - 5} more'
+                else:
+                    id_summary = ' '.join(id_list)
+                print(f"Waited {int(elapsed)}s, still pending: "
+                      f"{id_summary}. "
+                      f"Re-run this command.", flush=True)
+                sys.exit(3)
+
+            print(f"Sleeping {max_poll}s...", flush=True)
+            time.sleep(max_poll)
     else:
-        next_poll = 60
-    parts.append(f"NEXT_POLL={next_poll}")
-
-    print(", ".join(parts))
+        # Legacy single-phase mode
+        completed, errors, pending, total, next_poll = \
+            _check_phase(args.phase, ids, fast)
+        parts = [f"COMPLETED={completed}/{total}"]
+        if pending:
+            parts.append(f"PENDING={pending}")
+        if errors:
+            parts.append(f"ERRORS={errors}")
+        parts.append(f"NEXT_POLL={next_poll}")
+        print(", ".join(parts))
 
 
 if __name__ == "__main__":

--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -654,6 +654,27 @@ def cmd_run_phase(args):
         f.write(phase)
 
 
+def _check_agent_phase_complete(config):
+    """Return True if all agents for an agent phase are complete."""
+    ids_file = config.get("ids_file")
+    poll_phase = config.get("poll_phase")
+    if not ids_file or not poll_phase:
+        return True
+    ids = _read_ids(ids_file)
+    if not ids:
+        return True
+    from check_review_progress import check_id
+    phases_to_check = [poll_phase]
+    for p in config.get("parallel", []):
+        if p.get("poll_phase"):
+            phases_to_check.append(p["poll_phase"])
+    for phase in phases_to_check:
+        for rfe_id in ids:
+            if check_id(phase, rfe_id) == "pending":
+                return False
+    return True
+
+
 def cmd_advance(args):
     dry_run = "--dry-run" in args
     state = _load_state()
@@ -673,6 +694,21 @@ def cmd_advance(args):
         if marker_phase != phase:
             print(f"advance: dispatch marker is for {marker_phase},"
                   f" not current phase {phase}", file=sys.stderr)
+            sys.exit(1)
+    # Guard: agent phases must have all agents complete before advancing
+    if phase_type == "agent" and not dry_run:
+        if not _check_agent_phase_complete(config):
+            poll_phase = config.get("poll_phase", "")
+            ids_file = config.get("ids_file", "")
+            also = ""
+            for p in config.get("parallel", []):
+                if p.get("poll_phase"):
+                    also += f" --also-phase {p['poll_phase']}"
+            print(f"advance: agent phase {phase} has pending agents."
+                  f" Run: python3 scripts/check_review_progress.py --poll"
+                  f" --phase {poll_phase}{also}"
+                  f" --id-file {ids_file}",
+                  file=sys.stderr)
             sys.exit(1)
     next_phase, summary = advance(state, dry_run=dry_run)
     if not dry_run:
@@ -795,8 +831,12 @@ DISPATCH_PROTOCOL = {
         " run pre_script if set, launch background Agent with prompt:"
         ' "<vars>\\n\\nRead <prompt> and follow all instructions exactly."'
         " If parallel entries exist, launch one additional Agent per entry."
-        " 4. Poll with check_review_progress.py --phase <poll_phase> <IDs>"
-        " until PENDING=0. Sleep NEXT_POLL seconds between polls."
+        " 4. Poll: python3 scripts/check_review_progress.py --poll"
+        " --phase <poll_phase> [--also-phase <p> for each parallel"
+        " entry's poll_phase] [--fast-poll if not headless]"
+        " --id-file <ids_file>"
+        " — exit 0 means complete, exit 3 means pending."
+        " On exit 3, re-run step 4's poll command until exit 0."
         " 5. After all waves: run post_verify if set."
         " 6. Run: python3 scripts/pipeline_state.py advance"
     ),

--- a/tests/test_check_review_progress.py
+++ b/tests/test_check_review_progress.py
@@ -1,0 +1,618 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_review_progress.py — poll mode, phase checking,
+status formatting, and adaptive sleep intervals."""
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from check_review_progress import (
+    _check_phase,
+    _detect_fast,
+    _format_status,
+    check_id,
+)
+
+
+# ── check_id ──
+
+
+class TestCheckId:
+    def test_missing_file_is_pending(self, tmp_path):
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            assert check_id("fetch", "RHAIRFE-1") == "pending"
+
+    def test_existing_file_is_completed(self, tmp_path):
+        f = tmp_path / "RHAIRFE-1.md"
+        f.write_text("content")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            assert check_id("fetch", "RHAIRFE-1") == "completed"
+
+    def test_review_phase_score_present(self, tmp_path):
+        """Review phase: file with score → completed."""
+        f = tmp_path / "RHAIRFE-1-review.md"
+        f.write_text("---\nscore: 7\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"review": lambda id: str(tmp_path / f"{id}-review.md")},
+        ):
+            assert check_id("review", "RHAIRFE-1") == "completed"
+
+    def test_review_phase_score_missing(self, tmp_path):
+        """Review phase: file without score → pending."""
+        f = tmp_path / "RHAIRFE-1-review.md"
+        f.write_text("---\ntitle: test\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"review": lambda id: str(tmp_path / f"{id}-review.md")},
+        ):
+            assert check_id("review", "RHAIRFE-1") == "pending"
+
+    def test_review_phase_error_flag(self, tmp_path):
+        """Review phase: file with score + error → error."""
+        f = tmp_path / "RHAIRFE-1-review.md"
+        f.write_text("---\nscore: 5\nerror: true\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"review": lambda id: str(tmp_path / f"{id}-review.md")},
+        ):
+            assert check_id("review", "RHAIRFE-1") == "error"
+
+    def test_review_phase_unparseable(self, tmp_path):
+        """Review phase: unparseable frontmatter → pending."""
+        f = tmp_path / "RHAIRFE-1-review.md"
+        f.write_text("---\n: bad yaml [[\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"review": lambda id: str(tmp_path / f"{id}-review.md")},
+        ):
+            assert check_id("review", "RHAIRFE-1") == "pending"
+
+    def test_revise_phase_auto_revised_true(self, tmp_path):
+        """Revise phase: auto_revised=true → completed."""
+        f = tmp_path / "RHAIRFE-1-review.md"
+        f.write_text("---\nauto_revised: true\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"revise": lambda id: str(tmp_path / f"{id}-review.md")},
+        ):
+            assert check_id("revise", "RHAIRFE-1") == "completed"
+
+    def test_revise_phase_auto_revised_false(self, tmp_path):
+        """Revise phase: no auto_revised, no split recommendation → pending."""
+        f = tmp_path / "RHAIRFE-1-review.md"
+        f.write_text("---\nscore: 5\nrecommendation: improve\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"revise": lambda id: str(tmp_path / f"{id}-review.md")},
+        ):
+            assert check_id("revise", "RHAIRFE-1") == "pending"
+
+    def test_revise_phase_recommendation_split(self, tmp_path):
+        """Revise phase: recommendation=split → completed (can't fix)."""
+        f = tmp_path / "RHAIRFE-1-review.md"
+        f.write_text("---\nrecommendation: split\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"revise": lambda id: str(tmp_path / f"{id}-review.md")},
+        ):
+            assert check_id("revise", "RHAIRFE-1") == "completed"
+
+    def test_revise_phase_bad_frontmatter(self, tmp_path):
+        """Revise phase: unparseable frontmatter → pending."""
+        f = tmp_path / "RHAIRFE-1-review.md"
+        f.write_text("---\n: bad [[\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"revise": lambda id: str(tmp_path / f"{id}-review.md")},
+        ):
+            assert check_id("revise", "RHAIRFE-1") == "pending"
+
+
+# ── _check_phase ──
+
+
+class TestCheckPhase:
+    def test_all_pending(self, tmp_path):
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            completed, errors, pending, total, next_poll = \
+                _check_phase("fetch", ["A", "B", "C"], fast=False)
+            assert completed == 0
+            assert pending == 3
+            assert total == 3
+            assert next_poll == 60
+
+    def test_all_completed(self, tmp_path):
+        for name in ["A", "B", "C"]:
+            (tmp_path / f"{name}.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            completed, errors, pending, total, next_poll = \
+                _check_phase("fetch", ["A", "B", "C"], fast=False)
+            assert completed == 3
+            assert pending == 0
+            assert next_poll == 0
+
+    def test_adaptive_interval_half(self, tmp_path):
+        """50% complete → 30s interval."""
+        for name in ["A", "B"]:
+            (tmp_path / f"{name}.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            _, _, _, _, next_poll = \
+                _check_phase("fetch", ["A", "B", "C", "D"], fast=False)
+            assert next_poll == 30
+
+    def test_adaptive_interval_75pct(self, tmp_path):
+        """75%+ complete → 15s interval."""
+        for name in ["A", "B", "C"]:
+            (tmp_path / f"{name}.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            _, _, _, _, next_poll = \
+                _check_phase("fetch", ["A", "B", "C", "D"], fast=False)
+            assert next_poll == 15
+
+    def test_fast_poll_caps_at_15(self, tmp_path):
+        """Fast mode caps at 15s regardless of completion ratio."""
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            _, _, _, _, next_poll = \
+                _check_phase("fetch", ["A", "B", "C"], fast=True)
+            assert next_poll == 15
+
+
+# ── _format_status ──
+
+
+class TestFormatStatus:
+    def test_pending_format(self):
+        s = _format_status("assess", 2, 0, 3, 5, 30)
+        assert s == "assess: COMPLETED=2/5, PENDING=3, NEXT_POLL=30"
+
+    def test_complete_format(self):
+        s = _format_status("fetch", 5, 0, 0, 5, 0)
+        assert s == "fetch: COMPLETED=5/5, NEXT_POLL=0"
+
+    def test_error_format(self):
+        s = _format_status("review", 3, 1, 1, 5, 15)
+        assert s == "review: COMPLETED=3/5, PENDING=1, ERRORS=1, NEXT_POLL=15"
+
+
+# ── _detect_fast ──
+
+
+class TestDetectFast:
+    def test_explicit_flag(self):
+        assert _detect_fast(True) is True
+
+    def test_no_config_files(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert _detect_fast(False) is False
+
+    def test_headless_false_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        os.makedirs("tmp", exist_ok=True)
+        import yaml
+        with open("tmp/autofix-config.yaml", "w") as f:
+            yaml.dump({"headless": False}, f)
+        assert _detect_fast(False) is True
+
+    def test_headless_true_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        os.makedirs("tmp", exist_ok=True)
+        import yaml
+        with open("tmp/autofix-config.yaml", "w") as f:
+            yaml.dump({"headless": True}, f)
+        assert _detect_fast(False) is False
+
+
+# ── --poll mode (via main) ──
+
+
+class TestPollMode:
+    def _run_main(self, args):
+        """Run main() with given args, return (exit_code, stdout)."""
+        import io
+        from check_review_progress import main
+
+        old_argv = sys.argv
+        sys.argv = ["check_review_progress.py"] + args
+        captured = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            main()
+            exit_code = 0
+        except SystemExit as e:
+            exit_code = e.code
+        finally:
+            sys.stdout = old_stdout
+            sys.argv = old_argv
+        return exit_code, captured.getvalue()
+
+    def test_poll_exits_0_when_complete(self, tmp_path):
+        """All IDs complete → exit 0, no sleep."""
+        for name in ["RHAIRFE-1", "RHAIRFE-2"]:
+            (tmp_path / f"{name}.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            code, out = self._run_main(
+                ["--poll", "--phase", "fetch",
+                 "RHAIRFE-1", "RHAIRFE-2"])
+        assert code == 0
+        assert "COMPLETED=2/2" in out
+        assert "Sleeping" not in out
+
+    def test_poll_sleeps_then_completes(self, tmp_path):
+        """Pending IDs → sleeps, then file appears → exits 0."""
+        def create_on_sleep(seconds):
+            # Simulate agent completing during sleep
+            (tmp_path / "RHAIRFE-1.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ), patch("check_review_progress.time.sleep",
+                 side_effect=create_on_sleep) as mock_sleep:
+            code, out = self._run_main(
+                ["--poll", "--fast-poll", "--phase", "fetch",
+                 "RHAIRFE-1"])
+        assert code == 0
+        assert "PENDING=1" in out
+        assert "Sleeping 15s..." in out
+        assert "COMPLETED=1/1" in out
+        mock_sleep.assert_called_once_with(15)
+
+    def test_poll_uses_adaptive_interval(self, tmp_path):
+        """Sleep duration adapts to completion ratio."""
+        (tmp_path / "A.md").write_text("done")
+        def create_on_sleep(seconds):
+            (tmp_path / "B.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ), patch("check_review_progress.time.sleep",
+                 side_effect=create_on_sleep) as mock_sleep:
+            code, _ = self._run_main(
+                ["--poll", "--phase", "fetch", "A", "B"])
+        assert code == 0
+        # 1/2 = 50% → 30s interval
+        mock_sleep.assert_called_once_with(30)
+
+    def test_poll_multi_phase(self, tmp_path):
+        """--also-phase checks multiple phases, exits 0 only when all done."""
+        for name in ["A", "B"]:
+            (tmp_path / f"fetch-{name}.md").write_text("done")
+            (tmp_path / f"assess-{name}.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {
+                "fetch": lambda id: str(tmp_path / f"fetch-{id}.md"),
+                "assess": lambda id: str(tmp_path / f"assess-{id}.md"),
+            },
+        ):
+            code, out = self._run_main(
+                ["--poll", "--phase", "fetch",
+                 "--also-phase", "assess", "A", "B"])
+        assert code == 0
+        assert "fetch:" in out
+        assert "assess:" in out
+        assert "All phases complete." in out
+
+    def test_poll_multi_phase_partial(self, tmp_path):
+        """One phase done, other pending → sleeps until both complete."""
+        for name in ["A", "B"]:
+            (tmp_path / f"fetch-{name}.md").write_text("done")
+        # assess files missing → pending
+        def create_on_sleep(seconds):
+            for name in ["A", "B"]:
+                (tmp_path / f"assess-{name}.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {
+                "fetch": lambda id: str(tmp_path / f"fetch-{id}.md"),
+                "assess": lambda id: str(tmp_path / f"assess-{id}.md"),
+            },
+        ), patch("check_review_progress.time.sleep",
+                 side_effect=create_on_sleep) as mock_sleep:
+            code, out = self._run_main(
+                ["--poll", "--fast-poll", "--phase", "fetch",
+                 "--also-phase", "assess", "A", "B"])
+        assert code == 0
+        assert "Sleeping" in out
+        assert "All phases complete." in out
+
+    def test_poll_max_interval_across_phases(self, tmp_path):
+        """Sleep uses the longest interval across all phases."""
+        # fetch: 1/2 done → 30s, assess: 0/2 done → 60s → max = 60
+        (tmp_path / "fetch-A.md").write_text("done")
+        def create_on_sleep(seconds):
+            (tmp_path / "fetch-B.md").write_text("done")
+            for name in ["A", "B"]:
+                (tmp_path / f"assess-{name}.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {
+                "fetch": lambda id: str(tmp_path / f"fetch-{id}.md"),
+                "assess": lambda id: str(tmp_path / f"assess-{id}.md"),
+            },
+        ), patch("check_review_progress.time.sleep",
+                 side_effect=create_on_sleep) as mock_sleep:
+            code, _ = self._run_main(
+                ["--poll", "--phase", "fetch",
+                 "--also-phase", "assess", "A", "B"])
+        assert code == 0
+        mock_sleep.assert_called_once_with(60)
+
+    def test_poll_single_phase_no_all_complete_message(self, tmp_path):
+        """Single phase complete → no 'All phases complete.' message."""
+        (tmp_path / "A.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            code, out = self._run_main(
+                ["--poll", "--phase", "fetch", "A"])
+        assert code == 0
+        assert "All phases complete." not in out
+
+    def test_poll_max_wait_exits_3_on_timeout(self, tmp_path):
+        """Pending IDs + small max-wait → exit 3 with pending IDs on stdout."""
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ), patch("check_review_progress.time.sleep") as mock_sleep, \
+           patch("check_review_progress.time.monotonic",
+                 side_effect=[0, 0, 0]):
+            # monotonic: start=0, before-guard=0, elapsed+60>1 → timeout
+            code, out = self._run_main(
+                ["--poll", "--max-wait", "1", "--phase", "fetch",
+                 "RHAIRFE-1", "RHAIRFE-2"])
+        assert code == 3
+        assert "RHAIRFE-1" in out
+        assert "RHAIRFE-2" in out
+        assert "Re-run this command" in out
+        mock_sleep.assert_not_called()
+
+    def test_poll_max_wait_completes_before_timeout(self, tmp_path):
+        """Agents complete within max-wait → exit 0."""
+        def create_on_sleep(seconds):
+            (tmp_path / "RHAIRFE-1.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ), patch("check_review_progress.time.sleep",
+                 side_effect=create_on_sleep), \
+           patch("check_review_progress.time.monotonic",
+                 side_effect=[0, 0, 5, 5]):
+            # start=0, guard: 0+15<90 → sleep, second iter: complete
+            code, out = self._run_main(
+                ["--poll", "--fast-poll", "--max-wait", "90",
+                 "--phase", "fetch", "RHAIRFE-1"])
+        assert code == 0
+        assert "COMPLETED=1/1" in out
+
+    def test_poll_max_wait_zero_disables(self, tmp_path):
+        """--max-wait 0 disables timeout (runs until complete)."""
+        call_count = [0]
+        def create_on_second_sleep(seconds):
+            call_count[0] += 1
+            if call_count[0] >= 2:
+                (tmp_path / "A.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ), patch("check_review_progress.time.sleep",
+                 side_effect=create_on_second_sleep), \
+           patch("check_review_progress.time.monotonic",
+                 side_effect=[0, 0, 100, 100, 200, 200]):
+            # Even at elapsed=200, max_wait=0 means no timeout
+            code, out = self._run_main(
+                ["--poll", "--max-wait", "0", "--fast-poll",
+                 "--phase", "fetch", "A"])
+        assert code == 0
+        assert call_count[0] == 2
+
+    def test_poll_max_wait_multi_phase(self, tmp_path):
+        """Multi-phase with one stalling → exit 3."""
+        for name in ["A", "B"]:
+            (tmp_path / f"fetch-{name}.md").write_text("done")
+        # assess files missing → pending
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {
+                "fetch": lambda id: str(tmp_path / f"fetch-{id}.md"),
+                "assess": lambda id: str(tmp_path / f"assess-{id}.md"),
+            },
+        ), patch("check_review_progress.time.sleep"), \
+           patch("check_review_progress.time.monotonic",
+                 side_effect=[0, 0, 0]):
+            code, out = self._run_main(
+                ["--poll", "--max-wait", "1", "--phase", "fetch",
+                 "--also-phase", "assess", "A", "B"])
+        assert code == 3
+        assert "Re-run this command" in out
+
+    def test_poll_max_wait_message_format(self, tmp_path):
+        """Timeout message contains pending IDs and directive."""
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ), patch("check_review_progress.time.sleep"), \
+           patch("check_review_progress.time.monotonic",
+                 side_effect=[0, 5]):
+            # monotonic: start=0, elapsed=5-0=5, 5+60>1 → timeout
+            code, out = self._run_main(
+                ["--poll", "--max-wait", "1", "--phase", "fetch",
+                 "RHAIRFE-100", "RHAIRFE-200"])
+        assert code == 3
+        assert "Waited 5s" in out
+        assert "RHAIRFE-100" in out
+        assert "RHAIRFE-200" in out
+        assert "Re-run this command" in out
+
+    def test_poll_max_wait_deduplicates_ids(self, tmp_path):
+        """Pending in multiple phases → each ID appears only once."""
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {
+                "fetch": lambda id: str(tmp_path / f"fetch-{id}.md"),
+                "assess": lambda id: str(tmp_path / f"assess-{id}.md"),
+            },
+        ), patch("check_review_progress.time.sleep"), \
+           patch("check_review_progress.time.monotonic",
+                 side_effect=[0, 0, 0]):
+            code, out = self._run_main(
+                ["--poll", "--max-wait", "1", "--phase", "fetch",
+                 "--also-phase", "assess", "A"])
+        assert code == 3
+        # "A" pending in both phases but should appear only once
+        timeout_line = [l for l in out.splitlines() if "Re-run" in l][0]
+        assert timeout_line.count(" A") == 1
+
+    def test_poll_max_wait_caps_id_list(self, tmp_path):
+        """10+ pending IDs → message shows first 5 + '... and N more'."""
+        ids = [f"RFE-{i:03d}" for i in range(10)]
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ), patch("check_review_progress.time.sleep"), \
+           patch("check_review_progress.time.monotonic",
+                 side_effect=[0, 0, 0]):
+            code, out = self._run_main(
+                ["--poll", "--max-wait", "1", "--phase", "fetch"] + ids)
+        assert code == 3
+        assert "... and 5 more" in out
+        # First 5 sorted IDs should be present
+        for i in range(5):
+            assert f"RFE-{i:03d}" in out
+
+    def test_poll_max_wait_negative_rejected(self):
+        """--max-wait -1 should error."""
+        import io
+        from check_review_progress import main
+        old_argv = sys.argv
+        sys.argv = ["check_review_progress.py",
+                     "--poll", "--max-wait", "-1",
+                     "--phase", "fetch", "A"]
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            main()
+            exit_code = 0
+        except SystemExit as e:
+            exit_code = e.code
+        finally:
+            sys.stderr = old_stderr
+            sys.argv = old_argv
+        assert exit_code == 2  # argparse/validation error
+
+    def test_poll_with_id_file(self, tmp_path):
+        """--id-file reads IDs correctly."""
+        id_file = tmp_path / "ids.txt"
+        id_file.write_text("RHAIRFE-1 RHAIRFE-2\nRHAIRFE-3\n")
+        for name in ["RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"]:
+            (tmp_path / f"{name}.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            code, out = self._run_main(
+                ["--poll", "--phase", "fetch",
+                 "--id-file", str(id_file)])
+        assert code == 0
+        assert "COMPLETED=3/3" in out
+
+    def test_poll_errors_dont_block(self, tmp_path):
+        """Errors count as done — only pending blocks exit."""
+        # RHAIRFE-1: has score + error → error
+        (tmp_path / "RHAIRFE-1-review.md").write_text(
+            "---\nscore: 5\nerror: true\n---\nBody\n")
+        # RHAIRFE-2: has score → completed
+        (tmp_path / "RHAIRFE-2-review.md").write_text(
+            "---\nscore: 8\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"review": lambda id: str(tmp_path / f"{id}-review.md")},
+        ):
+            code, out = self._run_main(
+                ["--poll", "--phase", "review",
+                 "RHAIRFE-1", "RHAIRFE-2"])
+        assert code == 0
+        assert "ERRORS=1" in out
+        assert "COMPLETED=1/2" in out
+
+
+# ── Legacy mode (no --poll) ──
+
+
+class TestLegacyMode:
+    def _run_main(self, args):
+        import io
+        from check_review_progress import main
+
+        old_argv = sys.argv
+        sys.argv = ["check_review_progress.py"] + args
+        captured = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            main()
+            exit_code = 0
+        except SystemExit as e:
+            exit_code = e.code
+        finally:
+            sys.stdout = old_stdout
+            sys.argv = old_argv
+        return exit_code, captured.getvalue()
+
+    def test_legacy_format_unchanged(self, tmp_path):
+        """Legacy mode output format is flat CSV, not prefixed by phase."""
+        (tmp_path / "A.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            code, out = self._run_main(
+                ["--phase", "fetch", "A", "B"])
+        assert code is None or code == 0
+        assert out.strip() == "COMPLETED=1/2, PENDING=1, NEXT_POLL=30"
+
+    def test_legacy_no_ids_exits_2(self, tmp_path):
+        code, _ = self._run_main(["--phase", "fetch"])
+        assert code == 2
+
+    def test_max_wait_ignored_without_poll(self, tmp_path):
+        """--max-wait without --poll runs legacy mode, no timeout behavior."""
+        (tmp_path / "A.md").write_text("done")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"fetch": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            code, out = self._run_main(
+                ["--max-wait", "30", "--phase", "fetch", "A", "B"])
+        assert code is None or code == 0
+        assert "COMPLETED=1/2" in out
+        assert "Re-run" not in out

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -770,8 +770,12 @@ class TestDispatchMarker:
         assert "FETCH" in buf.getvalue()
 
     def test_advance_skips_marker_for_agent(self, tmp_dir, monkeypatch):
-        """Agent phases don't require a dispatch marker."""
+        """Agent phases don't require a dispatch marker (but do check completion)."""
         ps._save_state(make_state(phase="FETCH"))
+        # All IDs complete — create task files so check_id returns "completed"
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1001"])
+        with open("artifacts/rfe-tasks/RHAIRFE-1001.md", "w") as f:
+            f.write("fetched")
         monkeypatch.setattr(ps, "_run_script", lambda cmd: "")
         import io
         from contextlib import redirect_stdout
@@ -789,6 +793,104 @@ class TestDispatchMarker:
         with redirect_stdout(buf):
             ps.cmd_advance(["--dry-run"])
         assert "REASSESS_CHECK" in buf.getvalue()
+
+
+# ---------- Agent phase guard on advance ----------
+
+
+class TestAgentPhaseGuard:
+    """Verify advance refuses to proceed for agent phases with pending agents."""
+
+    def test_advance_rejects_pending_agents(self, tmp_dir):
+        """advance exits with error when agent phase has pending IDs."""
+        ps._save_state(make_state(phase="FETCH"))
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1001"])
+        # No task file → pending
+        with pytest.raises(SystemExit) as exc_info:
+            ps.cmd_advance([])
+        assert exc_info.value.code == 1
+
+    def test_advance_accepts_complete_agents(self, tmp_dir, monkeypatch):
+        """advance proceeds when all agent IDs are complete."""
+        ps._save_state(make_state(phase="FETCH"))
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1001"])
+        with open("artifacts/rfe-tasks/RHAIRFE-1001.md", "w") as f:
+            f.write("fetched")
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "")
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            ps.cmd_advance([])
+        assert "SETUP" in buf.getvalue()
+
+    def test_advance_checks_parallel_phases(self, tmp_dir, monkeypatch):
+        """advance checks parallel poll_phases too (e.g. ASSESS + feasibility)."""
+        ps._save_state(make_state(phase="ASSESS"))
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1001"])
+        # Assess file exists but feasibility file missing
+        os.makedirs("/tmp/rfe-assess/single", exist_ok=True)
+        with open("/tmp/rfe-assess/single/RHAIRFE-1001.result.md", "w") as f:
+            f.write("assessed")
+        # No feasibility file → pending on parallel phase
+        with pytest.raises(SystemExit) as exc_info:
+            ps.cmd_advance([])
+        assert exc_info.value.code == 1
+
+    def test_advance_parallel_all_complete(self, tmp_dir, monkeypatch):
+        """advance proceeds when both main and parallel phases are complete."""
+        ps._save_state(make_state(phase="ASSESS"))
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1001"])
+        os.makedirs("/tmp/rfe-assess/single", exist_ok=True)
+        with open("/tmp/rfe-assess/single/RHAIRFE-1001.result.md", "w") as f:
+            f.write("assessed")
+        with open("artifacts/rfe-reviews/RHAIRFE-1001-feasibility.md", "w") as f:
+            f.write("feasibility done")
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "")
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            ps.cmd_advance([])
+        assert "REVIEW" in buf.getvalue()
+
+    def test_advance_prints_poll_command_on_reject(self, tmp_dir):
+        """Rejection message includes the exact poll command to run."""
+        ps._save_state(make_state(phase="FETCH"))
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1001"])
+        import io
+        from contextlib import redirect_stderr
+        buf = io.StringIO()
+        with pytest.raises(SystemExit), redirect_stderr(buf):
+            ps.cmd_advance([])
+        err = buf.getvalue()
+        assert "check_review_progress.py --poll" in err
+        assert "--phase fetch" in err
+        assert "--id-file tmp/pipeline-active-ids.txt" in err
+
+    def test_advance_dry_run_skips_agent_check(self, tmp_dir):
+        """Dry-run bypasses the agent completion check."""
+        ps._save_state(make_state(phase="FETCH"))
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1001"])
+        # No task file → would fail without dry-run
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            ps.cmd_advance(["--dry-run"])
+        assert "SETUP" in buf.getvalue()
+
+    def test_advance_empty_ids_file_passes(self, tmp_dir, monkeypatch):
+        """Empty IDs file → no agents to check, advance proceeds."""
+        ps._save_state(make_state(phase="FETCH"))
+        write_ids("tmp/pipeline-active-ids.txt", [])
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "")
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            ps.cmd_advance([])
+        assert "SETUP" in buf.getvalue()
 
 
 # ---------- FIXUP → REASSESS_CHECK ----------
@@ -895,6 +997,33 @@ class TestDispatchLoopE2E:
             buf = io.StringIO()
             with redirect_stdout(buf):
                 ps.cmd_run_phase([])
+
+        # Simulate agent completion for agent phases
+        if phase_type == "agent":
+            ids_file = config.get("ids_file")
+            if ids_file:
+                ids = read_ids(ids_file)
+                poll_phase = config.get("poll_phase")
+                phases_to_sim = [poll_phase]
+                for p in config.get("parallel", []):
+                    if p.get("poll_phase"):
+                        phases_to_sim.append(p["poll_phase"])
+                for pp in phases_to_sim:
+                    for rfe_id in ids:
+                        from check_review_progress import PHASE_CHECKS
+                        path = PHASE_CHECKS[pp](rfe_id)
+                        os.makedirs(os.path.dirname(path), exist_ok=True)
+                        if pp == "review":
+                            with open(path, "w") as f:
+                                f.write("---\nscore: 7\n---\n")
+                        elif pp == "revise":
+                            # Check if file exists (review file); set
+                            # auto_revised
+                            with open(path, "w") as f:
+                                f.write("---\nauto_revised: true\n---\n")
+                        else:
+                            with open(path, "w") as f:
+                                f.write("done")
 
         # Step 3: advance
         buf = io.StringIO()


### PR DESCRIPTION
## Summary
- Adds `--max-wait=90s` default to `--poll` mode so the script exits cleanly (exit 3) before the 2-min bash timeout fires, requiring zero LLM cooperation on timeout parameters
- Adds advance guard in `cmd_advance` that refuses phase transitions if agents are still pending — safety net for LLM misbehavior (skipping poll, exiting early)
- Updates SKILL.md and DISPATCH_PROTOCOL with explicit anti-polling override clause and step-number anchoring to survive context compaction
- Adds 42 tests for `check_review_progress.py` (was 0) and 7 advance guard tests for `pipeline_state.py`

## Test plan
- [x] `pytest tests/test_check_review_progress.py -v` — 42 tests pass
- [x] `pytest tests/test_pipeline_state.py -v` — 76 tests pass
- [x] Full suite `pytest tests/ -q` — 393 tests pass
- [ ] Manual: `--poll --max-wait 5` with no agent files → exits 3 after ~5s
- [ ] Manual: `--poll` with agent files present → exits 0 immediately
- [ ] CI end-to-end with `/rfe.auto-fix` pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)