### PR TITLE
Exclude unchanged-processed RFEs from snapshot_fetch selection

### DIFF
--- a/docs/snapshot-incremental-fetch.md
+++ b/docs/snapshot-incremental-fetch.md
@@ -20,8 +20,10 @@ against Jira and processing every result. Two issues:
 Instead of filtering at the JQL level and relying on labels to decide
 what to process, the snapshot system fetches **all** open issues (minus
 permanent exclusions), computes a content hash of each description, and
-diffs against the previous snapshot. Changed and new issues get priority
-ordering; unchanged issues fill remaining capacity within the limit.
+diffs against the previous snapshot. Changed and new issues are selected
+for processing; unchanged-processed issues are excluded by default
+(they are no-ops). Pass `--reprocess` to include unchanged issues as
+filler within the limit.
 
 ## Hard vs Soft Filters
 
@@ -195,9 +197,10 @@ current content hash against the previous snapshot. The `processed` flag
 determines whether a previous entry counts as "seen":
 
 - **UNCHANGED** (`processed: true` + hash matches): issue's description
-  hasn't changed since last processed. Included in output after
-  changed/new issues. When a limit is set, unchanged issues fill
-  remaining capacity.
+  hasn't changed since last processed. **Excluded from selection by
+  default** — they're no-ops for downstream processing (already submitted
+  with current content). Pass `--reprocess` to include them (e.g., to
+  re-test everything in scope).
 - **CHANGED** (`processed: true` + hash differs): issue was previously
   processed but its description has been modified since. Gets priority
   ordering and bypasses `check_resume`.
@@ -414,9 +417,9 @@ These invariants must hold and should guide future refactors:
    NEW issues (not in snapshot, or `processed: false`) go through
    normal resume check — if a passing review exists, they're skipped.
 
-5. **Without a limit, behavior is identical to the old design.** When
-   `limit = len(current)`, all issues are selected, all merged — the
-   snapshot contains everything.
+5. **Without a limit, all changed and new issues are selected.**
+   Unchanged-processed issues are still excluded (they're no-ops).
+   With `--reprocess`, all issues become eligible — including unchanged.
 
 6. **`update_snapshot_hashes` is additive.** It writes dict-format
    entries (`{hash, processed: true}`) to the latest snapshot, adding

--- a/scripts/snapshot_fetch.py
+++ b/scripts/snapshot_fetch.py
@@ -13,11 +13,18 @@ never selected remain absent (staying NEW until selected).
 Usage:
     python3 scripts/snapshot_fetch.py fetch "<jql>" --ids-file tmp/autofix-all-ids.txt --changed-file tmp/autofix-changed-ids.txt [--limit 100] [--data-dir <path>]
 
+Selection: changed and new IDs are written to --ids-file. Unchanged-processed
+IDs (already submitted with current content) are EXCLUDED from selection by
+default — they are no-ops for downstream processing and would otherwise burn
+agent tokens re-reviewing already-handled work. Pass --reprocess to override
+and include unchanged IDs (e.g., to re-test everything in scope).
+
 Output (stdout):
-    TOTAL=<count>
-    CHANGED=<count>
-    NEW=<count>
-    UNCHANGED=<count>
+    TOTAL=<count selected for processing>
+    CHANGED=<count of changed in selection>
+    NEW=<count of new in selection>
+    UNCHANGED_SELECTED=<count of unchanged in selection (only with --reprocess)>
+    UNCHANGED_SKIPPED=<count of unchanged-processed not selected>
 """
 
 import argparse
@@ -359,6 +366,8 @@ def cmd_fetch(args):
     # changed and new are already ordered lists from diff_snapshots
     changed_set = set(changed)
     new_set = set(new)
+    unchanged = [k for k in current
+                 if k not in changed_set and k not in new_set]
 
     random_n = getattr(args, "random", None)
     if random_n is not None:
@@ -374,11 +383,12 @@ def cmd_fetch(args):
     else:
         limit = args.limit or len(current)
 
-        # Select up to limit: changed first, then new, then unchanged
+        # Select up to limit: changed first, then new. Unchanged-processed
+        # RFEs are no-ops (already submitted with current content) and are
+        # excluded from selection unless --reprocess is set, where the user
+        # explicitly wants to re-do everything in scope.
         all_ids = (changed + new)[:limit]
-        if len(all_ids) < limit:
-            unchanged = [k for k in current
-                         if k not in changed_set and k not in new_set]
+        if reprocess and len(all_ids) < limit:
             all_ids.extend(unchanged[:limit - len(all_ids)])
 
     # Build cumulative snapshot: previous entries + selected issues.
@@ -433,10 +443,16 @@ def cmd_fetch(args):
     changed_out = all_ids if reprocess else out_changed
     write_id_file(args.changed_file, changed_out)
 
+    # Counts: TOTAL is what's selected for processing. UNCHANGED_SKIPPED
+    # tracks unchanged-processed RFEs that were filtered out (the snapshot
+    # already records them as processed with current content).
+    unchanged_in_selection = sum(
+        1 for k in all_ids if k not in changed_set and k not in new_set)
     print(f"TOTAL={len(all_ids)}")
     print(f"CHANGED={len(changed_out)}")
     print(f"NEW={len(out_new)}")
-    print(f"UNCHANGED={len(all_ids) - len(changed_out) - len(out_new)}")
+    print(f"UNCHANGED_SELECTED={unchanged_in_selection}")
+    print(f"UNCHANGED_SKIPPED={len(unchanged) - unchanged_in_selection}")
 
 
 def main():

--- a/tests/test_snapshot_fetch.py
+++ b/tests/test_snapshot_fetch.py
@@ -581,3 +581,123 @@ class TestRandom:
         ids, _ = self._run_fetch(tmp_path, current, 5, monkeypatch)
 
         assert ids == sorted(ids)
+
+
+class TestUnchangedSkippedFromSelection:
+    """Verifies unchanged-processed RFEs are excluded from selection by
+    default and only included with --reprocess."""
+
+    def _setup_snapshot(self, tmp_path, prev_issues):
+        """Write a previous snapshot file under tmp_path's snapshot dir."""
+        snap_dir = tmp_path / "auto-fix-runs"
+        snap_dir.mkdir(parents=True, exist_ok=True)
+        snap_path = snap_dir / "issue-snapshot-20260501-000000.yaml"
+        with open(snap_path, "w") as f:
+            yaml.dump({
+                "query_timestamp": "2026-05-01T00:00:00Z",
+                "timestamp": "2026-05-01T00:00:01Z",
+                "issues": prev_issues,
+            }, f)
+        return str(snap_dir)
+
+    def _run_fetch(self, tmp_path, current, prev_issues, monkeypatch,
+                   reprocess=False, limit=None):
+        import argparse
+        snap_dir = self._setup_snapshot(tmp_path, prev_issues)
+        ids_file = str(tmp_path / "all-ids.txt")
+        changed_file = str(tmp_path / "changed-ids.txt")
+
+        monkeypatch.setattr("snapshot_fetch.require_env",
+                            lambda: ("http://x", "u", "t"))
+        monkeypatch.setattr("snapshot_fetch.fetch_all_issues",
+                            lambda *a, **kw: current)
+        monkeypatch.setattr("snapshot_fetch.find_previous_snapshot",
+                            lambda data_dir=None: (
+                                str(tmp_path / "auto-fix-runs" /
+                                    "issue-snapshot-20260501-000000.yaml"),
+                                {"issues": prev_issues}))
+        monkeypatch.setattr("snapshot_fetch.SNAPSHOT_DIR", snap_dir)
+
+        args = argparse.Namespace(
+            reprocess=reprocess, jql="project = TEST", random=None,
+            limit=limit, data_dir=None,
+            ids_file=ids_file, changed_file=changed_file)
+        cmd_fetch(args)
+        return read_id_file(ids_file), read_id_file(changed_file)
+
+    def test_unchanged_processed_excluded_by_default(
+            self, tmp_path, monkeypatch):
+        """Unchanged-processed RFEs are NOT in the selection."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa"},  # unchanged
+            "RHAIRFE-2": {"content_hash": "bbb"},  # unchanged
+            "RHAIRFE-3": {"content_hash": "ccc-new"},  # changed
+        }
+        prev_issues = {
+            "RHAIRFE-1": {"hash": "aaa", "processed": True},
+            "RHAIRFE-2": {"hash": "bbb", "processed": True},
+            "RHAIRFE-3": {"hash": "ccc", "processed": True},
+        }
+        ids, _ = self._run_fetch(tmp_path, current, prev_issues, monkeypatch)
+        assert ids == ["RHAIRFE-3"]
+
+    def test_unchanged_unprocessed_still_included(
+            self, tmp_path, monkeypatch):
+        """processed: false → treated as new → selected even when unchanged."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa"},
+            "RHAIRFE-2": {"content_hash": "bbb"},
+        }
+        prev_issues = {
+            "RHAIRFE-1": {"hash": "aaa", "processed": True},
+            "RHAIRFE-2": {"hash": "bbb", "processed": False},
+        }
+        ids, _ = self._run_fetch(tmp_path, current, prev_issues, monkeypatch)
+        assert ids == ["RHAIRFE-2"]
+
+    def test_reprocess_includes_unchanged_processed(
+            self, tmp_path, monkeypatch):
+        """--reprocess restores the fill-with-unchanged behavior."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa"},
+            "RHAIRFE-2": {"content_hash": "bbb"},
+            "RHAIRFE-3": {"content_hash": "ccc-new"},
+        }
+        prev_issues = {
+            "RHAIRFE-1": {"hash": "aaa", "processed": True},
+            "RHAIRFE-2": {"hash": "bbb", "processed": True},
+            "RHAIRFE-3": {"hash": "ccc", "processed": True},
+        }
+        ids, changed = self._run_fetch(
+            tmp_path, current, prev_issues, monkeypatch, reprocess=True)
+        assert sorted(ids) == ["RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"]
+        # --reprocess marks all as changed
+        assert sorted(changed) == sorted(ids)
+
+    def test_limit_caps_changed_plus_new_only(self, tmp_path, monkeypatch):
+        """--limit applies to changed+new; unchanged are not used as filler."""
+        current = {f"RHAIRFE-{i}": {"content_hash": f"new-{i}"}
+                   for i in range(1, 6)}  # all 5 changed
+        current["RHAIRFE-6"] = {"content_hash": "uchanged-hash"}  # unchanged
+        prev_issues = {f"RHAIRFE-{i}": {"hash": f"old-{i}", "processed": True}
+                       for i in range(1, 6)}
+        prev_issues["RHAIRFE-6"] = {"hash": "uchanged-hash", "processed": True}
+
+        ids, _ = self._run_fetch(
+            tmp_path, current, prev_issues, monkeypatch, limit=10)
+        # All 5 changed selected, RHAIRFE-6 (unchanged-processed) excluded
+        assert sorted(ids) == [f"RHAIRFE-{i}" for i in range(1, 6)]
+        assert "RHAIRFE-6" not in ids
+
+    def test_no_changes_empty_selection(self, tmp_path, monkeypatch):
+        """All unchanged-processed → empty selection (no work to do)."""
+        current = {
+            "RHAIRFE-1": {"content_hash": "aaa"},
+            "RHAIRFE-2": {"content_hash": "bbb"},
+        }
+        prev_issues = {
+            "RHAIRFE-1": {"hash": "aaa", "processed": True},
+            "RHAIRFE-2": {"hash": "bbb", "processed": True},
+        }
+        ids, _ = self._run_fetch(tmp_path, current, prev_issues, monkeypatch)
+        assert ids == []

--- a/tests/test_snapshot_fetch_integration.py
+++ b/tests/test_snapshot_fetch_integration.py
@@ -153,9 +153,9 @@ class TestCmdFetchFirstRun:
 # ── cmd_fetch: Incremental Run ───────────────────────────────────────────────
 
 class TestCmdFetchIncremental:
-    def test_unchanged_included_not_changed(self, work_dirs, jira,
-                                               monkeypatch, tmp_path):
-        """Issue with same hash → in output IDs but not in changed file."""
+    def test_unchanged_processed_excluded_from_selection(
+            self, work_dirs, jira, monkeypatch, tmp_path):
+        """Issue with same hash → excluded from selection (no-op)."""
         jira.create("RHAIRFE-1", "Issue one", "Same content.")
         same_hash = compute_content_hash(_text_to_adf("Same content."))
         _seed_snapshot(work_dirs, {"RHAIRFE-1": same_hash})
@@ -164,10 +164,10 @@ class TestCmdFetchIncremental:
         args = _fetch_args(tmp_path)
         stdout = _run_fetch(args)
 
-        assert "TOTAL=1" in stdout
+        assert "TOTAL=0" in stdout
         assert "CHANGED=0" in stdout
-        assert "UNCHANGED=1" in stdout
-        assert _read_ids(args.ids_file) == ["RHAIRFE-1"]
+        assert "UNCHANGED_SKIPPED=1" in stdout
+        assert _read_ids(args.ids_file) == []
         assert _read_ids(args.changed_file) == []
 
     def test_changed_detected(self, work_dirs, jira, monkeypatch, tmp_path):
@@ -186,7 +186,7 @@ class TestCmdFetchIncremental:
         assert _read_ids(args.changed_file) == ["RHAIRFE-1"]
 
     def test_new_detected(self, work_dirs, jira, monkeypatch, tmp_path):
-        """Issue not in previous snapshot → new. Unchanged fills remaining."""
+        """New issue selected; unchanged-processed excluded from selection."""
         jira.create("RHAIRFE-1", "Issue one", "Existing.")
         jira.create("RHAIRFE-2", "Issue two", "Brand new.")
         existing_hash = compute_content_hash(_text_to_adf("Existing."))
@@ -196,12 +196,12 @@ class TestCmdFetchIncremental:
         args = _fetch_args(tmp_path)
         stdout = _run_fetch(args)
 
-        assert "TOTAL=2" in stdout
+        assert "TOTAL=1" in stdout
         assert "NEW=1" in stdout
-        assert "UNCHANGED=1" in stdout
+        assert "UNCHANGED_SKIPPED=1" in stdout
         ids = _read_ids(args.ids_file)
-        assert "RHAIRFE-2" in ids
-        assert "RHAIRFE-1" in ids
+        assert ids == ["RHAIRFE-2"]
+        assert "RHAIRFE-1" not in ids
 
     def test_limit_caps_output(self, work_dirs, jira, monkeypatch, tmp_path):
         """--limit caps the number of output IDs."""
@@ -294,7 +294,7 @@ class TestMultiRunPipeline:
 
     def test_steady_state_skips_unchanged(self, work_dirs, jira,
                                           monkeypatch, tmp_path):
-        """Run 1 processes everything. Run 2 includes all but none changed."""
+        """Run 1 processes everything. Run 2 selects nothing (all unchanged)."""
         jira.create("RHAIRFE-1", "Issue one", "Description one.")
         jira.create("RHAIRFE-2", "Issue two", "Description two.")
         _jira_env(monkeypatch, jira.url)
@@ -309,13 +309,14 @@ class TestMultiRunPipeline:
             {}, work_dirs.snapshot_dir,
             mark_processed=["RHAIRFE-1", "RHAIRFE-2"])
 
-        # Run 2: nothing changed — all unchanged, none in changed file
+        # Run 2: nothing changed — all unchanged-processed, excluded
         args2 = _fetch_args(tmp_path)
         stdout2 = _run_fetch(args2)
-        assert "TOTAL=2" in stdout2
+        assert "TOTAL=0" in stdout2
         assert "CHANGED=0" in stdout2
-        assert "UNCHANGED=2" in stdout2
+        assert "UNCHANGED_SKIPPED=2" in stdout2
         assert _read_ids(args2.changed_file) == []
+        assert _read_ids(args2.ids_file) == []
 
     def test_user_edits_after_submit(self, work_dirs, jira,
                                      monkeypatch, tmp_path):
@@ -344,11 +345,12 @@ class TestMultiRunPipeline:
                       {"fields": {"description":
                                   "User rewrote this after our fix."}})
 
-        # Run 2: detects user's edit, RHAIRFE-2 unchanged fills capacity
+        # Run 2: detects user's edit; RHAIRFE-2 unchanged-processed excluded
         args2 = _fetch_args(tmp_path)
         stdout2 = _run_fetch(args2)
-        assert "TOTAL=2" in stdout2
+        assert "TOTAL=1" in stdout2
         assert "CHANGED=1" in stdout2
+        assert "UNCHANGED_SKIPPED=1" in stdout2
         assert _read_ids(args2.changed_file) == ["RHAIRFE-1"]
 
         # Run 2: simulate pipeline completing for both
@@ -356,11 +358,12 @@ class TestMultiRunPipeline:
             {}, work_dirs.snapshot_dir,
             mark_processed=["RHAIRFE-1", "RHAIRFE-2"])
 
-        # Run 3: nothing changed — all unchanged
+        # Run 3: nothing changed — all unchanged-processed, excluded
         args3 = _fetch_args(tmp_path)
         stdout3 = _run_fetch(args3)
+        assert "TOTAL=0" in stdout3
         assert "CHANGED=0" in stdout3
-        assert "UNCHANGED=2" in stdout3
+        assert "UNCHANGED_SKIPPED=2" in stdout3
 
     def test_submit_without_user_edit(self, work_dirs, jira,
                                       monkeypatch, tmp_path):
@@ -381,12 +384,15 @@ class TestMultiRunPipeline:
         jira.request( "PUT", "/rest/api/3/issue/RHAIRFE-1",
                       {"fields": {"description": "We revised this."}})
 
-        # Run 2: our own change is in the snapshot — unchanged
+        # Run 2: our own change is in the snapshot — unchanged-processed,
+        # excluded from selection
         args2 = _fetch_args(tmp_path)
         stdout2 = _run_fetch(args2)
-        assert "TOTAL=1" in stdout2
+        assert "TOTAL=0" in stdout2
         assert "CHANGED=0" in stdout2
+        assert "UNCHANGED_SKIPPED=1" in stdout2
         assert _read_ids(args2.changed_file) == []
+        assert _read_ids(args2.ids_file) == []
 
     def test_new_issue_created_by_submit(self, work_dirs, jira,
                                          monkeypatch, tmp_path):
@@ -479,16 +485,18 @@ class TestMultiRunPipeline:
                                   "User rewrote issue two."}})
         jira.create("RHAIRFE-3", "Issue three", "Brand new issue three.")
 
-        # Run 2: RHAIRFE-2 changed, RHAIRFE-3 new, RHAIRFE-1 unchanged
+        # Run 2: RHAIRFE-2 changed, RHAIRFE-3 new, RHAIRFE-1 unchanged-processed
+        # → only the changed and new are selected; RHAIRFE-1 is excluded
         args2 = _fetch_args(tmp_path)
         stdout2 = _run_fetch(args2)
-        assert "TOTAL=3" in stdout2
+        assert "TOTAL=2" in stdout2
         assert "CHANGED=1" in stdout2
         assert "NEW=1" in stdout2
-        assert "UNCHANGED=1" in stdout2
+        assert "UNCHANGED_SKIPPED=1" in stdout2
         changed2 = _read_ids(args2.changed_file)
         assert "RHAIRFE-2" in changed2
         assert "RHAIRFE-1" not in changed2
+        assert "RHAIRFE-1" not in _read_ids(args2.ids_file)
 
         # Between runs: RHAIRFE-2 closed, nothing else changes
         transitions = jira.request(
@@ -786,15 +794,15 @@ class TestCloneThenFetch:
         args = _fetch_args(tmp_path, data_dir=clone_dest)
         stdout = _run_fetch(args)
 
-        # RHAIRFE-1: unchanged → included but not changed
-        # RHAIRFE-2: hash differs → changed
-        # RHAIRFE-3: new
-        assert "TOTAL=3" in stdout
+        # RHAIRFE-1: unchanged-processed → excluded from selection
+        # RHAIRFE-2: hash differs → changed (selected)
+        # RHAIRFE-3: new (selected)
+        assert "TOTAL=2" in stdout
         assert "CHANGED=1" in stdout
         assert "NEW=1" in stdout
-        assert "UNCHANGED=1" in stdout
+        assert "UNCHANGED_SKIPPED=1" in stdout
         ids = _read_ids(args.ids_file)
-        assert "RHAIRFE-1" in ids
+        assert "RHAIRFE-1" not in ids
         assert "RHAIRFE-2" in ids
         assert "RHAIRFE-3" in ids
         changed = _read_ids(args.changed_file)


### PR DESCRIPTION
## Summary

Fixes a long-standing CI issue where every UNCHANGED-and-processed RFE has been silently re-reviewed on every pipeline run since the snapshot system shipped (Apr 2). The cause is a gap between two systems that don't talk to each other:

- `snapshot_fetch.py` correctly identifies UNCHANGED-processed RFEs but writes them to `--ids-file` as filler under `--limit`.
- `check_resume.py` is supposed to filter them out but only looks at local `artifacts/rfe-reviews/<ID>-review.md` files. In CI, `artifacts/` is gitignored and empty in fresh checkouts, so check_resume can't find any prior reviews and lets every UNCHANGED ID through.
- The snapshot's `processed: true` flag — the canonical "this is done" signal that survives across CI runs via the data-repo — was computed correctly on every run but never consulted by the filter.

Verified against [job 14222535687](https://gitlab.com/redhat/rhel-ai/agentic-ci/rfe-autofixer/-/jobs/14222535687): snapshot_fetch reported `100 total, 3 changed, 97 unchanged` — yet all 100 went through to the agent waves at full token cost.

## Fix

`snapshot_fetch.py` no longer fills `--limit` capacity with unchanged-processed IDs by default. Only changed and new IDs are written to `--ids-file`. Pass `--reprocess` to restore the prior behavior (include unchanged as filler, e.g. to force re-test everything in scope).

## Output format change

```
Before:                          After:
TOTAL=<all selected>             TOTAL=<selected for processing>
CHANGED=<n>                      CHANGED=<n>
NEW=<n>                          NEW=<n>
UNCHANGED=<n>                    UNCHANGED_SELECTED=<n>     # only nonzero with --reprocess
                                 UNCHANGED_SKIPPED=<n>      # excluded from selection
```

## Why this is the right place to fix it

Three options were considered:

- **Fix A** (modify `check_resume`): consult the snapshot too. Has a subtle bug: `snapshot_fetch`'s priority sort treats UNCHANGED uniformly and would happily fill `--limit` with no-ops before unchanged-unprocessed (real work that previously failed), starving real work. To fix that, snapshot_fetch would need to be processed-aware too — at which point Fix A and Fix B converge.
- **Fix B** (modify `snapshot_fetch`, this PR): filter at selection time. Single component owns the snapshot-aware logic. `--limit` becomes a true "max N RFEs of work per run" knob.
- **Fix C** (modify `clone_results_repo`): also clone prior reviews into `artifacts/`. Keeps existing design but transfers significantly more data per run; doesn't address the design-level inconsistency.

## Has this ever worked?

No, not in CI. Verified by reading commit history:
- `clone_results_repo.py` from Apr 2 (the day the snapshot system shipped) explicitly excludes `rfe-reviews/` from the sparse clone — by design.
- `check_resume.py` is byte-for-byte identical to its Apr 2 version.

So in CI, every `/rfe.auto-fix` run since the snapshot system has been re-reviewing every UNCHANGED RFE at full token cost. Locally it works correctly (artifacts/ persists between runs).

## Test plan

- [x] `pytest tests/` — full suite: 437 passed
- [x] 5 new unit tests in `TestUnchangedSkippedFromSelection` covering: default exclusion, `processed: false` still selected, `--reprocess` opt-in restores fill-with-unchanged, `--limit` doesn't pull no-ops, empty selection when nothing needs work
- [x] 7 existing integration tests updated to reflect new behavior
- [ ] Reviewer: trace the selection logic at `snapshot_fetch.py:374-388`
- [ ] Reviewer: confirm `--reprocess --jql` still re-processes everything
- [ ] First CI run after merge will show how much work is actually deferred (expected: dramatically reduced agent activity for steady-state runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
