### PR TITLE
Fix rfe-create skill to determine and record t-shirt size

### DIFF
--- a/.claude/skills/rfe.create/SKILL.md
+++ b/.claude/skills/rfe.create/SKILL.md
@@ -51,12 +51,14 @@ Do NOT ask about implementation approach, architecture, technology choices, or A
 
 ## Step 3: Generate RFEs
 
-After receiving answers, generate RFEs using the template in `${CLAUDE_SKILL_DIR}/rfe-template.md`.
+Read the template from `${CLAUDE_SKILL_DIR}/rfe-template.md`. Internalize the **Size Guide** — you will use it to determine each RFE's t-shirt size.
+
+After receiving answers, generate RFEs using that template.
 
 Key rules:
 - **WHAT/WHY only.** Describe the business need and its justification. Never prescribe architecture, technology choices, or implementation specifics.
 - **One RFE per distinct business need.** If the input describes multiple needs, create multiple RFEs. Each should map to roughly one strategy feature.
-- **Right-size the output.** Use the size indicators in the template — S-sized RFEs get a concise format, XL gets the full treatment.
+- **Determine size from acceptance criteria count.** After drafting each RFE, count its acceptance criteria and assign a size using the Size Guide: S (1-2), M (3-5), L (5-8), XL (8+). Use the corresponding format (Concise/Standard/Full) from the template.
 - **Priority uses Jira values.** Choose from: Blocker, Critical, Major, Normal, Minor. Default to Normal unless the PM's input clearly indicates urgency.
 - **Acceptance criteria from the user's perspective.** "User can do X" not "System implements Y." No implementation details in acceptance criteria.
 - **Platform vocabulary is allowed in describing the problem domain** — terms like KServe, ModelMesh, RHOAI, Operator are fine for describing what area the RFE touches. But do not prescribe that specific technologies must be used in the solution.


### PR DESCRIPTION
The create skill's Step 3 referenced the template's size indicators but only as a formatting hint ("S-sized RFEs get a concise format, XL gets the full treatment"). It never instructed the agent to read the Size Guide, count acceptance criteria, or map the count to S/M/L/XL. The size=<size> placeholder in the frontmatter command was left unfilled, triggering the schema's null default.

RFEs produced by rfe-split did get correct sizes because the split agent explicitly reads rfe-template.md and performs scope analysis before setting frontmatter. But only ~10-15% of RFEs go through the split path — the remaining 85-90% retained size: null from creation, making sizing data unavailable for effort estimation, workflow sorting, and any downstream consumers of RFE metadata.

The fix adds an explicit directive to read rfe-template.md and internalize the Size Guide before generating RFEs, and replaces the vague formatting guidance with a concrete sizing rule: count acceptance criteria, assign S/M/L/XL per the Size Guide, and use the corresponding template format. This mirrors what rfe-split already does correctly in split-agent.md Step 3.