### PR TITLE
Apply feasibility verdict as a Jira label on submit

### DIFF
--- a/.claude/skills/rfe.submit/SKILL.md
+++ b/.claude/skills/rfe.submit/SKILL.md
@@ -49,5 +49,10 @@ The scripts automatically apply labels based on what happened during the pipelin
 | `rfe-creator-split-result` | Child ticket produced by splitting another RFE |
 | `rfe-creator-needs-attention` | Automation couldn't fully resolve all issues — human review needed (review frontmatter `needs_attention: true`) |
 | `rfe-creator-autofix-rubric-pass` | RFE passed review (recommendation = "submit") — excluded from future auto-fix JQL queries |
+| `rfe-creator-feasibility-pass` | Technical feasibility check returned `feasible` |
+| `rfe-creator-feasibility-fail` | Technical feasibility check returned `infeasible` |
+| `rfe-creator-feasibility-unknown` | Technical feasibility check returned `indeterminate` |
+
+The three `rfe-creator-feasibility-*` labels are mutually exclusive: on each submit, the matching label is added and any others present in the ticket's `original_labels` are removed. Rejected RFEs have any feasibility labels stripped (no add).
 
 $ARGUMENTS

--- a/docs/snapshot-incremental-fetch.md
+++ b/docs/snapshot-incremental-fetch.md
@@ -31,6 +31,9 @@ ordering; unchanged issues fill remaining capacity within the limit.
 | `rfe-creator-ignore` | JQL | JQL | Permanent human override — never touch |
 | `rfe-creator-autofix-rubric-pass` | JQL | Hash diff | If someone edits a passing RFE, we should see it |
 | `rfe-creator-needs-attention` | Not filtered | Hash diff | If a human resolves the flag and revises the description, we should re-evaluate |
+| `rfe-creator-feasibility-pass` | Not filtered | Hash diff | Informational verdict; description change triggers re-review and may flip the label |
+| `rfe-creator-feasibility-fail` | Not filtered | Hash diff | Same as above; not filtered out so re-edited infeasible RFEs surface |
+| `rfe-creator-feasibility-unknown` | Not filtered | Hash diff | Same as above |
 
 Soft-filtered labels are no longer excluded from the query. Issues with
 these labels are fetched and hashed like everything else. If their

--- a/docs/state-machine/pipeline-correctness-reference.md
+++ b/docs/state-machine/pipeline-correctness-reference.md
@@ -183,7 +183,12 @@ applies to issues that have never appeared in any snapshot.
 | `rfe-creator-needs-attention` | submit.py, split_submit.py | Never (by pipeline) | Human escalation flag |
 | `rfe-creator-split-original` | split_submit.py Phase 3 | Never | Parent ticket was decomposed into children |
 | `rfe-creator-split-result` | split_submit.py Phase 2 | Never | Child ticket created from split |
+| `rfe-creator-feasibility-pass` | submit.py, split_submit.py | submit.py (on verdict change or reject, when present in `original_labels`) | Technical feasibility verdict was `feasible` |
+| `rfe-creator-feasibility-fail` | submit.py, split_submit.py | submit.py (on verdict change or reject, when present in `original_labels`) | Technical feasibility verdict was `infeasible` |
+| `rfe-creator-feasibility-unknown` | submit.py, split_submit.py | submit.py (on verdict change or reject, when present in `original_labels`) | Technical feasibility verdict was `indeterminate` |
 | `rfe-creator-ignore` | Human (manually) | Human (manually) | Permanent exclusion from all pipeline queries |
+
+The three `rfe-creator-feasibility-*` labels are mutually exclusive: at most one is present per ticket at any time. Conditional removal (only labels present in `original_labels`) preserves the existing action decision tree.
 
 ### 1.13 Speedrun Phases
 
@@ -270,10 +275,10 @@ The `parent_key` exclusion ensures split children are only processed by
 | Action | Condition | Jira Operation | Snapshot Effect |
 |---|---|---|---|
 | **SKIP (rejected)** | `rec` in `(reject, autorevise_reject)` AND no label to remove | None | Marked processed |
-| **Remove labels** | `rec` in `(reject, autorevise_reject)` AND `rubric-pass` in `original_labels` | `remove_labels()` only; does NOT set `status=Submitted` | Marked processed |
+| **Remove labels** | `rec` in `(reject, autorevise_reject)` AND any of (`rubric-pass`, `feasibility-pass`, `feasibility-fail`, `feasibility-unknown`) in `original_labels` | `remove_labels()` only; does NOT set `status=Submitted` | Marked processed |
 | **SKIP (conflict)** | `rfe-originals/{ID}.md` exists AND differs from live Jira | None | NOT marked processed (enables retry) |
 | **SKIP (no changes)** | Content unchanged, no new labels needed | None | Marked processed |
-| **Label only** | Content unchanged but labels needed | `add_labels()` only | Marked processed, but NO content hash recorded |
+| **Label only** | Content unchanged but labels needed (existing label triggers OR new feasibility label needed OR stale feasibility label present in `original_labels`) | `remove_labels()` (if any) then `add_labels()` (if any) | Marked processed, but NO content hash recorded |
 | **Create** | `rfe_id` starts with `RFE-` | `create_issue()` + `rename_to_jira_key()` | Content hash recorded |
 | **Update** | Existing `RHAIRFE-` with content changes | `update_issue()` | Content hash recorded |
 
@@ -798,7 +803,7 @@ failures that may not surface until production runs.
 - **Split submit Phase 1 completion guard:** Phase 2 refuses to proceed (exit 1) if any archival comment is missing.
 - **Split submit transition fallback:** Logs WARNING and skips closure gracefully if no "Closed" transition exists on the parent ticket.
 - **Label-only path still sets `status=Submitted`** (`submit.py:507-509`).
-- **`rfe-creator-autofix-rubric-pass` is the only label ever removed** by the pipeline (L5). Guard: `is_existing AND label in original_labels`.
+- **Pipeline-removed labels:** `rfe-creator-autofix-rubric-pass` (on re-review regression to reject) and the three `rfe-creator-feasibility-*` labels (on verdict change or reject). All use the same conditional guard: `label in original_labels`. No other automation labels are ever removed by the pipeline.
 - **Conflict check compares `rfe-originals/{ID}.md` against live Jira** via `normalize_for_compare()`. Stale (conflict) → skip, NOT marked processed.
 - **Submit error (E8) also sets `needs_attention=true`** as side effect, not just `error` field.
 - **Content preservation filtering:** `submit.py` only posts `genuine`/`unclassified` removed-context blocks to Jira; `reworded`/`non-substantive` silently dropped (see 1.19).

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -59,6 +59,15 @@ from artifact_utils import (
 
 MAX_LEAF_CHILDREN = 6
 
+# Mirrors FEASIBILITY_LABELS in submit.py — keep in sync.
+# Duplicated rather than cross-imported to avoid loading submit.py's
+# heavy module-level imports (generate_run_report, snapshot_fetch).
+FEASIBILITY_LABELS = {
+    "feasible": "rfe-creator-feasibility-pass",
+    "infeasible": "rfe-creator-feasibility-fail",
+    "indeterminate": "rfe-creator-feasibility-unknown",
+}
+
 
 # ─── Recovery / State Detection ──────────────────────────────────────────────
 
@@ -202,6 +211,7 @@ def phase2_create_link(server, user, token, parent_key, children, state,
         review_path = find_review_file(artifacts_dir, rfe_id)
         review_rec = None
         attn_reason = None
+        feas_label = None
         if review_path:
             try:
                 review_data, _ = read_frontmatter_validated(
@@ -212,10 +222,14 @@ def phase2_create_link(server, user, token, parent_key, children, state,
                 if review_data.get("needs_attention", False):
                     labels.append("rfe-creator-needs-attention")
                     attn_reason = review_data.get("needs_attention_reason")
+                feas_label = FEASIBILITY_LABELS.get(
+                    review_data.get("feasibility"))
             except (ValidationError, Exception):
                 pass  # proceed without review data
         if review_rec == "submit":
             labels.append("rfe-creator-autofix-rubric-pass")
+        if feas_label:
+            labels.append(feas_label)
 
         # Inherit non-automation labels from parent
         labels = state.parent_labels + labels

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -62,6 +62,32 @@ from artifact_utils import (
 )
 
 
+FEASIBILITY_LABELS = {
+    "feasible": "rfe-creator-feasibility-pass",
+    "infeasible": "rfe-creator-feasibility-fail",
+    "indeterminate": "rfe-creator-feasibility-unknown",
+}
+
+
+def feasibility_label_changes(verdict, *, is_reject, original_labels):
+    """Return (label_to_add_or_None, [labels_to_remove]) for feasibility labels.
+
+    Conditional removal: only labels actually in original_labels (mirrors
+    the rubric-pass pattern at submit.py reject path). original_labels may
+    be None (NOT []) when the Jira issue has no labels.
+    """
+    original = original_labels or []
+    if is_reject:
+        return None, [lbl for lbl in FEASIBILITY_LABELS.values()
+                      if lbl in original]
+    if verdict not in FEASIBILITY_LABELS:
+        return None, []
+    new_label = FEASIBILITY_LABELS[verdict]
+    stale = [lbl for lbl in FEASIBILITY_LABELS.values()
+             if lbl != new_label and lbl in original]
+    return new_label, stale
+
+
 def _render_jira_comment(yaml_path):
     """Read removed-context YAML and render postable blocks as markdown.
 
@@ -380,6 +406,10 @@ def main():
             if (is_existing
                     and "rfe-creator-autofix-rubric-pass" in original_labels):
                 remove.append("rfe-creator-autofix-rubric-pass")
+            # Strip any feasibility labels currently on the issue
+            _, feas_remove = feasibility_label_changes(
+                None, is_reject=True, original_labels=original_labels)
+            remove.extend(feas_remove)
             plan.append({
                 "rfe_id": rfe_id, "title": title,
                 "is_existing": is_existing, "priority": priority, "size": size,
@@ -445,13 +475,24 @@ def main():
                         no_change_labels.append("rfe-creator-needs-attention")
                     if review_data and rec == "submit":
                         no_change_labels.append("rfe-creator-autofix-rubric-pass")
+                    feas_remove = []
+                    if review_data:
+                        feas_add, feas_remove = feasibility_label_changes(
+                            review_data.get("feasibility"),
+                            is_reject=False,
+                            original_labels=original_labels,
+                        )
+                        if feas_add:
+                            no_change_labels.append(feas_add)
+                    has_work = no_change_labels or feas_remove
                     plan.append({
                         "rfe_id": rfe_id, "title": title,
                         "is_existing": is_existing, "priority": priority,
                         "size": size,
-                        "action": "Label only" if no_change_labels else "SKIP",
-                        "labels": no_change_labels, "remove_labels": [],
-                        "skip_reason": None if no_change_labels else "no changes",
+                        "action": "Label only" if has_work else "SKIP",
+                        "labels": no_change_labels,
+                        "remove_labels": feas_remove,
+                        "skip_reason": None if has_work else "no changes",
                         "task_path": task_path,
                         "attn_reason": attn_reason,
                         "original_labels": original_labels,
@@ -468,12 +509,21 @@ def main():
             labels.append("rfe-creator-needs-attention")
         if review_data and rec == "submit":
             labels.append("rfe-creator-autofix-rubric-pass")
+        feas_remove = []
+        if review_data:
+            feas_add, feas_remove = feasibility_label_changes(
+                review_data.get("feasibility"),
+                is_reject=False,
+                original_labels=original_labels,
+            )
+            if feas_add:
+                labels.append(feas_add)
 
         action = f"Update {rfe_id}" if is_existing else "Create"
         plan.append({
             "rfe_id": rfe_id, "title": title,
             "is_existing": is_existing, "priority": priority, "size": size,
-            "action": action, "labels": labels, "remove_labels": [],
+            "action": action, "labels": labels, "remove_labels": feas_remove,
             "skip_reason": None, "task_path": task_path,
             "attn_reason": attn_reason, "original_labels": original_labels,
         })
@@ -522,12 +572,22 @@ def main():
                 continue
             if entry["action"] == "Label only":
                 labels = entry["labels"]
+                remove = entry.get("remove_labels") or []
                 if args.dry_run:
-                    print(f"  {rfe_id}: Would add labels: "
-                          f"{', '.join(labels)}")
+                    if remove:
+                        print(f"  {rfe_id}: Would remove labels: "
+                              f"{', '.join(remove)}")
+                    if labels:
+                        print(f"  {rfe_id}: Would add labels: "
+                              f"{', '.join(labels)}")
                 else:
-                    add_labels(server, user, token, rfe_id, labels)
-                    print(f"  {rfe_id}: Labels: {', '.join(labels)}")
+                    if remove:
+                        remove_labels(server, user, token, rfe_id, remove)
+                        print(f"  {rfe_id}: Removed labels: "
+                              f"{', '.join(remove)}")
+                    if labels:
+                        add_labels(server, user, token, rfe_id, labels)
+                        print(f"  {rfe_id}: Labels: {', '.join(labels)}")
                     update_frontmatter(entry["task_path"],
                                        {"status": "Submitted"},
                                        "rfe-task")
@@ -545,15 +605,22 @@ def main():
 
             title = entry["title"]
             labels = entry["labels"]
+            remove = entry.get("remove_labels") or []
 
             if entry["is_existing"]:
                 # Update existing ticket (rfe_id is the Jira key)
                 if args.dry_run:
                     print(f"  {rfe_id}: Would update")
+                    if remove:
+                        print(f"           Would remove: "
+                              f"{', '.join(remove)}")
                 else:
                     update_issue(server, user, token, rfe_id, title,
                                  description_adf)
                     print(f"  {rfe_id}: Updated")
+                    if remove:
+                        remove_labels(server, user, token, rfe_id, remove)
+                        print(f"           Removed: {', '.join(remove)}")
                     if labels:
                         add_labels(server, user, token, rfe_id, labels)
                         print(f"           Labels: {', '.join(labels)}")

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -348,6 +348,197 @@ class TestRemoveLabels:
         assert "Would remove labels" in stdout
 
 
+class TestFeasibilityLabelHelper:
+    """Direct unit tests for feasibility_label_changes()."""
+
+    @pytest.fixture(autouse=True)
+    def _import_helper(self):
+        from submit import (
+            FEASIBILITY_LABELS,
+            feasibility_label_changes,
+        )
+        self.LABELS = FEASIBILITY_LABELS
+        self.fn = feasibility_label_changes
+
+    @pytest.mark.parametrize("verdict,expected_label", [
+        ("feasible", "rfe-creator-feasibility-pass"),
+        ("infeasible", "rfe-creator-feasibility-fail"),
+        ("indeterminate", "rfe-creator-feasibility-unknown"),
+    ])
+    def test_each_verdict_no_existing_labels(self, verdict, expected_label):
+        add, remove = self.fn(verdict, is_reject=False, original_labels=None)
+        assert add == expected_label
+        assert remove == []
+
+    def test_each_verdict_with_matching_label_already_present(self):
+        for verdict, label in self.LABELS.items():
+            add, remove = self.fn(
+                verdict, is_reject=False, original_labels=[label])
+            assert add == label, (
+                f"{verdict}: matching label is added (Jira no-ops)")
+            assert remove == []
+
+    def test_flip_removes_only_present_stale(self):
+        # original has fail; new verdict feasible
+        add, remove = self.fn(
+            "feasible", is_reject=False,
+            original_labels=["rfe-creator-feasibility-fail"])
+        assert add == "rfe-creator-feasibility-pass"
+        assert remove == ["rfe-creator-feasibility-fail"]
+
+    def test_reject_with_no_feasibility_labels(self):
+        add, remove = self.fn(
+            None, is_reject=True, original_labels=["unrelated-label"])
+        assert add is None
+        assert remove == []
+
+    def test_reject_with_one_feasibility_label(self):
+        add, remove = self.fn(
+            None, is_reject=True,
+            original_labels=["rfe-creator-feasibility-pass", "other"])
+        assert add is None
+        assert remove == ["rfe-creator-feasibility-pass"]
+
+    def test_missing_verdict(self):
+        for verdict in (None, "", "yes", "TBD"):
+            add, remove = self.fn(
+                verdict, is_reject=False, original_labels=None)
+            assert add is None
+            assert remove == []
+
+    def test_original_labels_none_treated_as_empty(self):
+        add, remove = self.fn(
+            "feasible", is_reject=False, original_labels=None)
+        assert add == "rfe-creator-feasibility-pass"
+        assert remove == []
+
+
+FEAS_TASK_FM = """\
+---
+rfe_id: {rfe_id}
+title: Test RFE
+priority: Major
+status: Ready
+{extra}---
+
+## Problem Statement
+
+Users need better logging for compliance audits.
+
+## Acceptance Criteria
+
+- Audit logs capture all inference requests
+"""
+
+
+def _feas_review(rfe_id, verdict, recommendation="submit"):
+    return f"""\
+---
+rfe_id: {rfe_id}
+score: 9
+pass: true
+recommendation: {recommendation}
+feasibility: {verdict}
+auto_revised: false
+needs_attention: false
+scores:
+  what: 2
+  why: 2
+  open_to_how: 2
+  not_a_task: 2
+  right_sized: 1
+---
+
+## Assessor Feedback
+ok.
+"""
+
+
+class TestFeasibilityLabelOnSubmit:
+    """End-to-end (dry-run) tests for feasibility label wiring."""
+
+    def _task(self, rfe_id, original_labels=None):
+        if original_labels is None:
+            extra = ""
+        else:
+            labels_yaml = "\n".join(f"- {l}" for l in original_labels)
+            extra = f"original_labels:\n{labels_yaml}\n"
+        return FEAS_TASK_FM.format(rfe_id=rfe_id, extra=extra)
+
+    @pytest.mark.parametrize("verdict,label", [
+        ("feasible", "rfe-creator-feasibility-pass"),
+        ("infeasible", "rfe-creator-feasibility-fail"),
+        ("indeterminate", "rfe-creator-feasibility-unknown"),
+    ])
+    def test_feasibility_label_on_create(self, art_dir, verdict, label):
+        """Each verdict applies the matching label on a new RFE."""
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md", self._task("RFE-001"))
+        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md",
+               _feas_review("RFE-001", verdict))
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert label in stdout
+
+    def test_feasibility_label_flip_on_update(self, art_dir):
+        """Existing RHAIRFE with stale label → flip adds new, removes stale."""
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               self._task("RHAIRFE-1234",
+                          original_labels=["rfe-creator-feasibility-fail"]))
+        # Original snapshot identical to current body for "no content change"
+        # path exercising remove + add via Label only.
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md",
+               self._task("RHAIRFE-1234",
+                          original_labels=["rfe-creator-feasibility-fail"]))
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               _feas_review("RHAIRFE-1234", "feasible"))
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert "rfe-creator-feasibility-pass" in stdout
+        assert "rfe-creator-feasibility-fail" in stdout
+        assert "Would remove labels" in stdout
+
+    def test_reject_strips_present_feasibility_label(self, art_dir):
+        """Rejected RFE with stale feasibility label → Remove labels."""
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               self._task("RHAIRFE-1234",
+                          original_labels=["rfe-creator-feasibility-pass"]))
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               _feas_review("RHAIRFE-1234", "feasible",
+                            recommendation="reject"))
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert "Remove labels" in stdout
+        assert "rfe-creator-feasibility-pass" in stdout
+
+    def test_reject_without_feasibility_label_stays_skip(self, art_dir):
+        """Rejected RFE with no feasibility labels → SKIP, no remove ops.
+
+        Locks the conditional-removal behavior so a future "blind self-healing"
+        refactor can't silently shift this case to Remove labels.
+        """
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               self._task("RHAIRFE-1234"))
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               _feas_review("RHAIRFE-1234", "feasible",
+                            recommendation="reject"))
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert "SKIP" in stdout
+        assert "Remove labels" not in stdout
+        assert "rfe-creator-feasibility" not in stdout
+
+    def test_no_review_skips_feasibility_op(self, art_dir):
+        """Missing review file → no feasibility label, but submit still runs."""
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md", self._task("RFE-001"))
+        # No review file written
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        # Still creates the RFE
+        assert "Create" in stdout or "Would create" in stdout
+        # But no feasibility label
+        assert "rfe-creator-feasibility" not in stdout
+
+
 class TestSplitRefusal:
     """Tests for submit.py handling split_submit.py exit code 2."""
 

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -357,6 +357,79 @@ class TestRemoveLabels:
         assert entry == {"hash": "original-hash", "processed": True}
 
 
+FEAS_REVIEW_TEMPLATE = """\
+---
+rfe_id: {rfe_id}
+score: 9
+pass: true
+recommendation: submit
+feasibility: {verdict}
+auto_revised: false
+needs_attention: false
+scores:
+  what: 2
+  why: 2
+  open_to_how: 2
+  not_a_task: 2
+  right_sized: 1
+---
+
+## Assessor Feedback
+ok.
+"""
+
+
+class TestFeasibilityLabelExecutor:
+    """End-to-end coverage that the executor actually fires remove_labels()
+    in both the Label-only and Update branches when feasibility flips."""
+
+    def test_label_only_path_calls_remove(self, art_dir, jira):
+        """Re-submit existing RHAIRFE, no body change, verdict flipped →
+        Label-only branch must remove stale feasibility label."""
+        body = "## Problem\n\nSame content.\n"
+        jira.create("RHAIRFE-1234", "Test RFE", body,
+                    labels=["rfe-creator-feasibility-fail"])
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", body)
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n"
+               f"original_labels:\n- rfe-creator-feasibility-fail\n"
+               f"---\n{body}")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               FEAS_REVIEW_TEMPLATE.format(rfe_id="RHAIRFE-1234",
+                                           verdict="feasible"))
+
+        r = _run_submit(art_dir, jira.url)
+        assert r.returncode == 0, r.stderr
+
+        issue = jira.get("RHAIRFE-1234")
+        assert "rfe-creator-feasibility-pass" in issue["fields"]["labels"]
+        assert "rfe-creator-feasibility-fail" not in issue["fields"]["labels"]
+
+    def test_update_path_calls_remove(self, art_dir, jira):
+        """Body change AND verdict flip → Update branch must remove stale."""
+        original_body = "## Problem\n\nOriginal content.\n"
+        new_body = "## Problem\n\nUpdated content.\n"
+        jira.create("RHAIRFE-1234", "Test RFE", original_body,
+                    labels=["rfe-creator-feasibility-fail"])
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", original_body)
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n"
+               f"original_labels:\n- rfe-creator-feasibility-fail\n"
+               f"---\n{new_body}")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               FEAS_REVIEW_TEMPLATE.format(rfe_id="RHAIRFE-1234",
+                                           verdict="feasible"))
+
+        r = _run_submit(art_dir, jira.url)
+        assert r.returncode == 0, r.stderr
+
+        issue = jira.get("RHAIRFE-1234")
+        assert "rfe-creator-feasibility-pass" in issue["fields"]["labels"]
+        assert "rfe-creator-feasibility-fail" not in issue["fields"]["labels"]
+
+
 class TestConflictDetection:
     def test_conflict_prevents_update(self, art_dir, jira):
         """Jira description differs from original → skip, no PUT."""


### PR DESCRIPTION
## Summary

Surfaces the technical-feasibility verdict (currently only in local review frontmatter) as one of three mutually-exclusive Jira labels on every RHAIRFE ticket the tool touches:

- `feasibility: feasible` → `rfe-creator-feasibility-pass`
- `feasibility: infeasible` → `rfe-creator-feasibility-fail`
- `feasibility: indeterminate` → `rfe-creator-feasibility-unknown`

Stakeholders can now JQL-filter and visually distinguish RFEs flagged by the feasibility check.

## Design

- Conditional removal pattern (only labels actually in `original_labels`) — mirrors the existing `rfe-creator-autofix-rubric-pass` removal at `submit.py:380-382`. Preserves the documented action decision tree exactly: feasibility labels participate in the `Remove labels` and `Label only` actions the same way rubric-pass does.
- Reuses existing `add_labels` / `remove_labels` helpers — no new helper, no combined PUT.
- Reject path strips any feasibility label present in `original_labels` (no add) — parallel to existing rubric-pass removal on rejection.
- Split children get the matching label at create time.

## What changed

- `scripts/submit.py` — `FEASIBILITY_LABELS` constant + `feasibility_label_changes()` helper; wired into all three plan-build sites; fixed `Label-only` and `Update` executor branches to actually call `remove_labels` for stale labels (with empty-list guards).
- `scripts/split_submit.py` — duplicated constant; appended matching label to children.
- Docs: 3 rows in `rfe.submit/SKILL.md` label table; 3 rows in `pipeline-correctness-reference` label inventory; `Remove labels` and `Label only` action conditions updated in section 1.18; corrected the "only label ever removed" submission invariant; 3 rows in `snapshot-incremental-fetch` hard-vs-soft filter table.
- Tests: 8 helper unit tests, 5 plan-level tests (including SKIP-preservation regression lock), 2 integration tests covering `remove_labels` firing in both Label-only and Update executor branches.

## Test plan

- [x] `pytest tests/test_submit.py tests/test_submit_integration.py` — green
- [x] `pytest tests/` — full suite: 450 passed
- [ ] Reviewer: scan the helper logic in `submit.py` for the three sites
- [ ] Reviewer: confirm the executor's `if labels:` guards are present in both branches
- [ ] Optional live smoke test: pick one throwaway RHAIRFE, run a real submit, then a second after editing its review verdict; confirm via Jira that the label flipped and the others are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
