### PR TITLE
Make speedrun batch_size deterministic across runs

### DIFF
--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -17,11 +17,11 @@ Parse `$ARGUMENTS` for:
 - `--batch-size N`: Override batch size (default 5), passed to auto-fix
 - Remaining arguments: either a single Jira key (RHAIRFE-NNNN) or a free-text idea
 
-Clean temp state and persist parsed flags:
+Clean temp state and persist parsed flags. `batch_size` MUST always be a concrete integer — if the user did not pass `--batch-size`, substitute the speedrun default of `5`. Do not write `<N>`, `null`, or omit the field.
 
 ```bash
 python3 scripts/state.py clean
-python3 scripts/state.py init tmp/speedrun-config.yaml headless=<true/false> announce_complete=<true/false> dry_run=<true/false> batch_size=<N> input_file=<path or null>
+python3 scripts/state.py init tmp/speedrun-config.yaml headless=<true/false> announce_complete=<true/false> dry_run=<true/false> batch_size=<N or 5> input_file=<path or null>
 ```
 
 Determine pipeline mode:
@@ -97,10 +97,10 @@ python3 scripts/state.py read-ids tmp/speedrun-all-ids.txt
 Build the auto-fix command using flags from the config file:
 
 ```
-/rfe.auto-fix [--headless] [--announce-complete] [--batch-size N] <all_IDs_from_file>
+/rfe.auto-fix [--headless] [--announce-complete] --batch-size <batch_size> <all_IDs_from_file>
 ```
 
-Pass `--headless` and `--announce-complete` through if set. Pass `--batch-size` if provided.
+Pass `--headless` and `--announce-complete` through if set in the config. **Always** pass `--batch-size <batch_size>` using the value from `tmp/speedrun-config.yaml` — never omit it, never let auto-fix's own default take over. The speedrun default (5) was already pinned in Step 0; relying on it here is what makes runs reproducible.
 
 Auto-fix handles: assessment, feasibility checks, review, auto-revision, re-assessment, splitting oversized RFEs, retry queue, and report generation. Wait for it to complete.
 


### PR DESCRIPTION
## Summary
- Pin `batch_size` so identical inputs yield identical orchestration. Step 0 always writes a concrete integer (CLI value or the speedrun default of 5), and Phase 2 always passes `--batch-size` from the speedrun config to `/rfe.auto-fix`.
- Removes three discretionary points where the LLM previously diverged: the unfilled `batch_size=<N>` placeholder, the ambiguous "Pass `--batch-size` if provided" wording, and the implicit fallback to auto-fix's own default of 50.

## Why
Two consecutive eval runs with identical config diverged ~4× in cost and duration because one orchestrator chose `batch_size=50` (1 wave of 20 RFEs) while the other chose `5` (4 sequential waves of 5).

## Test plan
- [ ] Run `/rfe.speedrun --headless --dry-run --input batch.yaml` twice without `--batch-size`; confirm both runs invoke `/rfe.auto-fix --batch-size 5 ...`.
- [ ] Run with explicit `/rfe.speedrun --batch-size 10 ...`; confirm the override is honored end-to-end.
- [ ] Confirm `tmp/speedrun-config.yaml` contains a concrete `batch_size: <int>`, never `null` or `<N>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)