### PR TITLE
Add --random flag, wave_size computation, and empty-IDs skip

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -11,7 +11,7 @@ You are a non-interactive RFE auto-fix pipeline. Do not ask questions or wait fo
 
 Parse `$ARGUMENTS` for:
 - `--jql "<query>"`, `--limit N`, `--batch-size N` (default 50), `--data-dir "<path>"`
-- `--headless`, `--announce-complete`, `--reprocess`
+- `--headless`, `--announce-complete`, `--reprocess`, `--random N`
 - Remaining arguments: explicit RFE IDs
 
 ### 1. Init
@@ -25,7 +25,7 @@ python3 scripts/pipeline_state.py init [--batch-size N] [--headless] [--announce
 **JQL mode** (`--jql`):
 
 ```bash
-python3 scripts/snapshot_fetch.py fetch "<query>" --ids-file tmp/pipeline-all-ids.txt --changed-file tmp/pipeline-changed-ids.txt [--limit N] [--data-dir "<path>"] [--reprocess]
+python3 scripts/snapshot_fetch.py fetch "<query>" --ids-file tmp/pipeline-all-ids.txt --changed-file tmp/pipeline-changed-ids.txt [--limit N] [--data-dir "<path>"] [--reprocess] [--random N]
 ```
 
 Print `[AUTOFIX] JQL: <jql>` from stderr output. Pass `--reprocess` if set.
@@ -97,7 +97,7 @@ Parse YAML for: `type`, `prompt`, `ids_file`, `vars`, `poll_phase`, `post_verify
 
 1. Read IDs from `ids_file`.
 2. Pre-filter already done: `python3 scripts/check_review_progress.py --phase <poll_phase> <IDs>` — remove COMPLETED IDs from the working set.
-3. Compute wave size: `max_concurrent` (default `batch_size`) divided by `(1 + number of parallel entries)`, rounded down (minimum 1). Process remaining IDs in waves of that size:
+3. Use `wave_size` from the phase config output. Process remaining IDs in waves of that size:
 
    a. For each ID in the wave:
       - If `pre_script`: run it with `{ID}` replaced by the current ID.

--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -623,6 +623,10 @@ def cmd_get_phase_config(args):
     config.pop("command", None)
     if config.get("type") == "script":
         config.pop("ids_file", None)
+    if config.get("type") == "agent":
+        max_concurrent = int(state.get("batch_size", 50))
+        n_parallel = len(config.get("parallel", []))
+        config["wave_size"] = max(1, max_concurrent // (1 + n_parallel))
     print(yaml.dump(config, default_flow_style=False, sort_keys=False),
           end="")
 
@@ -647,6 +651,12 @@ def cmd_run_phase(args):
         ids = _read_ids(config["ids_file"])
         if ids:
             cmd += " " + " ".join(ids)
+        else:
+            print(f"[run-phase] {phase}: no IDs, skipping")
+            # Write dispatch marker and return — nothing to do
+            with open(DISPATCH_MARKER, "w") as f:
+                f.write(phase)
+            return
     print(f"[run-phase] {phase}")
     result = subprocess.run(cmd, shell=True)
     if result.returncode != 0:
@@ -829,7 +839,8 @@ DISPATCH_PROTOCOL = {
         "1. Read IDs from ids_file."
         " 2. Pre-filter: python3 scripts/check_review_progress.py"
         " --phase <poll_phase> <IDs> — remove COMPLETED IDs."
-        " 3. For each ID: replace {ID} in vars to build KEY=VALUE lines,"
+        " 3. Process IDs in waves of wave_size (from config output)."
+        " For each ID: replace {ID} in vars to build KEY=VALUE lines,"
         " run pre_script if set, launch background Agent with prompt:"
         ' "<vars>\\n\\nRead <prompt> and follow all instructions exactly."'
         " If parallel entries exist, launch one additional Agent per entry"

--- a/scripts/snapshot_fetch.py
+++ b/scripts/snapshot_fetch.py
@@ -25,6 +25,7 @@ from collections import OrderedDict
 import glob
 import hashlib
 import os
+import random
 import sys
 import urllib.parse
 from datetime import datetime, timezone
@@ -358,14 +359,27 @@ def cmd_fetch(args):
     # changed and new are already ordered lists from diff_snapshots
     changed_set = set(changed)
     new_set = set(new)
-    limit = args.limit or len(current)
 
-    # Select up to limit: changed first, then new, then unchanged
-    all_ids = (changed + new)[:limit]
-    if len(all_ids) < limit:
-        unchanged = [k for k in current
-                     if k not in changed_set and k not in new_set]
-        all_ids.extend(unchanged[:limit - len(all_ids)])
+    random_n = getattr(args, "random", None)
+    if random_n is not None:
+        # Random sampling from all fetched issues (for testing)
+        all_keys = list(current.keys())
+        if random_n >= len(all_keys):
+            print(f"Warning: --random {random_n} >= fetched "
+                  f"{len(all_keys)} issues, using all",
+                  file=sys.stderr)
+            all_ids = sorted(all_keys)
+        else:
+            all_ids = sorted(random.sample(all_keys, random_n))
+    else:
+        limit = args.limit or len(current)
+
+        # Select up to limit: changed first, then new, then unchanged
+        all_ids = (changed + new)[:limit]
+        if len(all_ids) < limit:
+            unchanged = [k for k in current
+                         if k not in changed_set and k not in new_set]
+            all_ids.extend(unchanged[:limit - len(all_ids)])
 
     # Build cumulative snapshot: previous entries + selected issues.
     # Only selected issues get their hashes recorded (or updated).
@@ -447,6 +461,9 @@ def main():
     fetch_p.add_argument("--reprocess", action="store_true",
                          help="Skip Jira fetch, reuse prior IDs, "
                          "mark all as changed")
+    fetch_p.add_argument("--random", type=int, default=None,
+                         help="With --reprocess: randomly sample N IDs "
+                         "from the prior set (for testing)")
 
     args = parser.parse_args()
     if args.command == "fetch":

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -1245,9 +1245,10 @@ class TestDispatchLoopE2E:
         script_phases_hit = [p for p in phases
                              if ps.PHASE_CONFIG.get(p, {}).get("type")
                              == "script"]
-        # Each script phase should have produced a subprocess.run call
-        assert len(run_phase_calls) == len(script_phases_hit)
-        assert len(run_phase_calls) > 0  # at least FIXUP
+        # Script phases with empty IDs files are skipped (no subprocess call),
+        # so run_phase_calls may be fewer than script_phases_hit.
+        assert len(run_phase_calls) <= len(script_phases_hit)
+        assert len(run_phase_calls) > 0  # at least SETUP/REPORT
 
     def test_correction_loop(self, tmp_dir, monkeypatch):
         """Split correction: SPLIT_CORRECTION_CHECK → SPLIT loop-back.
@@ -1448,13 +1449,15 @@ class TestDispatchLoopE2E:
         # Should see 3 REASSESS_CHECK (enter cycle 1, enter cycle 2, exit)
         assert phases.count("REASSESS_CHECK") == 3
 
-        # After cycle 2's REASSESS_RESTORE, revise IDs should be empty
-        # The dispatch loop still walks through REASSESS_REVISE and
-        # REASSESS_FIXUP — verify FIXUP ran with empty IDs
-        last_fixup_cmd = fixup_commands[-1]
-        # The command should be just the base command with no IDs appended
-        # (since pipeline-revise-ids.txt is empty after last cycle guard)
-        assert "RHAIRFE" not in last_fixup_cmd
+        # After cycle 2's REASSESS_RESTORE, revise IDs should be empty.
+        # run-phase skips the command entirely when IDs file is empty,
+        # so fixup_commands should only contain calls from earlier cycles
+        # where IDs were present. The last cycle's FIXUP is skipped.
+        # Verify we got fixup calls from cycle 1 (with IDs) but the
+        # total count reflects that the empty-ID cycle was skipped.
+        assert len(fixup_commands) >= 1  # at least cycle 1's FIXUP ran
+        # Cycle 1's fixup should have the ID
+        assert "RHAIRFE-1001" in fixup_commands[0]
 
     def test_dispatch_context_hides_ids_file_for_scripts(self, tmp_dir):
         """dispatch-context must not leak ids_file for script phases."""

--- a/tests/test_snapshot_fetch.py
+++ b/tests/test_snapshot_fetch.py
@@ -488,7 +488,7 @@ class TestReprocess:
 
         import argparse
         args = argparse.Namespace(
-            reprocess=True, jql=None,
+            reprocess=True, jql=None, random=None,
             ids_file=ids_file, changed_file=changed_file)
         cmd_fetch(args)
 
@@ -502,7 +502,7 @@ class TestReprocess:
 
         import argparse
         args = argparse.Namespace(
-            reprocess=True, jql=None,
+            reprocess=True, jql=None, random=None,
             ids_file=ids_file, changed_file=changed_file)
         with pytest.raises(SystemExit) as exc_info:
             cmd_fetch(args)
@@ -516,8 +516,68 @@ class TestReprocess:
 
         import argparse
         args = argparse.Namespace(
-            reprocess=True, jql=None,
+            reprocess=True, jql=None, random=None,
             ids_file=ids_file, changed_file=changed_file)
         cmd_fetch(args)
 
         assert read_id_file(ids_file) == ["RHAIRFE-1", "RHAIRFE-2"]
+
+
+class TestRandom:
+    """Tests for --random N with --reprocess --jql (random sampling from JQL)."""
+
+    def _make_current(self, keys):
+        """Build a fake fetch_all_issues return dict."""
+        return {k: {"content_hash": f"hash-{k}"} for k in keys}
+
+    def _run_fetch(self, tmp_path, current, random_n, monkeypatch):
+        """Run cmd_fetch with mocked Jira fetch, return (ids, changed)."""
+        import argparse
+        ids_file = str(tmp_path / "all-ids.txt")
+        changed_file = str(tmp_path / "changed-ids.txt")
+        snap_dir = str(tmp_path / "snapshots")
+
+        monkeypatch.setattr("snapshot_fetch.require_env",
+                            lambda: ("http://x", "u", "t"))
+        monkeypatch.setattr("snapshot_fetch.fetch_all_issues",
+                            lambda *a, **kw: current)
+        monkeypatch.setattr("snapshot_fetch.find_previous_snapshot",
+                            lambda: (None, None))
+        monkeypatch.setattr("snapshot_fetch.SNAPSHOT_DIR", snap_dir)
+
+        args = argparse.Namespace(
+            reprocess=True, jql="project = TEST", random=random_n,
+            limit=None, data_dir=None,
+            ids_file=ids_file, changed_file=changed_file)
+        cmd_fetch(args)
+        return read_id_file(ids_file), read_id_file(changed_file)
+
+    def test_random_samples_n_ids(self, tmp_path, monkeypatch):
+        """--random N picks N random IDs from JQL results."""
+        keys = [f"RHAIRFE-{i}" for i in range(1, 11)]
+        current = self._make_current(keys)
+
+        ids, changed = self._run_fetch(tmp_path, current, 3, monkeypatch)
+
+        assert len(ids) == 3
+        assert all(k in keys for k in ids)
+        # --reprocess marks all as changed
+        assert changed == ids
+
+    def test_random_exceeding_count_uses_all(self, tmp_path, monkeypatch):
+        """--random N >= fetched issues uses all with a warning."""
+        keys = ["RHAIRFE-1", "RHAIRFE-2"]
+        current = self._make_current(keys)
+
+        ids, changed = self._run_fetch(tmp_path, current, 10, monkeypatch)
+
+        assert sorted(ids) == sorted(keys)
+
+    def test_random_results_are_sorted(self, tmp_path, monkeypatch):
+        """--random output is sorted for deterministic downstream."""
+        keys = [f"RHAIRFE-{i}" for i in range(1, 21)]
+        current = self._make_current(keys)
+
+        ids, _ = self._run_fetch(tmp_path, current, 5, monkeypatch)
+
+        assert ids == sorted(ids)


### PR DESCRIPTION
## Summary
- Add `--random N` to `snapshot_fetch.py` for JQL path: fetches all matching issues then randomly samples N for testing smaller batches
- Compute `wave_size` server-side in `get-phase-config` instead of relying on LLM arithmetic (fixes artificial 25-agent waving in REVIEW)
- Skip `run-phase` gracefully when `ids_file` is empty (fixes SPLIT_SAVE crash when no revisions needed)

## Test plan
- [x] All 41 snapshot_fetch tests pass (3 new --random tests)
- [x] All 118 pipeline_state tests pass (2 updated for empty-IDs skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)