### PR TITLE
Rename --poll to --wait and add CLAUDE.md pipeline constraint

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -106,14 +106,14 @@ Parse YAML for: `type`, `prompt`, `ids_file`, `vars`, `poll_phase`, `post_verify
         `"<vars as KEY=VALUE lines>\n\nRead <prompt> and follow all instructions exactly."`
       - If `parallel` entries exist: for each entry, launch one additional background Agent. If the entry has its own `vars`, build the env string from those (with `{ID}` replaced) — do NOT use the parent phase's `vars`. Use the entry's `subagent_type` if set. The prompt format is the same: `"<vars as KEY=VALUE lines>\n\nRead <entry's prompt> and follow all instructions exactly."`
 
-   b. Poll until wave completes:
+   b. Wait for wave to complete:
 
       ```bash
-      python3 scripts/check_review_progress.py --poll --phase <poll_phase> [--also-phase <p> for each parallel entry's poll_phase] [--fast-poll if not headless] --id-file <ids_file>
+      python3 scripts/check_review_progress.py --wait --phase <poll_phase> [--also-phase <p> for each parallel entry's poll_phase] [--fast-poll if not headless] --id-file <ids_file>
       ```
 
       Blocks ~90s (sleeps internally), then exits 0 (done) or 3 (pending).
-      On exit 3, re-run the exact same command until exit 0 — this is a required retry, not polling.
+      On exit 3, re-run the exact same command until exit 0.
 
 4. After all waves: if `post_verify` is set, run it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,17 @@ Skills that only work with local artifacts (`/rfe.create`) do not require Jira a
 
 Before modifying `scripts/snapshot_fetch.py`, `scripts/bootstrap_snapshot.py`, or `scripts/submit.py` (snapshot-related code), read `docs/snapshot-incremental-fetch.md` — especially the **Design Invariants** section. Changes must preserve all invariants.
 
+## Pipeline Execution Constraint
+
+When `tmp/pipeline-state.yaml` exists and the phase is not DONE:
+
+1. A text-only response (no tool call) during pipeline execution terminates the CI process.
+2. After launching each wave of agents, your next Bash call MUST be
+   `python3 scripts/check_review_progress.py --wait`. This is a blocking
+   synchronization barrier that reads artifact files on disk.
+3. Do not wait for agent-completion notifications — the progress check command
+   is unrelated to the Agent tool's notification system.
+
 ## Architecture Context
 
 `/rfe.review` automatically fetches architecture context from [opendatahub-io/architecture-context](https://github.com/opendatahub-io/architecture-context) into `.context/architecture-context/` and detects the latest RHOAI version. No manual setup needed.

--- a/scripts/check_review_progress.py
+++ b/scripts/check_review_progress.py
@@ -1,7 +1,7 @@
 """Phase-aware progress checker for agent polling.
 
 Reports completion status for a list of RFE IDs based on the current phase.
-Supports ``--poll`` mode which sleeps internally so the caller does not need
+Supports ``--wait`` mode which sleeps internally so the caller does not need
 to parse ``NEXT_POLL`` values.
 """
 
@@ -122,18 +122,18 @@ def main():
     parser.add_argument("--also-phase", action="append",
                         dest="also_phases",
                         choices=list(PHASE_CHECKS.keys()),
-                        help="Additional phases to check (poll mode)")
+                        help="Additional phases to check (wait mode)")
     parser.add_argument("--id-file",
                         help="File containing IDs (one per line or "
                              "space-separated)")
     parser.add_argument("--fast-poll", action="store_true",
                         help="Cap poll interval at 15s (interactive mode). "
                              "Auto-enabled when config files show headless=false.")
-    parser.add_argument("--poll", action="store_true",
+    parser.add_argument("--wait", action="store_true",
                         help="Block until all agents complete, sleeping "
                              "internally between checks. Exit 0 when done.")
     parser.add_argument("--max-wait", type=int, default=90,
-                        help="Max seconds to wait in --poll mode before timing out (exit 3). "
+                        help="Max seconds to wait in --wait mode before timing out (exit 3). "
                              "Default 90 (fits within 2-min bash timeout).")
     parser.add_argument("ids", nargs="*", metavar="ID",
                         help="RFE IDs to check")
@@ -153,8 +153,8 @@ def main():
     if args.max_wait < 0:
         parser.error("--max-wait must be non-negative")
 
-    if args.poll:
-        # --poll mode: block until all phases show PENDING=0.
+    if args.wait:
+        # --wait mode: block until all phases show PENDING=0.
         # Keeps the LLM inside a bash execution so it can't exit early.
         start = time.monotonic()
         while True:

--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -717,7 +717,7 @@ def cmd_advance(args):
                 if p.get("poll_phase"):
                     also += f" --also-phase {p['poll_phase']}"
             print(f"advance: agent phase {phase} has pending agents."
-                  f" Run: python3 scripts/check_review_progress.py --poll"
+                  f" Run: python3 scripts/check_review_progress.py --wait"
                   f" --phase {poll_phase}{also}"
                   f" --id-file {ids_file}",
                   file=sys.stderr)
@@ -845,12 +845,12 @@ DISPATCH_PROTOCOL = {
         ' "<vars>\\n\\nRead <prompt> and follow all instructions exactly."'
         " If parallel entries exist, launch one additional Agent per entry"
         " using the entry's own vars (not the parent's) with {ID} replaced."
-        " 4. Poll: python3 scripts/check_review_progress.py --poll"
+        " 4. Wait: python3 scripts/check_review_progress.py --wait"
         " --phase <poll_phase> [--also-phase <p> for each parallel"
         " entry's poll_phase] [--fast-poll if not headless]"
         " --id-file <ids_file>"
         " — exit 0 means complete, exit 3 means pending."
-        " On exit 3, re-run step 4's poll command until exit 0."
+        " On exit 3, re-run step 4's wait command until exit 0."
         " 5. After all waves: run post_verify if set."
         " 6. Run: python3 scripts/pipeline_state.py advance"
     ),

--- a/tests/test_check_review_progress.py
+++ b/tests/test_check_review_progress.py
@@ -227,7 +227,7 @@ class TestDetectFast:
         assert _detect_fast(False) is False
 
 
-# ── --poll mode (via main) ──
+# ── --wait mode (via main) ──
 
 
 class TestPollMode:
@@ -260,7 +260,7 @@ class TestPollMode:
             {"fetch": lambda id: str(tmp_path / f"{id}.md")},
         ):
             code, out = self._run_main(
-                ["--poll", "--phase", "fetch",
+                ["--wait", "--phase", "fetch",
                  "RHAIRFE-1", "RHAIRFE-2"])
         assert code == 0
         assert "COMPLETED=2/2" in out
@@ -277,7 +277,7 @@ class TestPollMode:
         ), patch("check_review_progress.time.sleep",
                  side_effect=create_on_sleep) as mock_sleep:
             code, out = self._run_main(
-                ["--poll", "--fast-poll", "--phase", "fetch",
+                ["--wait", "--fast-poll", "--phase", "fetch",
                  "RHAIRFE-1"])
         assert code == 0
         assert "PENDING=1" in out
@@ -296,7 +296,7 @@ class TestPollMode:
         ), patch("check_review_progress.time.sleep",
                  side_effect=create_on_sleep) as mock_sleep:
             code, _ = self._run_main(
-                ["--poll", "--phase", "fetch", "A", "B"])
+                ["--wait", "--phase", "fetch", "A", "B"])
         assert code == 0
         # 1/2 = 50% → 30s interval
         mock_sleep.assert_called_once_with(30)
@@ -314,7 +314,7 @@ class TestPollMode:
             },
         ):
             code, out = self._run_main(
-                ["--poll", "--phase", "fetch",
+                ["--wait", "--phase", "fetch",
                  "--also-phase", "assess", "A", "B"])
         assert code == 0
         assert "fetch:" in out
@@ -338,7 +338,7 @@ class TestPollMode:
         ), patch("check_review_progress.time.sleep",
                  side_effect=create_on_sleep) as mock_sleep:
             code, out = self._run_main(
-                ["--poll", "--fast-poll", "--phase", "fetch",
+                ["--wait", "--fast-poll", "--phase", "fetch",
                  "--also-phase", "assess", "A", "B"])
         assert code == 0
         assert "Sleeping" in out
@@ -361,7 +361,7 @@ class TestPollMode:
         ), patch("check_review_progress.time.sleep",
                  side_effect=create_on_sleep) as mock_sleep:
             code, _ = self._run_main(
-                ["--poll", "--phase", "fetch",
+                ["--wait", "--phase", "fetch",
                  "--also-phase", "assess", "A", "B"])
         assert code == 0
         mock_sleep.assert_called_once_with(60)
@@ -374,7 +374,7 @@ class TestPollMode:
             {"fetch": lambda id: str(tmp_path / f"{id}.md")},
         ):
             code, out = self._run_main(
-                ["--poll", "--phase", "fetch", "A"])
+                ["--wait", "--phase", "fetch", "A"])
         assert code == 0
         assert "All phases complete." not in out
 
@@ -388,7 +388,7 @@ class TestPollMode:
                  side_effect=[0, 0, 0]):
             # monotonic: start=0, before-guard=0, elapsed+60>1 → timeout
             code, out = self._run_main(
-                ["--poll", "--max-wait", "1", "--phase", "fetch",
+                ["--wait", "--max-wait", "1", "--phase", "fetch",
                  "RHAIRFE-1", "RHAIRFE-2"])
         assert code == 3
         assert "RHAIRFE-1" in out
@@ -409,7 +409,7 @@ class TestPollMode:
                  side_effect=[0, 0, 5, 5]):
             # start=0, guard: 0+15<90 → sleep, second iter: complete
             code, out = self._run_main(
-                ["--poll", "--fast-poll", "--max-wait", "90",
+                ["--wait", "--fast-poll", "--max-wait", "90",
                  "--phase", "fetch", "RHAIRFE-1"])
         assert code == 0
         assert "COMPLETED=1/1" in out
@@ -430,7 +430,7 @@ class TestPollMode:
                  side_effect=[0, 0, 100, 100, 200, 200]):
             # Even at elapsed=200, max_wait=0 means no timeout
             code, out = self._run_main(
-                ["--poll", "--max-wait", "0", "--fast-poll",
+                ["--wait", "--max-wait", "0", "--fast-poll",
                  "--phase", "fetch", "A"])
         assert code == 0
         assert call_count[0] == 2
@@ -450,7 +450,7 @@ class TestPollMode:
            patch("check_review_progress.time.monotonic",
                  side_effect=[0, 0, 0]):
             code, out = self._run_main(
-                ["--poll", "--max-wait", "1", "--phase", "fetch",
+                ["--wait", "--max-wait", "1", "--phase", "fetch",
                  "--also-phase", "assess", "A", "B"])
         assert code == 3
         assert "Re-run this command" in out
@@ -465,7 +465,7 @@ class TestPollMode:
                  side_effect=[0, 5]):
             # monotonic: start=0, elapsed=5-0=5, 5+60>1 → timeout
             code, out = self._run_main(
-                ["--poll", "--max-wait", "1", "--phase", "fetch",
+                ["--wait", "--max-wait", "1", "--phase", "fetch",
                  "RHAIRFE-100", "RHAIRFE-200"])
         assert code == 3
         assert "Waited 5s" in out
@@ -485,7 +485,7 @@ class TestPollMode:
            patch("check_review_progress.time.monotonic",
                  side_effect=[0, 0, 0]):
             code, out = self._run_main(
-                ["--poll", "--max-wait", "1", "--phase", "fetch",
+                ["--wait", "--max-wait", "1", "--phase", "fetch",
                  "--also-phase", "assess", "A"])
         assert code == 3
         # "A" pending in both phases but should appear only once
@@ -502,7 +502,7 @@ class TestPollMode:
            patch("check_review_progress.time.monotonic",
                  side_effect=[0, 0, 0]):
             code, out = self._run_main(
-                ["--poll", "--max-wait", "1", "--phase", "fetch"] + ids)
+                ["--wait", "--max-wait", "1", "--phase", "fetch"] + ids)
         assert code == 3
         assert "... and 5 more" in out
         # First 5 sorted IDs should be present
@@ -515,7 +515,7 @@ class TestPollMode:
         from check_review_progress import main
         old_argv = sys.argv
         sys.argv = ["check_review_progress.py",
-                     "--poll", "--max-wait", "-1",
+                     "--wait", "--max-wait", "-1",
                      "--phase", "fetch", "A"]
         old_stderr = sys.stderr
         sys.stderr = io.StringIO()
@@ -540,7 +540,7 @@ class TestPollMode:
             {"fetch": lambda id: str(tmp_path / f"{id}.md")},
         ):
             code, out = self._run_main(
-                ["--poll", "--phase", "fetch",
+                ["--wait", "--phase", "fetch",
                  "--id-file", str(id_file)])
         assert code == 0
         assert "COMPLETED=3/3" in out
@@ -558,14 +558,14 @@ class TestPollMode:
             {"review": lambda id: str(tmp_path / f"{id}-review.md")},
         ):
             code, out = self._run_main(
-                ["--poll", "--phase", "review",
+                ["--wait", "--phase", "review",
                  "RHAIRFE-1", "RHAIRFE-2"])
         assert code == 0
         assert "ERRORS=1" in out
         assert "COMPLETED=1/2" in out
 
 
-# ── Legacy mode (no --poll) ──
+# ── Legacy mode (no --wait) ──
 
 
 class TestLegacyMode:
@@ -605,7 +605,7 @@ class TestLegacyMode:
         assert code == 2
 
     def test_max_wait_ignored_without_poll(self, tmp_path):
-        """--max-wait without --poll runs legacy mode, no timeout behavior."""
+        """--max-wait without --wait runs legacy mode, no timeout behavior."""
         (tmp_path / "A.md").write_text("done")
         with patch.dict(
             "check_review_progress.PHASE_CHECKS",

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -864,7 +864,7 @@ class TestAgentPhaseGuard:
         with pytest.raises(SystemExit), redirect_stderr(buf):
             ps.cmd_advance([])
         err = buf.getvalue()
-        assert "check_review_progress.py --poll" in err
+        assert "check_review_progress.py --wait" in err
         assert "--phase fetch" in err
         assert "--id-file tmp/pipeline-active-ids.txt" in err
 


### PR DESCRIPTION
## Summary

- Renames `--poll` to `--wait` in `check_review_progress.py` to eliminate lexical conflict with the Agent tool's "do NOT poll" instruction that caused CI run #114 to fail after context compaction
- Adds a Pipeline Execution Constraint section to CLAUDE.md (system-prompt level) that directly addresses the failure mode: mandates running the progress check command after launching agents, prohibits waiting for agent-completion notifications
- Updates all references in `pipeline_state.py` (DISPATCH_PROTOCOL, advance guard), `SKILL.md`, and tests

## Test plan

- [x] All 118 existing tests pass with renamed flag
- [x] `--wait` flag works: `python3 scripts/check_review_progress.py --wait --phase fetch A B`
- [x] Legacy mode unaffected: `python3 scripts/check_review_progress.py --phase fetch A B`
- [x] Interactive skills (`rfe.review`, `rfe.split`) unaffected — they use legacy mode without the `--wait` flag
- [ ] Full CI validation requires a pipeline run with compaction

Generated with [Claude Code](https://claude.com/claude-code)