### PR TITLE
Fix feasibility agents inheriting assess-phase vars

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -104,7 +104,7 @@ Parse YAML for: `type`, `prompt`, `ids_file`, `vars`, `poll_phase`, `post_verify
       - Build the agent environment string from `vars`: for each key-value pair, replace `{ID}` with the current ID, producing lines like `ID=RHAIRFE-1234`, `ASSESS_PATH=/tmp/rfe-assess/single/RHAIRFE-1234.result.md`, etc.
       - Launch a background Agent with `subagent_type` (if set). The prompt is:
         `"<vars as KEY=VALUE lines>\n\nRead <prompt> and follow all instructions exactly."`
-      - If `parallel` entries exist: for each entry, launch one additional background Agent using the same pattern with the entry's `prompt`.
+      - If `parallel` entries exist: for each entry, launch one additional background Agent. If the entry has its own `vars`, build the env string from those (with `{ID}` replaced) — do NOT use the parent phase's `vars`. Use the entry's `subagent_type` if set. The prompt format is the same: `"<vars as KEY=VALUE lines>\n\nRead <entry's prompt> and follow all instructions exactly."`
 
    b. Poll until wave completes:
 

--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -70,7 +70,8 @@ PHASE_CONFIG = {
         "poll_phase": "assess",
         "parallel": [
             {"prompt": ".claude/skills/rfe-feasibility-review/SKILL.md",
-             "poll_phase": "feasibility"},
+             "poll_phase": "feasibility",
+             "vars": {"ID": "{ID}"}},
         ],
         "pre_script": "python3 scripts/prep_assess.py {ID}",
         "post_verify": "python3 scripts/verify_phase.py --phase assess"
@@ -195,7 +196,8 @@ PHASE_CONFIG = {
         "pre_script": "python3 scripts/prep_assess.py {ID}",
         "parallel": [
             {"prompt": ".claude/skills/rfe-feasibility-review/SKILL.md",
-             "poll_phase": "feasibility"},
+             "poll_phase": "feasibility",
+             "vars": {"ID": "{ID}"}},
         ],
         "post_verify": "python3 scripts/verify_phase.py --phase assess"
                        " --ids-file tmp/pipeline-split-children-ids.txt",
@@ -830,7 +832,8 @@ DISPATCH_PROTOCOL = {
         " 3. For each ID: replace {ID} in vars to build KEY=VALUE lines,"
         " run pre_script if set, launch background Agent with prompt:"
         ' "<vars>\\n\\nRead <prompt> and follow all instructions exactly."'
-        " If parallel entries exist, launch one additional Agent per entry."
+        " If parallel entries exist, launch one additional Agent per entry"
+        " using the entry's own vars (not the parent's) with {ID} replaced."
         " 4. Poll: python3 scripts/check_review_progress.py --poll"
         " --phase <poll_phase> [--also-phase <p> for each parallel"
         " entry's poll_phase] [--fast-poll if not headless]"


### PR DESCRIPTION
## Summary
- Feasibility agents in ASSESS/SPLIT_ASSESS were receiving parent phase vars (DATA_FILE, RUN_DIR, PROMPT_PATH) instead of just ID
- RUN_DIR caused agents to write to `/tmp/rfe-assess/single/artifacts/rfe-reviews/` instead of `artifacts/rfe-reviews/`
- PROMPT_PATH caused some agents to run the rubric scoring prompt instead of the feasibility prompt
- Added `vars: {ID: "{ID}"}` to both parallel entries so feasibility agents get only what they need
- Clarified SKILL.md and DISPATCH_PROTOCOL to specify parallel entries use their own vars, not the parent's

## Test plan
- [x] All 118 existing tests pass
- [ ] CI run validates feasibility agents write to correct paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)