### PR TITLE
Auto-transition passing RFEs to Approved status

### DIFF
--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -205,6 +205,23 @@ def do_transition(server, user, token, issue_key, transition_id, fields=None):
     api_call_with_retry(server, path, user, token, body=body)
 
 
+def transition_issue(server, user, token, issue_key, target_status):
+    """Transition an issue to the named target status. Returns True on success."""
+    transitions = get_transitions(server, user, token, issue_key)
+    match = None
+    for t in transitions:
+        if t["to"].get("name", "").lower() == target_status.lower():
+            match = t
+            break
+    if not match:
+        available = [t["name"] for t in transitions]
+        print(f"  WARNING: No '{target_status}' transition found for "
+              f"{issue_key}. Available: {available}", file=sys.stderr)
+        return False
+    do_transition(server, user, token, issue_key, match["id"])
+    return True
+
+
 # ─── ADF Helpers ──────────────────────────────────────────────────────────────
 
 def _adf_doc(content):

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -38,6 +38,7 @@ from jira_utils import (
     remove_labels,
     add_comment,
     get_issue,
+    transition_issue,
     adf_to_markdown,
     strip_metadata,
     markdown_to_adf,
@@ -137,6 +138,9 @@ def main():
                         help="Print planned actions without making API calls")
     parser.add_argument("--artifacts-dir", default="artifacts",
                         help="Artifacts directory (default: artifacts)")
+    parser.add_argument("--auto-approve", action="store_true",
+                        help="Transition qualifying RFEs to Approved status "
+                             "in Jira (pass=true + feasibility=feasible)")
     parser.add_argument("--generate-report", action="store_true",
                         help="Generate YAML and HTML reports after submission")
     parser.add_argument("--report-timestamp",
@@ -373,6 +377,11 @@ def main():
         if review_data and review_data.get("needs_attention", False):
             attn_reason = review_data.get("needs_attention_reason")
 
+        # Determine if this RFE qualifies for auto-approve
+        auto_approve = (review_data
+                        and review_data.get("pass", False)
+                        and review_data.get("feasibility") == "feasible")
+
         if rec in ("reject", "autorevise_reject"):
             # Check if rubric-pass label needs to be removed (RFE was
             # previously passing but no longer does after re-review)
@@ -388,6 +397,7 @@ def main():
                 "skip_reason": None if remove else "rejected",
                 "task_path": task_path,
                 "attn_reason": None, "original_labels": original_labels,
+                "auto_approve": False,
             })
             continue
 
@@ -421,6 +431,7 @@ def main():
                             "task_path": task_path,
                             "attn_reason": None,
                             "original_labels": original_labels,
+                            "auto_approve": False,
                         })
                         continue
                 except Exception as e:
@@ -455,6 +466,7 @@ def main():
                         "task_path": task_path,
                         "attn_reason": attn_reason,
                         "original_labels": original_labels,
+                        "auto_approve": auto_approve,
                     })
                     continue
 
@@ -476,6 +488,7 @@ def main():
             "action": action, "labels": labels, "remove_labels": [],
             "skip_reason": None, "task_path": task_path,
             "attn_reason": attn_reason, "original_labels": original_labels,
+            "auto_approve": auto_approve,
         })
 
     # Print summary
@@ -494,6 +507,27 @@ def main():
         if entry["skip_reason"]:
             print(f"{'':>10} Reason: {entry['skip_reason']}")
     print()
+
+    _APPROVE_COMMENT = (
+        "*[RFE Creator]* This RFE has been automatically transitioned to "
+        "Approved status based on passing rubric scoring and technical "
+        "feasibility checks. Approval does not constitute a commitment to "
+        "customers until this RFE is prioritized into a product release "
+        "by product management."
+    )
+
+    def _maybe_approve(rfe_id, jira_key, entry):
+        """Transition to Approved if --auto-approve and review qualifies."""
+        if not args.auto_approve or not entry.get("auto_approve"):
+            return
+        if args.dry_run:
+            print(f"  {rfe_id}: Would transition to Approved")
+            return
+        if transition_issue(server, user, token, jira_key, "Approved"):
+            print(f"  {rfe_id}: Transitioned to Approved")
+            comment_adf = markdown_to_adf(_APPROVE_COMMENT)
+            add_comment(server, user, token, jira_key, comment_adf)
+            print(f"  {rfe_id}: Posted auto-approve comment")
 
     # Execute
     results = {}  # rfe_id -> assigned jira key
@@ -534,6 +568,7 @@ def main():
                 results[rfe_id] = rfe_id
                 _post_needs_attention_comment(
                     server, user, token, entry, results, args.dry_run)
+                _maybe_approve(rfe_id, rfe_id, entry)
                 mark_processed_ids.append(rfe_id)
                 continue
 
@@ -600,6 +635,11 @@ def main():
             # Post needs-attention comment if newly flagged
             _post_needs_attention_comment(
                 server, user, token, entry, results, args.dry_run)
+
+            # Auto-approve if qualifying
+            target_key = results.get(rfe_id)
+            if target_key:
+                _maybe_approve(rfe_id, target_key, entry)
 
             # Rename new RFEs after all Jira ops succeed (must be after
             # comment posting which looks up files by original rfe_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,14 @@ def jira(jira_emu):
         if lt["name"] not in {x["name"] for x in _orig}
     ]
 
-    # Reset all data before each test (re-seeds with patched link types)
+    # Patch RHAIRFE workflow to add global "Approve" transition (matches
+    # production Jira where the workflow is fully open).
+    _wf = seed_service.WORKFLOWS.get("RHAIRFE Workflow", [])
+    _global_approve = (None, "Approve", "Approved")
+    if _global_approve not in _wf:
+        seed_service.WORKFLOWS["RHAIRFE Workflow"] = _wf + [_global_approve]
+
+    # Reset all data before each test (re-seeds with patched data)
     req = urllib.request.Request(
         f"{jira_emu}/api/admin/reset", method="POST", data=b"")
     urllib.request.urlopen(req)

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -17,7 +17,7 @@ def _write(path, content):
         f.write(content)
 
 
-def _run_submit(artifacts_dir):
+def _run_submit(artifacts_dir, extra_flags=None):
     """Run submit.py --dry-run and return stdout."""
     env = {
         **os.environ,
@@ -25,10 +25,10 @@ def _run_submit(artifacts_dir):
         "JIRA_USER": "fake@example.com",
         "JIRA_TOKEN": "fake-token",
     }
-    result = subprocess.run(
-        ["python3", SCRIPT, "--dry-run", "--artifacts-dir", artifacts_dir],
-        capture_output=True, text=True, env=env,
-    )
+    cmd = ["python3", SCRIPT, "--dry-run", "--artifacts-dir", artifacts_dir]
+    if extra_flags:
+        cmd.extend(extra_flags)
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
     return result.stdout, result.stderr, result.returncode
 
 
@@ -478,3 +478,58 @@ class TestGenerateReportFlag:
         )
         assert result.returncode == 0
         assert "--report-timestamp is required" not in result.stderr
+
+
+class TestApprovedTransition:
+    def test_passing_review_prints_would_transition(self, art_dir):
+        """--auto-approve + passing review → prints would-transition."""
+        body = "Original.\n"
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", body)
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n---\nRevised.")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               REVIEW_FM.format(rfe_id="RHAIRFE-1234", auto_revised="true"))
+
+        stdout, stderr, rc = _run_submit(art_dir, ["--auto-approve"])
+        assert rc == 0, stderr
+        assert "Would transition to Approved" in stdout
+
+    def test_failing_review_no_transition(self, art_dir):
+        """--auto-approve + failing review → no transition message."""
+        body = "Original.\n"
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", body)
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n---\nRevised.")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
+
+        stdout, stderr, rc = _run_submit(art_dir, ["--auto-approve"])
+        assert rc == 0, stderr
+        assert "Would transition to Approved" not in stdout
+
+    def test_new_rfe_prints_would_transition(self, art_dir):
+        """--auto-approve + new RFE with passing review → would-transition."""
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
+               REVIEW_FM.format(rfe_id="RFE-001", auto_revised="false"))
+
+        stdout, stderr, rc = _run_submit(art_dir, ["--auto-approve"])
+        assert rc == 0, stderr
+        assert "Would transition to Approved" in stdout
+
+    def test_no_flag_no_transition(self, art_dir):
+        """Without --auto-approve → no transition even if review passes."""
+        body = "Original.\n"
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", body)
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n---\nRevised.")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               REVIEW_FM.format(rfe_id="RHAIRFE-1234", auto_revised="true"))
+
+        stdout, stderr, rc = _run_submit(art_dir)
+        assert rc == 0, stderr
+        assert "Would transition to Approved" not in stdout

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -44,7 +44,7 @@ def art_dir(tmp_path):
     os.chdir(orig)
 
 
-def _run_submit(artifacts_dir, server_url):
+def _run_submit(artifacts_dir, server_url, extra_flags=None):
     """Run submit.py (non-dry-run) against the jira-emulator."""
     env = {
         **os.environ,
@@ -52,10 +52,10 @@ def _run_submit(artifacts_dir, server_url):
         "JIRA_USER": "admin",
         "JIRA_TOKEN": "admin",
     }
-    return subprocess.run(
-        [sys.executable, SCRIPT, "--artifacts-dir", artifacts_dir],
-        capture_output=True, text=True, env=env,
-    )
+    cmd = [sys.executable, SCRIPT, "--artifacts-dir", artifacts_dir]
+    if extra_flags:
+        cmd.extend(extra_flags)
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
 
 
 # ── Templates ────────────────────────────────────────────────────────────────
@@ -1044,3 +1044,81 @@ class TestSplitChildSnapshot:
         with open(snap_path) as f:
             data = yaml.safe_load(f)
         assert data["issues"] == {"RHAIRFE-1000": "parent-hash"}
+
+
+class TestApprovedTransition:
+    def test_existing_rfe_transitions_to_approved(self, art_dir, jira):
+        """--auto-approve + passing review → existing RFE moved to Approved."""
+        body = "Original."
+        jira.create("RHAIRFE-1234", "Test RFE", body)
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", body)
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n---\nRevised.")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               _review("RHAIRFE-1234", auto_revised="true"))
+
+        r = _run_submit(art_dir, jira.url, ["--auto-approve"])
+        assert r.returncode == 0, r.stderr
+        assert "Transitioned to Approved" in r.stdout
+
+        issue = jira.get("RHAIRFE-1234")
+        assert issue["fields"]["status"]["name"] == "Approved"
+
+        comments = jira.request(
+            "GET", "/rest/api/3/issue/RHAIRFE-1234/comment")
+        bodies = [c["body"] for c in comments["comments"]]
+        assert any("automatically transitioned to Approved" in json.dumps(b)
+                    for b in bodies)
+
+    def test_new_rfe_transitions_to_approved(self, art_dir, jira):
+        """--auto-approve + new RFE with passing review → Approved."""
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md",
+               TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
+               _review("RFE-001"))
+
+        r = _run_submit(art_dir, jira.url, ["--auto-approve"])
+        assert r.returncode == 0, r.stderr
+        assert "Transitioned to Approved" in r.stdout
+
+        issues = jira.search("project = RHAIRFE")
+        assert len(issues) == 1
+        issue = jira.get(issues[0]["key"])
+        assert issue["fields"]["status"]["name"] == "Approved"
+
+    def test_failing_review_not_transitioned(self, art_dir, jira):
+        """--auto-approve + failing review → status unchanged."""
+        body = "Original."
+        jira.create("RHAIRFE-1234", "Test RFE", body)
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", body)
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n---\nRevised.")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               REJECT_REVIEW_FM.format(rfe_id="RHAIRFE-1234"))
+
+        r = _run_submit(art_dir, jira.url, ["--auto-approve"])
+        assert r.returncode == 0, r.stderr
+        assert "Transitioned to Approved" not in r.stdout
+
+        issue = jira.get("RHAIRFE-1234")
+        assert issue["fields"]["status"]["name"] == "New"
+
+    def test_no_flag_no_transition(self, art_dir, jira):
+        """Without --auto-approve → no transition even with passing review."""
+        body = "Original."
+        jira.create("RHAIRFE-1234", "Test RFE", body)
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", body)
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n---\nRevised.")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               _review("RHAIRFE-1234", auto_revised="true"))
+
+        r = _run_submit(art_dir, jira.url)
+        assert r.returncode == 0, r.stderr
+        assert "Transitioned to Approved" not in r.stdout
+
+        issue = jira.get("RHAIRFE-1234")
+        assert issue["fields"]["status"]["name"] == "New"


### PR DESCRIPTION
## Summary

- Adds `--auto-approve` flag to `submit.py` that transitions RFEs to "Approved" in Jira when they pass both rubric scoring (`pass: true`) and technical feasibility (`feasibility: feasible`)
- Posts an explanatory comment to the Jira issue on approval clarifying that approval does not constitute a commitment to customers
- Adds reusable `transition_issue` helper to `jira_utils.py` (extracts pattern from `split_submit.py`)
- Gated behind CLI flag so local workflow is unaffected — only CI passes `--auto-approve`

## Test plan

- [x] 4 new dry-run unit tests in `test_submit.py::TestApprovedTransition`
- [x] 4 new integration tests in `test_submit_integration.py::TestApprovedTransition` (against jira-emulator)
- [x] All 61 existing + new tests pass
- [x] Live-tested on RHAIRFE-2165 — successfully transitioned to Approved with comment
- [ ] Verify CI pipeline passes with `--auto-approve` flag added to submit invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)