### PR TITLE
Fix wait-for-wave hang on broken agent frontmatter

### DIFF
--- a/scripts/check_review_progress.py
+++ b/scripts/check_review_progress.py
@@ -35,7 +35,9 @@ def check_id(phase, rfe_id):
         try:
             data, _ = read_frontmatter(path)
         except Exception:
-            return "pending"
+            return "error"
+        if not data:
+            return "error"
         if data.get("score") is None:
             return "pending"
         if data.get("error"):
@@ -44,7 +46,9 @@ def check_id(phase, rfe_id):
         try:
             data, _ = read_frontmatter(path)
         except Exception:
-            return "pending"
+            return "error"
+        if not data:
+            return "error"
         if data.get("auto_revised"):
             return "completed"
         if data.get("recommendation") == "split":

--- a/scripts/verify_phase.py
+++ b/scripts/verify_phase.py
@@ -63,11 +63,15 @@ def verify(phase, ids_file):
             try:
                 subprocess.run([
                     "python3", "scripts/frontmatter.py", "set", review_path,
+                    f"rfe_id={rfe_id}",
                     f"error={error_msg}",
                     "score=0", "pass=false", "recommendation=revise",
                     "feasibility=feasible", "auto_revised=false",
                     "needs_attention=true",
                     f"needs_attention_reason=Agent failed: {error_msg}",
+                    "scores.what=0", "scores.why=0",
+                    "scores.open_to_how=0", "scores.not_a_task=0",
+                    "scores.right_sized=0",
                 ], check=True, capture_output=True)
             except Exception:
                 pass

--- a/tests/test_check_review_progress.py
+++ b/tests/test_check_review_progress.py
@@ -68,14 +68,14 @@ class TestCheckId:
             assert check_id("review", "RHAIRFE-1") == "error"
 
     def test_review_phase_unparseable(self, tmp_path):
-        """Review phase: unparseable frontmatter → pending."""
+        """Review phase: unparseable frontmatter → error."""
         f = tmp_path / "RHAIRFE-1-review.md"
         f.write_text("---\n: bad yaml [[\n---\nBody\n")
         with patch.dict(
             "check_review_progress.PHASE_CHECKS",
             {"review": lambda id: str(tmp_path / f"{id}-review.md")},
         ):
-            assert check_id("review", "RHAIRFE-1") == "pending"
+            assert check_id("review", "RHAIRFE-1") == "error"
 
     def test_revise_phase_auto_revised_true(self, tmp_path):
         """Revise phase: auto_revised=true → completed."""
@@ -108,14 +108,45 @@ class TestCheckId:
             assert check_id("revise", "RHAIRFE-1") == "completed"
 
     def test_revise_phase_bad_frontmatter(self, tmp_path):
-        """Revise phase: unparseable frontmatter → pending."""
+        """Revise phase: unparseable frontmatter → error."""
         f = tmp_path / "RHAIRFE-1-review.md"
         f.write_text("---\n: bad [[\n---\nBody\n")
         with patch.dict(
             "check_review_progress.PHASE_CHECKS",
             {"revise": lambda id: str(tmp_path / f"{id}-review.md")},
         ):
-            assert check_id("revise", "RHAIRFE-1") == "pending"
+            assert check_id("revise", "RHAIRFE-1") == "error"
+
+    def test_review_phase_missing_closing_delimiter(self, tmp_path):
+        """Review phase: missing closing --- → error (CI #128 regression)."""
+        f = tmp_path / "RHAIRFE-1-review.md"
+        f.write_text("---\nscore: 7\npass: true\nrecommendation: submit\n"
+                      "Review body without closing delimiter.\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"review": lambda id: str(tmp_path / f"{id}-review.md")},
+        ):
+            assert check_id("review", "RHAIRFE-1") == "error"
+
+    def test_review_phase_empty_frontmatter(self, tmp_path):
+        """Review phase: empty --- / --- → error (CI #122 regression)."""
+        f = tmp_path / "RHAIRFE-1-review.md"
+        f.write_text("---\n---\nReview body with empty frontmatter.\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"review": lambda id: str(tmp_path / f"{id}-review.md")},
+        ):
+            assert check_id("review", "RHAIRFE-1") == "error"
+
+    def test_revise_phase_empty_frontmatter(self, tmp_path):
+        """Revise phase: empty frontmatter → error."""
+        f = tmp_path / "RHAIRFE-1-review.md"
+        f.write_text("---\n---\nBody.\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"revise": lambda id: str(tmp_path / f"{id}-review.md")},
+        ):
+            assert check_id("revise", "RHAIRFE-1") == "error"
 
 
 # ── _check_phase ──


### PR DESCRIPTION
## Summary
- **check_id()** now returns `"error"` instead of `"pending"` for review/revise files with broken or empty frontmatter, preventing `wait-for-wave` from polling indefinitely (CI #122, #128 regressions)
- **verify_phase.py** now includes required `rfe_id` and `scores.*` fields when writing error frontmatter, so the `frontmatter.py set` validation passes and the ID flows into the retry batch instead of being silently lost
- Added 3 new regression tests and updated 2 existing tests

## Test plan
- [x] All 432 tests pass
- [x] Validated by 3 independent Opus agents (scores: 8/10, 8/10, 6/10 — agent 3 finding fixed)
- [x] Traced full error-to-retry flow: broken frontmatter → check_id error → wait-for-wave exits → verify_phase writes valid error frontmatter → collect_recommendations --errors picks up ID → retry batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)