### PR TITLE
Fix architecture context loading via LATEST_VERSION file

### DIFF
--- a/.claude/skills/rfe-feasibility-review/SKILL.md
+++ b/.claude/skills/rfe-feasibility-review/SKILL.md
@@ -20,9 +20,9 @@ Review a single RFE specified by ID. Read the task file at `artifacts/rfe-tasks/
 
 ## Architecture Context
 
-Check for architecture context in `.context/architecture-context/architecture/`. Look for a `rhoai-*` directory (there should be exactly one from the sparse checkout). If found, read `PLATFORM.md` to identify which components the RFE touches, then read relevant component docs. Use this to ground your feasibility assessment in the actual platform.
+Read the file `.context/architecture-context/LATEST_VERSION` to get the version directory name (e.g., `rhoai-3.4-ea.2`). Then read `.context/architecture-context/architecture/<version>/PLATFORM.md` to identify which components the RFE touches, and read relevant component docs. Use this to ground your feasibility assessment in the actual platform.
 
-If no architecture context is available (directory missing or empty), assess feasibility based on the RFE content alone and note that architecture context was not available.
+If `LATEST_VERSION` does not exist or the PLATFORM.md read fails, assess feasibility based on the RFE content alone and note that architecture context was not available.
 
 ## Prior Review
 

--- a/scripts/fetch-architecture-context.sh
+++ b/scripts/fetch-architecture-context.sh
@@ -24,4 +24,5 @@ else
   git -C "$CONTEXT_DIR" sparse-checkout set "architecture/$LATEST"
 fi
 
+echo "$LATEST" > "$CONTEXT_DIR/LATEST_VERSION"
 echo "Architecture context ready: $CONTEXT_DIR/architecture/$LATEST"


### PR DESCRIPTION
## Summary
- `scripts/fetch-architecture-context.sh` now writes the selected version into `.context/architecture-context/LATEST_VERSION` after the sparse checkout completes.
- `.claude/skills/rfe-feasibility-review/SKILL.md` reads `LATEST_VERSION` as the single source of truth for locating `PLATFORM.md`, replacing the previous glob over `rhoai-*` directories which silently picked the wrong version when multiple existed (or none after a partial sync).

## Test plan
- [ ] Run `bash scripts/fetch-architecture-context.sh` and confirm `.context/architecture-context/LATEST_VERSION` exists and matches `architecture/<version>/`.
- [ ] Invoke `/rfe.review` against an existing RFE; confirm the produced `-feasibility.md` references actual platform components rather than saying "architecture context was not available."
- [ ] Delete `LATEST_VERSION` and re-run `/rfe.review`; confirm graceful fallback path triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)