### PR TITLE
Skip auto-approve transition for already-Approved RFEs

### DIFF
--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -427,11 +427,12 @@ def main():
                 "skip_reason": None if remove else "rejected",
                 "task_path": task_path,
                 "attn_reason": None, "original_labels": original_labels,
-                "auto_approve": False,
+                "auto_approve": False, "jira_status": None,
             })
             continue
 
         # For existing RFEs, check for Jira conflicts
+        jira_status = None
         if is_existing and not args.dry_run:
             original_path = os.path.join(
                 args.artifacts_dir, "rfe-originals", f"{rfe_id}.md")
@@ -440,7 +441,9 @@ def main():
                     with open(original_path, encoding="utf-8") as f:
                         orig_snap = _normalize_for_compare(f.read())
                     issue = get_issue(server, user, token, rfe_id,
-                                      fields=["description"])
+                                      fields=["description", "status"])
+                    jira_status = (issue.get("fields", {})
+                                   .get("status", {}).get("name"))
                     desc_raw = issue.get("fields", {}).get("description")
                     if isinstance(desc_raw, dict):
                         jira_desc = _normalize_for_compare(
@@ -461,7 +464,7 @@ def main():
                             "task_path": task_path,
                             "attn_reason": None,
                             "original_labels": original_labels,
-                            "auto_approve": False,
+                            "auto_approve": False, "jira_status": jira_status,
                         })
                         continue
                 except Exception as e:
@@ -508,6 +511,7 @@ def main():
                         "attn_reason": attn_reason,
                         "original_labels": original_labels,
                         "auto_approve": auto_approve,
+                        "jira_status": jira_status,
                     })
                     continue
 
@@ -538,7 +542,7 @@ def main():
             "action": action, "labels": labels, "remove_labels": feas_remove,
             "skip_reason": None, "task_path": task_path,
             "attn_reason": attn_reason, "original_labels": original_labels,
-            "auto_approve": auto_approve,
+            "auto_approve": auto_approve, "jira_status": jira_status,
         })
 
     # Print summary
@@ -569,6 +573,9 @@ def main():
     def _maybe_approve(rfe_id, jira_key, entry):
         """Transition to Approved if --auto-approve and review qualifies."""
         if not args.auto_approve or not entry.get("auto_approve"):
+            return
+        if entry.get("jira_status") == "Approved":
+            print(f"  {rfe_id}: Already Approved, skipping transition")
             return
         if args.dry_run:
             print(f"  {rfe_id}: Would transition to Approved")

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -1178,6 +1178,31 @@ class TestApprovedTransition:
         issue = jira.get("RHAIRFE-1234")
         assert issue["fields"]["status"]["name"] == "New"
 
+    def test_already_approved_skips_transition(self, art_dir, jira):
+        """--auto-approve + already Approved → skips transition."""
+        body = "Original."
+        jira.create("RHAIRFE-1234", "Test RFE", body)
+        # Pre-transition to Approved
+        transitions = jira.request(
+            "GET", "/rest/api/3/issue/RHAIRFE-1234/transitions")
+        approve_id = next(
+            t["id"] for t in transitions["transitions"]
+            if t["to"]["name"] == "Approved")
+        jira.request("POST", "/rest/api/3/issue/RHAIRFE-1234/transitions",
+                     {"transition": {"id": approve_id}})
+
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1234.md", body)
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+               f"---\nrfe_id: RHAIRFE-1234\ntitle: Test RFE\n"
+               f"priority: Major\nstatus: Ready\n---\nRevised.")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+               _review("RHAIRFE-1234", auto_revised="true"))
+
+        r = _run_submit(art_dir, jira.url, ["--auto-approve"])
+        assert r.returncode == 0, r.stderr
+        assert "Already Approved, skipping transition" in r.stdout
+        assert "Transitioned to Approved" not in r.stdout
+
     def test_no_flag_no_transition(self, art_dir, jira):
         """Without --auto-approve → no transition even with passing review."""
         body = "Original."


### PR DESCRIPTION
## Summary

- Reuses the Jira issue status from the existing conflict-detection `get_issue` call (widened to include `status` field) to detect when an RFE is already in Approved state
- Skips the transition and prints "Already Approved, skipping transition" instead of attempting a no-op transition that produces a noisy warning
- Adds integration test that pre-transitions an RFE to Approved and verifies the skip behavior

## Test plan

- [x] New integration test `test_already_approved_skips_transition`
- [x] All 80 tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)