### PR TITLE
add structural validation for test plan readiness

### DIFF
--- a/.claude/skills/strat.review/SKILL.md
+++ b/.claude/skills/strat.review/SKILL.md
@@ -19,6 +19,22 @@ Check if prior reviews exist in `artifacts/strat-reviews/`. If any exist for the
 bash scripts/fetch-architecture-context.sh
 ```
 
+## Step 2.5: Run Structural Validation (Pre-Filter)
+
+For each strategy in `artifacts/strat-tasks/`, run structural validation to get fast, deterministic metrics:
+
+```bash
+mkdir -p tmp
+for strat_file in artifacts/strat-tasks/*.md; do
+    strat_id=$(basename "$strat_file" .md)
+    python3 scripts/validate_strat_testability.py "$strat_file" > "tmp/structural-${strat_id}.json"
+done
+```
+
+Read the structural validation JSON files to identify any critical structural issues. If any STRAT has `structural_score < 5` or multiple CRITICAL warnings, it will likely produce a low-quality test plan.
+
+Pass the structural validation results to testability-review by including them in the review context (the fork skill will read from tmp/).
+
 ## Step 3: Run Reviews
 
 Invoke these forked reviewer skills in parallel. Each runs in its own isolated context — no reviewer sees another's output.

--- a/.claude/skills/testability-review/SKILL.md
+++ b/.claude/skills/testability-review/SKILL.md
@@ -15,6 +15,13 @@ Read the strategy artifacts in `artifacts/strat-tasks/`. Cross-reference against
 
 If `artifacts/strat-reviews/` exists and contains review files for the strategies being reviewed, read them — this is a re-review.
 
+**Structural validation results** (if available): The orchestrator runs `scripts/validate_strat_testability.py` before launching reviewers and saves results to `tmp/structural-{STRAT_ID}.json`. Read these files to focus your semantic review:
+- If structural_score < 5: Major structural issues (missing sections, no interactions detected)
+- Check warnings for specific gaps (no error cases, no edge cases, TBDs, etc.)
+- Use detected_interaction_types to understand what kind of feature this is (API, UI, Operator, etc.)
+
+The structural validation provides fast, deterministic metrics. Your semantic review assesses whether the content is **sufficient and appropriate** for test plan generation.
+
 ## What to Assess
 
 For each strategy:
@@ -30,17 +37,44 @@ If this is a re-review:
 - What concerns remain?
 - What new issues did the revisions introduce?
 
+## Test Plan Generation Readiness
+
+In addition to evaluating testability, assess whether the STRAT contains sufficient information for automated test plan generation via `/test-plan-create`.
+
+**Use the [Test-Plan-Create Compatibility Checklist](./test-plan-compatibility.md)** which defines:
+- 9 compatibility checks across 3 analyzers (Interaction, Risks, Infra)
+- Scoring criteria for each analyzer (✅ Ready / ⚠️ Partial / ❌ Insufficient)
+- Aggregate scoring to determine overall readiness (Ready / Needs improvement / Not ready)
+- Decision tree with recommended actions for each readiness level
+
+Apply the checks and use the scoring table to determine readiness.
+
 ## Output
 
 For each strategy:
 
 ```
 ### STRAT-NNN: <title>
+
 **Testability**: <testable / partially testable / untestable criteria listed>
+
+**Test Plan Generation Readiness**: <Ready / Needs improvement / Not ready>
+  - Interaction analyzer: <✅ Ready / ⚠️ Partial / ❌ Insufficient>
+  - Risks analyzer: <✅ Ready / ⚠️ Partial / ❌ Insufficient>
+  - Infra analyzer: <✅ Ready / ⚠️ Partial / ❌ Insufficient>
+
+**Missing for test plan generation:**
+- <List specific gaps that would cause test-plan-create to produce TBDs or low quality score>
+- <For each analyzer with ⚠️ or ❌, specify which compatibility checks failed and what to add>
+
 **Missing edge cases**: <list or "none identified">
 **Untestable criteria**: <list or "none">
 **Test complexity**: <straightforward / moderate / requires significant test infrastructure>
-**Recommendation**: <approve / revise criteria / add test plan>
+
+**Recommendation:**
+- **If Ready**: Proceed to `/test-plan-create RHAISTRAT-NNN` (expected quality ≥8/10)
+- **If Needs improvement**: <Specific additions needed> (expected quality 4-7/10 if proceeding anyway)
+- **If Not ready**: <Blocking issues preventing test plan generation> (do NOT proceed)
 ```
 
-Focus on what can't be tested or validated. If acceptance criteria are vague, suggest specific rewrites that would make them testable.
+Focus on what can't be tested or validated. If acceptance criteria are vague, suggest specific rewrites that would make them testable. For test plan readiness, be specific about which compatibility checks failed and what content is missing.

--- a/.claude/skills/testability-review/test-plan-compatibility.md
+++ b/.claude/skills/testability-review/test-plan-compatibility.md
@@ -1,0 +1,309 @@
+# Test-Plan-Create Compatibility Checklist
+
+## Purpose
+
+This checklist defines the specific requirements a STRAT must meet to successfully generate a quality test plan via `/test-plan-create`. It extends assess-strat's testability scoring by explicitly checking for information needed by test-plan-create's three parallel analyzers.
+
+## Background
+
+assess-strat evaluates whether acceptance criteria are measurable and testable (score 0-2). However, test-plan-create requires additional technical details beyond acceptance criteria alone:
+- Concrete endpoint paths/methods (not just "add API")
+- Environment version requirements (not just "uses PostgreSQL")
+- Specific error cases and edge cases
+
+A STRAT can have testable acceptance criteria (assess-strat score 2) but still produce a low-quality test plan if it lacks these details.
+
+## How to Use This Checklist
+
+### Structural Validation Results (Already Available)
+
+The `strat.review` orchestrator has already run `scripts/validate_strat_testability.py` and saved results to `tmp/structural-{STRAT_ID}.json`.
+
+**Read the JSON file for the STRAT you're reviewing:**
+```bash
+# Example: For RHAISTRAT-1431
+cat tmp/structural-RHAISTRAT-1431.json
+```
+
+**Key metrics to check:**
+- `structural_score < 5`: Major structural issues (likely Not ready)
+- `warnings` with "CRITICAL": Blocking structural gaps
+- `concrete_interactions_count == 0`: No concrete examples found (likely Insufficient)
+- `tbd_count > 5`: Incomplete STRAT
+- `error_case_mentions == 0` and `edge_case_mentions == 0`: Coverage gaps
+
+**Fast decisions:**
+- If structural_score < 5 AND multiple CRITICAL warnings → likely "Not ready"
+- If structural_score ≥ 8 AND no CRITICAL warnings → focus semantic checks on nuance
+- Use warnings array to target specific compatibility checks
+
+### Semantic Assessment (Your Task)
+
+Structural validation provides the metrics. You assess whether the content is **semantically sufficient**:
+- Are the detected endpoints concrete enough for test plan Section 4?
+- Are NFRs measurable enough for test strategy?
+- Is test data format inferable from the acceptance criteria + technical approach?
+
+Apply the 9 compatibility checks below, using structural validation to focus your review.
+
+## Compatibility Checks
+
+**Note:** These checks apply to all STRAT types (UI/API, Operator/CRD, CLI, SDK, Configuration, Backend). The terminology is generalized to support any interaction mechanism.
+
+For a STRAT to score **testability=2** AND be **ready for test-plan-create**, it must pass ALL compatibility checks below:
+
+### Interaction Analyzer Compatibility
+
+The interaction analyzer (test-plan-analyze-endpoints) extracts feature scope and populates Section 4 (Endpoints/Methods Under Test). It requires concrete interaction mechanisms regardless of feature type:
+
+- [ ] **Concrete interaction mechanism specified**
+  
+  Choose the appropriate interaction type(s) for your STRAT:
+  
+  - **REST API:** ✅ "`GET /api/v1/catalog/models?query={term}`" | ❌ "Will add API endpoint"
+  - **UI/Dashboard:** ✅ "Models page > MaaS Model Refs tab > Register button" | ❌ "Dashboard UI for models"
+  - **CLI:** ✅ "`kubectl apply -f maasmodelref.yaml`", "`odh-cli model create --provider=openai`" | ❌ "CLI command to create models"
+  - **CRD/Custom Resource:** ✅ "MaaSModelRef CR with spec: {provider, endpoint, modelId}" | ❌ "New custom resource for models"
+  - **SDK/Library:** ✅ "`client.models.create(provider='openai', endpoint='...')`" | ❌ "Programmatic API"
+  - **Configuration:** ✅ "ConfigMap with fields: {enableMaaS: bool, providers: []}" | ❌ "Config file for MaaS"
+  - **Operator/Controller:** ✅ "MaaSModelRef controller reconciles .spec.externalModel → Istio VirtualService" | ❌ "Operator handles external models"
+  
+- [ ] **Interaction specifications traceable to source**
+  - ✅ Acceptance criteria or Technical Approach explicitly states the interaction mechanism with concrete examples
+  - ❌ Interactions are inferable but not explicitly documented
+
+- [ ] **If multi-layer feature, all layers identified**
+  - ✅ UI feature: Both UI flow AND BFF/API endpoints specified (e.g., "Dashboard calls `POST /api/v1/maasmodel`")
+  - ✅ Operator feature: Both CRD spec AND controller reconciliation logic described
+  - ✅ CLI feature: Command syntax AND underlying API/SDK calls identified (if applicable)
+  - ❌ Only one layer described (e.g., "UI for models" without BFF endpoint, or "CRD for models" without reconciliation behavior)
+
+**Scoring impact:**
+- All 3 checks pass → Interaction analyzer: ✅ Ready
+- 1-2 checks fail → Interaction analyzer: ⚠️ Partial (test plan will have TBDs in Section 4)
+- All 3 checks fail → Interaction analyzer: ❌ Insufficient (test plan generation may fail)
+
+### Risks Analyzer Compatibility
+
+The risks analyzer (test-plan-analyze-risks) extracts test strategy, NFRs, and risks. It requires:
+
+- [ ] **NFRs include specific, measurable targets**
+  - ✅ Good: "p95 latency <300ms for 1000 models", "Support 200 concurrent users"
+  - ❌ Bad: "System is performant", "API is fast"
+
+- [ ] **Error cases covered**
+  - ✅ Acceptance criteria or Technical Approach lists error scenarios ("Returns 400 if query malformed", "Returns 503 if backend unavailable")
+  - ❌ Only happy path described
+
+- [ ] **At least one edge case identified per major workflow**
+  - ✅ Acceptance criteria or Technical Approach mentions boundary conditions ("What about 201 resources?", "Concurrent creates", "Stale cache")
+  - ❌ No edge cases mentioned
+
+**Scoring impact:**
+- All 3 checks pass → Risks analyzer: ✅ Ready
+- 1-2 checks fail → Risks analyzer: ⚠️ Partial (NFR section will have TBDs, risk analysis generic)
+- All 3 checks fail → Risks analyzer: ❌ Insufficient (test plan NFR section will be weak)
+
+### Infra Analyzer Compatibility
+
+The infra analyzer (test-plan-analyze-infra) extracts environment, test data, and infrastructure requirements. It requires:
+
+- [ ] **Environment requirements specified**
+  - ✅ Good: "Requires model-registry v1.5.0+, PostgreSQL 13+, OpenShift 4.15+"
+  - ❌ Bad: "Uses model registry", "Requires database"
+
+- [ ] **Test data format described or inferable**
+  - ✅ Acceptance criteria shows example data structure ("MaaSModelRef CR with ExternalModel provider type... endpoint URL, model identifier, credential Secret reference")
+  - ✅ Technical Approach describes data models
+  - ❌ No indication of data structure
+
+- [ ] **RBAC requirements identified (if applicable)**
+  - ✅ Acceptance criteria or Technical Approach mentions required permissions ("Requires `catalog:read` permission", "Platform admin only")
+  - ❌ RBAC not mentioned despite feature requiring specific roles
+
+**Scoring impact:**
+- All 3 checks pass → Infra analyzer: ✅ Ready
+- 1-2 checks fail → Infra analyzer: ⚠️ Partial (environment section will have TBDs, test data format unclear)
+- All 3 checks fail → Infra analyzer: ❌ Insufficient (test plan environment section will be weak)
+
+## Aggregate Scoring
+
+**Test Plan Generation Readiness** is determined by combining all three analyzer assessments:
+
+| Interaction | Risks | Infra | Overall Readiness | Expected Test Plan Quality |
+|-------------|-------|-------|-------------------|---------------------------|
+| ✅ Ready | ✅ Ready | ✅ Ready | **Ready** | ≥8/10 (proceed to test-plan-create) |
+| ✅ Ready | ✅ Ready | ⚠️ Partial | **Ready** (minor gaps) | 7-9/10 (proceed, expect minor TBDs) |
+| ✅ Ready | ⚠️ Partial | ⚠️ Partial | **Needs improvement** | 5-7/10 (can proceed but expect gaps) |
+| ⚠️ Partial | ⚠️ Partial | ⚠️ Partial | **Needs improvement** | 4-6/10 (address gaps first recommended) |
+| ❌ Insufficient | (any) | (any) | **Not ready** | <4/10 (do NOT proceed) |
+| (any) | ❌ Insufficient | (any) | **Not ready** | <4/10 (do NOT proceed) |
+| (any) | (any) | ❌ Insufficient | **Not ready** | <4/10 (do NOT proceed) |
+
+**Decision criteria:**
+- **Ready**: Proceed to `/test-plan-create`
+- **Needs improvement**: Recommend addressing gaps first, but can proceed if user accepts expected quality 4-7
+- **Not ready**: Do NOT proceed; revise STRAT to add missing details
+
+## Decision Tree: Actions Based on Readiness
+
+### If Readiness = "Ready" ✅
+**Meaning:** STRAT contains sufficient detail for quality test plan generation
+
+**Testability reviewer recommendation:**
+- Proceed to `/test-plan-create RHAISTRAT-XXX`
+- Expected test plan quality: ≥8/10
+- Expected gaps: <5 minor gaps
+
+**Next steps:**
+1. Run `/test-plan-create RHAISTRAT-XXX [ADR_FILE]`
+2. Review TestPlan.md and TestPlanGaps.md
+3. If quality ≥8, proceed to test case generation
+
+### If Readiness = "Needs Improvement" ⚠️
+**Meaning:** STRAT can support test plan generation but will have gaps
+
+**Testability reviewer recommendation:**
+Two options for the STRAT author:
+
+**Option A (Recommended) - Fix STRAT First:**
+1. Address specific gaps listed (endpoint paths, error codes, env versions, etc.)
+2. Re-run `/strat.review` to verify improvements
+3. Once readiness = "Ready", run `/test-plan-create`
+4. Time investment: 20-40 min to improve STRAT
+5. Payoff: Quality test plan on first try (≥8/10)
+
+**Option B - Proceed with Gaps:**
+1. Run `/test-plan-create RHAISTRAT-XXX` now
+2. Expected test plan quality: 4-7/10
+3. Expected gaps: 5-15 gaps in TestPlanGaps.md
+4. Provide ADR/API spec during test plan generation to resolve gaps
+5. May require test plan revisions
+6. Time cost: 1-2 hours of iteration
+
+### If Readiness = "Not Ready" ❌
+**Meaning:** STRAT lacks critical details; test plan generation would fail or produce quality <4/10
+
+**Testability reviewer recommendation:**
+**Do NOT proceed to test-plan-create**
+
+**Required actions:**
+1. Identify blocking issues (typically 2+ analyzers scored ❌ Insufficient)
+2. Add critical missing content to STRAT:
+   - **Interaction analyzer insufficient:** Add concrete endpoints, UI flows, CLI commands, or CRD specs to Technical Approach
+   - **Risks analyzer insufficient:** Add measurable NFRs, error cases, edge cases
+   - **Infra analyzer insufficient:** Specify environment versions, test data format, RBAC requirements
+3. Re-run `/strat.review` after revisions
+4. Only proceed to test plan generation once readiness ≥ "Needs improvement"
+
+**Time investment:** 30-60 min to improve STRAT
+**Time saved:** 2-3 hours avoiding failed test plan generation and full rewrite
+
+## Integration with assess-strat Testability Scoring
+
+**Relationship:**
+- assess-strat testability scoring (0-2) evaluates acceptance criteria measurability
+- This compatibility checklist evaluates technical detail sufficiency for test-plan-create
+
+**Combined decision logic:**
+
+| assess-strat Testability | Test-Plan Readiness | Action |
+|-------------------------|---------------------|--------|
+| 0 (untestable criteria) | (any) | ❌ Block: Fix acceptance criteria first |
+| 1 (partial criteria) | Not ready | ❌ Block: Fix both criteria and add technical details |
+| 1 (partial criteria) | Needs improvement | ⚠️ Can proceed, expect quality 4-6 |
+| 2 (measurable criteria) | Not ready | ⚠️ Criteria good, but missing technical details for test plan |
+| 2 (measurable criteria) | Needs improvement | ✅ Proceed, expect quality 6-8 |
+| 2 (measurable criteria) | Ready | ✅ Proceed, expect quality ≥8 |
+
+## Example: RHAISTRAT-1431
+
+**STRAT:** UI for Registering Internal and External Model Endpoints in MaaS
+
+**Detailed assessment:** See [RHAISTRAT-1431-assessment.md](./RHAISTRAT-1431-assessment.md) for complete analysis with all 9 checks applied.
+
+**Summary:**
+- Interaction analyzer: ✅ Ready
+- Risks analyzer: ⚠️ Partial (limited error/edge cases)  
+- Infra analyzer: ✅ Ready
+
+**Overall:** Ready (with minor gaps) → Predicted quality 7-9/10
+
+## Common Gaps and Fixes
+
+### Gap: "Vague interaction specifications"
+**Example:** "Dashboard UI for managing models", "CLI for model management", "Operator handles models"
+
+**Impact:** Interaction analyzer cannot populate Section 4 (Endpoints/Methods Under Test)
+
+**Fix:** Add concrete interaction mechanisms to Technical Approach or Acceptance Criteria:
+- **For UI:** Specific BFF endpoint paths (e.g., "`POST /api/v1/maasmodel` to create MaaSModelRef") AND UI flows ("Models page > MaaS Model Refs tab > Register button")
+- **For CLI:** Command syntax with examples (e.g., "`kubectl apply -f model.yaml`", "`odh-cli model create --name=gpt4`")
+- **For Operator:** CRD spec structure AND reconciliation logic (e.g., "MaaSModelRef CR with .spec.provider → controller creates Istio VirtualService")
+- **For SDK:** Method signatures (e.g., "`client.models.create(name, provider, endpoint)`")
+
+### Gap: "Generic NFRs"
+**Example:** "System should be performant and scalable"
+
+**Impact:** Risks analyzer produces generic risk assessments, weak NFR section
+
+**Fix:** Add measurable targets:
+- "List view renders ≤2s for 200 resources"
+- "Supports 50 concurrent model registrations without degradation"
+
+### Gap: "Missing environment versions"
+**Example:** "Uses PostgreSQL and model-registry"
+
+**Impact:** Infra analyzer cannot populate Section 3 (Test Environment), leaves versions as TBD
+
+**Fix:** Specify versions in Dependencies:
+- "Requires model-registry v1.5.0+ (for ExternalModel support)"
+- "PostgreSQL 13+ (existing platform dependency)"
+
+### Gap: "No error cases"
+**Example:** Acceptance criteria only describes happy path
+
+**Impact:** Risks analyzer misses error scenarios, test objectives incomplete
+
+**Fix:** Add error cases to Technical Approach or Acceptance Criteria:
+- "Returns 400 if provider is not in allowed list"
+- "Returns 409 if MaaSModelRef with same name already exists"
+- "Returns 503 if model-registry is unavailable"
+
+### Gap: "RBAC unclear"
+**Example:** No mention of required permissions
+
+**Impact:** Infra analyzer cannot determine test user setup
+
+**Fix:** Add to NFRs or Technical Approach:
+- "Requires `maasmodel:create` and `maasmodel:read` permissions"
+- "Platform admin role required for MaaSModelRef CRUD"
+
+## Using This Checklist
+
+### During STRAT Review (testability-review skill)
+1. Read acceptance criteria and Technical Approach
+2. Check each of the 9 compatibility checks (3 per analyzer)
+3. Assign analyzer status: ✅ Ready (3/3 pass), ⚠️ Partial (1-2 pass), ❌ Insufficient (0 pass)
+4. Determine overall Test Plan Generation Readiness
+5. List specific gaps preventing "Ready" status
+6. Include in testability review output
+
+### During STRAT Refinement (strat.refine skill)
+1. After generating STRAT, self-assess against this checklist
+2. If any analyzer scores ⚠️ Partial or ❌ Insufficient, add missing details before finalizing
+3. Target: all three analyzers ✅ Ready before submitting STRAT for review
+
+### Before Running /test-plan-create
+1. Quick checklist review
+2. If overall readiness is "Not ready", do NOT proceed
+3. If "Needs improvement", decide: address gaps now or accept lower quality and fix with ADR later
+4. If "Ready", proceed confidently
+
+## Maintenance
+
+This checklist should be updated when:
+- test-plan-create analyzer requirements change
+- New analyzer types are added
+- Patterns of false positives/negatives emerge (predicted Ready but got quality <8)
+- New gap categories are discovered through testing

--- a/.claude/skills/testability-review/test-plan-compatibility.md
+++ b/.claude/skills/testability-review/test-plan-compatibility.md
@@ -131,59 +131,97 @@ The infra analyzer (test-plan-analyze-infra) extracts environment, test data, an
 
 **Test Plan Generation Readiness** is determined by combining all three analyzer assessments:
 
-| Interaction | Risks | Infra | Overall Readiness | Expected Test Plan Quality | Expected Gaps |
-|-------------|-------|-------|-------------------|---------------------------|---------------|
-| ✅ Ready | ✅ Ready | ✅ Ready | **Ready** | ≥8/10 | <5 (all explicit) |
-| ✅ Ready | ✅ Ready | ⚠️ Partial | **Ready** (with gaps) | 7-9/10 | 10-20 (pending deps) |
-| ✅ Ready | ⚠️ Partial | ⚠️ Partial | **Needs improvement** | 5-7/10 | 15-25 (mix) |
-| ⚠️ Partial | ⚠️ Partial | ⚠️ Partial | **Needs improvement** | 4-6/10 | 20-30 (many partial) |
-| ❌ Insufficient | (any) | (any) | **Not ready** | <4/10 | 30+ (unfixable) |
-| (any) | ❌ Insufficient | (any) | **Not ready** | <4/10 | 30+ (unfixable) |
-| (any) | (any) | ❌ Insufficient | **Not ready** | <4/10 | 30+ (unfixable) |
+| Interaction | Risks | Infra | Overall Readiness | Expected Quality | Expected Gap Resolvability |
+|-------------|-------|-------|-------------------|------------------|---------------------------|
+| ✅ Ready | ✅ Ready | ✅ Ready | **Ready** | ≥8/10 | **All addressable** - Can provide API specs, design docs now |
+| ✅ Ready | ✅ Ready | ⚠️ Partial | **Ready (pending deps)** | 7-9/10 | **Mixed** - Some blocked until dependencies ship |
+| ✅ Ready | ⚠️ Partial | ⚠️ Partial | **Needs improvement** | 5-7/10 | **Mixed** - Some require STRAT revision |
+| ⚠️ Partial | ⚠️ Partial | ⚠️ Partial | **Needs improvement** | 4-6/10 | **Many unfixable** - STRAT deficiencies |
+| ❌ Insufficient | (any) | (any) | **Not ready** | <4/10 | **Most unfixable** - Requires STRAT rewrite |
+| (any) | ❌ Insufficient | (any) | **Not ready** | <4/10 | **Most unfixable** |
+| (any) | (any) | ❌ Insufficient | **Not ready** | <4/10 | **Most unfixable** |
+
+**Gap Resolvability Types:**
+
+1. **Addressable** - Can be resolved by providing documentation now:
+   - API specifications (OpenAPI schemas, endpoint contracts)
+   - Design documents (implementation choices, architecture decisions)
+   - Deployment guides (environment variables, configurations)
+   - ADRs (architectural decision records)
+   - Example: "PostgreSQL migration details" → Provide design doc
+
+2. **Blocked** - Waiting for pending dependencies to ship:
+   - Dependencies with status "Needed" (RHAISTRAT-XXXX not yet implemented)
+   - Pending design work (UX review required, architecture review pending)
+   - Example: "CRD schema from RHAISTRAT-1295" → Wait for dependency to land
+
+3. **Unfixable** - Require STRAT revision:
+   - Missing from STRAT (no concrete interactions, vague criteria, unclear scope)
+   - Cannot be resolved with documentation alone
+   - Example: "No API endpoints specified" → Revise STRAT to add endpoints
+
+**Gap Count:** Expect 10-20 gaps even for "Ready" STRATs. What matters is resolvability:
+- All addressable → Can proceed with test planning and address gaps incrementally
+- Mix of addressable + blocked → Can proceed but some gaps remain until dependencies ship
+- Many unfixable → Should revise STRAT before test planning
 
 **Decision criteria:**
-- **Ready**: Proceed to `/test-plan-create`
-- **Needs improvement**: Recommend addressing gaps first, but can proceed if user accepts expected quality 4-7
-- **Not ready**: Do NOT proceed; revise STRAT to add missing details
+- **Ready**: All gaps addressable or blocked by documented dependencies → Quality ≥8/10
+- **Needs improvement**: Mix of addressable and unfixable gaps → Quality 4-7/10
+- **Not ready**: Most gaps unfixable without STRAT revision → Quality <4/10
 
 ## Decision Tree: Actions Based on Readiness
 
 ### If Readiness = "Ready" ✅
 **Meaning:** STRAT contains sufficient detail for quality test plan generation
 
+**Gap resolvability:** All gaps will be **addressable** (can provide API specs, design docs now) or **blocked** (waiting for documented dependencies)
+
 **Testability reviewer recommendation:**
 - Proceed to `/test-plan-create RHAISTRAT-XXX`
 - Expected test plan quality: ≥8/10
-- Expected gaps: <5 minor gaps
+- Expected gaps: 10-20 gaps, all with clear resolution paths
+
+**What to provide during test plan generation:**
+- API specifications (OpenAPI schemas, endpoint contracts)
+- Design documents (implementation details, tool choices)
+- Deployment configurations (environment variables, resource limits)
+- ADRs (if available)
 
 **Next steps:**
 1. Run `/test-plan-create RHAISTRAT-XXX [ADR_FILE]`
-2. Review TestPlan.md and TestPlanGaps.md
-3. If quality ≥8, proceed to test case generation
+2. Review TestPlanGaps.md - all gaps should have "Would be resolved by: ..." statements
+3. Provide available documentation to resolve addressable gaps
+4. Document blocked gaps (waiting for dependencies) with timeline
+5. If quality ≥8, proceed to test case generation
 
 ### If Readiness = "Needs Improvement" ⚠️
-**Meaning:** STRAT can support test plan generation but will have gaps
+**Meaning:** STRAT can support test plan generation but will have mix of addressable and unfixable gaps
+
+**Gap resolvability:** Mix of **addressable** (can provide docs), **blocked** (pending dependencies), and **unfixable** (require STRAT revision)
 
 **Testability reviewer recommendation:**
 Two options for the STRAT author:
 
 **Option A (Recommended) - Fix STRAT First:**
-1. Address specific gaps listed (endpoint paths, error codes, env versions, etc.)
+1. Address **unfixable gaps** listed in assessment (missing endpoints, vague criteria, unclear scope)
 2. Re-run `/strat.review` to verify improvements
-3. Once readiness = "Ready", run `/test-plan-create`
-4. Time investment: 20-40 min to improve STRAT
-5. Payoff: Quality test plan on first try (≥8/10)
+3. Once readiness improves to "Ready", run `/test-plan-create`
+4. Time investment: 30-60 min to improve STRAT
+5. Payoff: Higher quality test plan (7-9/10 instead of 4-7/10), fewer unfixable gaps
 
 **Option B - Proceed with Gaps:**
 1. Run `/test-plan-create RHAISTRAT-XXX` now
 2. Expected test plan quality: 4-7/10
-3. Expected gaps: 5-15 gaps in TestPlanGaps.md
-4. Provide ADR/API spec during test plan generation to resolve gaps
-5. May require test plan revisions
-6. Time cost: 1-2 hours of iteration
+3. Expected gaps: 15-30 gaps, some **unfixable** without STRAT revision
+4. Provide documentation for addressable gaps
+5. Some gaps will remain unfixable → require test plan revision after STRAT update
+6. Time cost: 2-3 hours (iteration on both STRAT and test plan)
 
 ### If Readiness = "Not Ready" ❌
 **Meaning:** STRAT lacks critical details; test plan generation would fail or produce quality <4/10
+
+**Gap resolvability:** Most gaps **unfixable** - require STRAT revision, not just documentation
 
 **Testability reviewer recommendation:**
 **Do NOT proceed to test-plan-create**
@@ -197,8 +235,13 @@ Two options for the STRAT author:
 3. Re-run `/strat.review` after revisions
 4. Only proceed to test plan generation once readiness ≥ "Needs improvement"
 
-**Time investment:** 30-60 min to improve STRAT
-**Time saved:** 2-3 hours avoiding failed test plan generation and full rewrite
+**Why gaps are unfixable without STRAT revision:**
+- No concrete interactions → Cannot provide in documentation, must be in STRAT
+- Vague acceptance criteria → Cannot add metrics via API spec, must fix criteria
+- Missing scope boundaries → Cannot clarify in design doc, must define in STRAT
+
+**Time investment:** 1-2 hours to fix STRAT
+**Time saved:** 3-5 hours avoiding failed test plan generation with 30+ unfixable gaps
 
 ## Integration with assess-strat Testability Scoring
 

--- a/.claude/skills/testability-review/test-plan-compatibility.md
+++ b/.claude/skills/testability-review/test-plan-compatibility.md
@@ -108,9 +108,10 @@ The risks analyzer (test-plan-analyze-risks) extracts test strategy, NFRs, and r
 
 The infra analyzer (test-plan-analyze-infra) extracts environment, test data, and infrastructure requirements. It requires:
 
-- [ ] **Environment requirements specified**
-  - ✅ Good: "Requires model-registry v1.5.0+, PostgreSQL 13+, OpenShift 4.15+"
-  - ❌ Bad: "Uses model registry", "Requires database"
+- [ ] **Environment requirements explicitly specified**
+  - ✅ PASS: Versions stated directly in this STRAT ("Requires model-registry v1.5.0+, PostgreSQL 13+, OpenShift 4.15+")
+  - ⚠️ PARTIAL: Versions exist but in referenced STRATs/docs ("See RHAISTRAT-1295 for CRD schema") - will cause TBDs
+  - ❌ FAIL: No version information ("Uses model registry", "Requires database")
 
 - [ ] **Test data format described or inferable**
   - ✅ Acceptance criteria shows example data structure ("MaaSModelRef CR with ExternalModel provider type... endpoint URL, model identifier, credential Secret reference")
@@ -130,15 +131,15 @@ The infra analyzer (test-plan-analyze-infra) extracts environment, test data, an
 
 **Test Plan Generation Readiness** is determined by combining all three analyzer assessments:
 
-| Interaction | Risks | Infra | Overall Readiness | Expected Test Plan Quality |
-|-------------|-------|-------|-------------------|---------------------------|
-| ✅ Ready | ✅ Ready | ✅ Ready | **Ready** | ≥8/10 (proceed to test-plan-create) |
-| ✅ Ready | ✅ Ready | ⚠️ Partial | **Ready** (minor gaps) | 7-9/10 (proceed, expect minor TBDs) |
-| ✅ Ready | ⚠️ Partial | ⚠️ Partial | **Needs improvement** | 5-7/10 (can proceed but expect gaps) |
-| ⚠️ Partial | ⚠️ Partial | ⚠️ Partial | **Needs improvement** | 4-6/10 (address gaps first recommended) |
-| ❌ Insufficient | (any) | (any) | **Not ready** | <4/10 (do NOT proceed) |
-| (any) | ❌ Insufficient | (any) | **Not ready** | <4/10 (do NOT proceed) |
-| (any) | (any) | ❌ Insufficient | **Not ready** | <4/10 (do NOT proceed) |
+| Interaction | Risks | Infra | Overall Readiness | Expected Test Plan Quality | Expected Gaps |
+|-------------|-------|-------|-------------------|---------------------------|---------------|
+| ✅ Ready | ✅ Ready | ✅ Ready | **Ready** | ≥8/10 | <5 (all explicit) |
+| ✅ Ready | ✅ Ready | ⚠️ Partial | **Ready** (with gaps) | 7-9/10 | 10-20 (pending deps) |
+| ✅ Ready | ⚠️ Partial | ⚠️ Partial | **Needs improvement** | 5-7/10 | 15-25 (mix) |
+| ⚠️ Partial | ⚠️ Partial | ⚠️ Partial | **Needs improvement** | 4-6/10 | 20-30 (many partial) |
+| ❌ Insufficient | (any) | (any) | **Not ready** | <4/10 | 30+ (unfixable) |
+| (any) | ❌ Insufficient | (any) | **Not ready** | <4/10 | 30+ (unfixable) |
+| (any) | (any) | ❌ Insufficient | **Not ready** | <4/10 | 30+ (unfixable) |
 
 **Decision criteria:**
 - **Ready**: Proceed to `/test-plan-create`
@@ -215,19 +216,6 @@ Two options for the STRAT author:
 | 2 (measurable criteria) | Not ready | ⚠️ Criteria good, but missing technical details for test plan |
 | 2 (measurable criteria) | Needs improvement | ✅ Proceed, expect quality 6-8 |
 | 2 (measurable criteria) | Ready | ✅ Proceed, expect quality ≥8 |
-
-## Example: RHAISTRAT-1431
-
-**STRAT:** UI for Registering Internal and External Model Endpoints in MaaS
-
-**Detailed assessment:** See [RHAISTRAT-1431-assessment.md](./RHAISTRAT-1431-assessment.md) for complete analysis with all 9 checks applied.
-
-**Summary:**
-- Interaction analyzer: ✅ Ready
-- Risks analyzer: ⚠️ Partial (limited error/edge cases)  
-- Infra analyzer: ✅ Ready
-
-**Overall:** Ready (with minor gaps) → Predicted quality 7-9/10
 
 ## Common Gaps and Fixes
 

--- a/scripts/validate_strat_testability.py
+++ b/scripts/validate_strat_testability.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Structural validation for STRAT test plan readiness.
+
+Performs fast, deterministic checks on STRAT content before LLM semantic validation.
+Outputs JSON with structural metrics and warnings for testability reviewer to consume.
+
+Usage:
+    python scripts/validate_strat_testability.py artifacts/strat-tasks/RHAISTRAT-1431.md
+
+Output:
+    JSON to stdout with structural validation results
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass
+from typing import List, Optional
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+@dataclass
+class StructuralValidationResult:
+    """Results of structural validation checks"""
+
+    # Section presence
+    has_acceptance_criteria: bool
+    has_technical_approach: bool
+    has_dependencies: bool
+    has_nfrs: bool
+    has_risks: bool
+
+    # Acceptance criteria format
+    acceptance_criteria_format: str  # "given-when-then", "checkbox", "other", "none"
+    acceptance_criteria_count: int
+    acceptance_criteria_word_count: int
+
+    # Content quality indicators
+    tbd_count: int  # "TBD", "to be determined", "will add later"
+    placeholder_count: int  # "...", "TODO", "<placeholder>"
+
+    # Technical detail indicators
+    error_case_mentions: int
+    edge_case_mentions: int
+    version_specifications: int
+
+    # Interaction mechanism detection
+    detected_interaction_types: List[str]  # ["REST_API", "UI", "CLI", "CRD", "SDK"]
+    concrete_interactions_count: int
+
+    # Word counts
+    technical_approach_word_count: int
+
+    # Dependency analysis
+    dependency_count: int
+    dependencies_have_versions: bool
+
+    # Warnings/flags
+    warnings: List[str]
+
+    # Overall structural score (0-10, purely deterministic)
+    structural_score: int
+
+
+class StratStructuralValidator:
+    """Validates STRAT structure for test plan readiness"""
+
+    # Validation thresholds
+    MIN_TECHNICAL_APPROACH_WORDS = 100
+    MIN_DETAILED_TECHNICAL_APPROACH_WORDS = 150
+    MAX_ACCEPTABLE_TBDS = 5
+    MIN_CONCRETE_INTERACTIONS = 3
+    MIN_ERROR_MENTIONS = 2
+    MIN_EDGE_MENTIONS = 2
+
+    # Section header patterns (pre-compiled)
+    SECTION_PATTERNS = {
+        'acceptance_criteria': re.compile(r'^#+\s*Acceptance Criteria', re.IGNORECASE | re.MULTILINE),
+        'technical_approach': re.compile(r'^#+\s*Technical Approach', re.IGNORECASE | re.MULTILINE),
+        'dependencies': re.compile(r'^#+\s*Dependencies', re.IGNORECASE | re.MULTILINE),
+        'nfrs': re.compile(r'^#+\s*Non-Functional Requirements', re.IGNORECASE | re.MULTILINE),
+        'risks': re.compile(r'^#+\s*Risks', re.IGNORECASE | re.MULTILINE),
+    }
+
+    # Gap indicator patterns
+    TBD_PATTERNS = [
+        r'\bTBD\b',
+        r'\bto be determined\b',
+        r'\bwill add later\b',
+        r'\bto be defined\b',
+        r'\bpending\b',
+    ]
+
+    PLACEHOLDER_PATTERNS = [
+        r'\.\.\.+',
+        r'\bTODO\b',
+        r'<[^>]*placeholder[^>]*>',
+        r'\[TBD\]',
+    ]
+
+    # Technical detail patterns
+    ERROR_PATTERNS = [
+        r'\berror\b',
+        r'\bfail(?:ure|s|ed)?\b',
+        r'\binvalid\b',
+        r'\bexception\b',
+        r'\breturns?\s+4\d{2}\b',  # HTTP 4xx
+        r'\breturns?\s+5\d{2}\b',  # HTTP 5xx
+    ]
+
+    EDGE_CASE_PATTERNS = [
+        r'\bedge case\b',
+        r'\bboundary\b',
+        r'\bconcurren(?:t|cy)\b',
+        r'\brace condition\b',
+        r'\bdeadlock\b',
+        r'\boverload\b',
+        r'\bthrottle\b',
+        r'\bretry\b',
+    ]
+
+    VERSION_PATTERNS = [
+        r'v?\d+\.\d+(?:\.\d+)?(?:-[a-z0-9]+)?',  # v1.2.3 or 1.2-alpha
+        r'version\s+\d+\.\d+',
+        r'>=?\s*\d+\.\d+',
+        r'OpenShift\s+4\.\d+',
+        r'Kubernetes\s+1\.\d+',
+        r'PostgreSQL\s+\d+',
+    ]
+
+    # Interaction type detection patterns
+    INTERACTION_PATTERNS = {
+        'REST_API': [
+            r'`(?:GET|POST|PUT|DELETE|PATCH)\s+/[a-z0-9/_\-{}\?&=]+',
+            r'/api/v?\d+/[a-z0-9/_\-]+',
+        ],
+        'UI': [
+            r'\bdashboard\b',
+            r'\bUI\s+(?:flow|interaction)\b',
+            r'\b(?:click|select|fill|submit)\s+.*(?:button|form|field)',
+            r'\bpage\s+>\s+',  # Navigation breadcrumb
+        ],
+        'CLI': [
+            r'`kubectl\s+',
+            r'`oc\s+',
+            r'`odh-cli\s+',
+            r'`[a-z]+-cli\s+',
+        ],
+        'CRD': [
+            r'\bCustom\s+Resource\s+Definition\b',
+            r'\b[A-Z][a-zA-Z]*(?:Ref|Config|Policy)\b',  # CRD name patterns
+            r'\bCR\s+with\s+spec\b',
+            r'\.spec\.',
+            r'\.status\.',
+        ],
+        'OPERATOR': [
+            r'\bcontroller\s+reconciles\b',
+            r'\boperator\s+(?:handles|manages)\b',
+            r'\breconciliation\s+logic\b',
+        ],
+        'SDK': [
+            r'`client\.[a-z]+\.',
+            r'\bSDK\s+method\b',
+            r'\bprogrammatic\s+(?:API|interface)\b',
+        ],
+        'CONFIG': [
+            r'\bConfigMap\b',
+            r'\bconfiguration\s+file\b',
+            r'\.yaml\s+with\s+fields',
+        ],
+    }
+
+    # Acceptance criteria format pattern (pre-compiled)
+    GIVEN_WHEN_THEN_PATTERN = re.compile(r'\b(?:Given|When|Then|Measured by)\b', re.IGNORECASE)
+
+    def __init__(self, strat_content: str):
+        self.content = strat_content
+        self.content_lower = strat_content.lower()
+
+    def _extract_section(self, section_name: str) -> Optional[str]:
+        """Extract content of a specific section"""
+        pattern = self.SECTION_PATTERNS.get(section_name)
+        if not pattern:
+            return None
+
+        match = pattern.search(self.content)
+        if not match:
+            return None
+
+        start = match.end()
+        # Find next section header (## or ###)
+        next_section = re.search(r'\n^#+\s+', self.content[start:], re.MULTILINE)
+        end = start + next_section.start() if next_section else len(self.content)
+
+        return self.content[start:end]
+
+    def _count_patterns(self, patterns: List[str], text: Optional[str] = None) -> int:
+        """Count occurrences of regex patterns"""
+        if text is None:
+            text = self.content_lower
+
+        count = 0
+        for pattern in patterns:
+            count += len(re.findall(pattern, text, re.IGNORECASE))
+        return count
+
+    def _detect_interaction_types(self) -> tuple[List[str], int]:
+        """Detect which interaction types are present and count concrete examples"""
+        detected = set()
+        concrete_count = 0
+
+        for interaction_type, patterns in self.INTERACTION_PATTERNS.items():
+            for pattern in patterns:
+                matches = re.findall(pattern, self.content, re.IGNORECASE | re.MULTILINE)
+                if matches:
+                    detected.add(interaction_type)
+                    # Count concrete examples (backtick-wrapped or with paths)
+                    concrete_count += sum('`' in str(m) or '/' in str(m) for m in matches)
+
+        return list(detected), concrete_count
+
+    def _analyze_acceptance_criteria(self, ac_section: Optional[str]) -> tuple[str, int, int]:
+        """Analyze acceptance criteria format and count"""
+        if not ac_section:
+            return "none", 0, 0
+
+        # Check for Given-When-Then format
+        gwt_matches = len(self.GIVEN_WHEN_THEN_PATTERN.findall(ac_section))
+        if gwt_matches >= 4:  # At least one full Given-When-Then-Measured cycle
+            # Count criteria by "Given" occurrences
+            criteria_count = len(re.findall(r'^-?\s*Given\b', ac_section, re.IGNORECASE | re.MULTILINE))
+            word_count = len(ac_section.split())
+            return "given-when-then", criteria_count, word_count
+
+        # Check for checkbox format
+        checkbox_count = len(re.findall(r'-\s*\[\s*\]', ac_section))
+        if checkbox_count >= 1:
+            word_count = len(ac_section.split())
+            return "checkbox", checkbox_count, word_count
+
+        # Other format - count bullet points
+        criteria_count = len(re.findall(r'^\s*[-*]\s+', ac_section, re.MULTILINE))
+        word_count = len(ac_section.split())
+        return "other", criteria_count, word_count
+
+    def _calculate_structural_score(self, data: dict) -> int:
+        """Calculate overall structural score (0-10) based on presence and quality"""
+        score = 0
+
+        # Required sections (0-4 points)
+        if data['has_acceptance_criteria']:
+            score += 1
+        if data['has_technical_approach']:
+            score += 1
+        if data['has_dependencies']:
+            score += 1
+        if data['has_nfrs'] or data['has_risks']:
+            score += 1
+
+        # Content completeness (0-2 points)
+        # Only award points if there's actual content (not empty STRAT)
+        tbd_total = data['tbd_count'] + data['placeholder_count']
+        has_content = data['technical_approach_word_count'] > 0 or data['acceptance_criteria_count'] > 0
+
+        if has_content and tbd_total == 0:
+            score += 2
+        elif has_content and tbd_total <= 2:
+            score += 1
+        # Empty content gets 0 points (no content bonus)
+
+        # Technical detail (0-2 points)
+        if data['technical_approach_word_count'] >= self.MIN_DETAILED_TECHNICAL_APPROACH_WORDS:
+            score += 1
+        if data['error_case_mentions'] >= self.MIN_ERROR_MENTIONS or data['edge_case_mentions'] >= self.MIN_EDGE_MENTIONS:
+            score += 1
+
+        # Interaction mechanisms (0-2 points)
+        if data['detected_interaction_types']:
+            score += 1
+        if data['concrete_interactions_count'] >= self.MIN_CONCRETE_INTERACTIONS:
+            score += 1
+
+        return min(score, 10)
+
+    def validate(self) -> StructuralValidationResult:
+        """Run all structural validation checks"""
+        warnings = []
+
+        # Check section presence
+        has_ac = bool(self._extract_section('acceptance_criteria'))
+        has_ta = bool(self._extract_section('technical_approach'))
+        has_deps = bool(self._extract_section('dependencies'))
+        has_nfrs = bool(self._extract_section('nfrs'))
+        has_risks = bool(self._extract_section('risks'))
+
+        # Extract sections
+        ac_section = self._extract_section('acceptance_criteria')
+        ta_section = self._extract_section('technical_approach')
+        deps_section = self._extract_section('dependencies')
+
+        # Analyze acceptance criteria
+        ac_format, ac_count, ac_word_count = self._analyze_acceptance_criteria(ac_section)
+
+        # Count quality indicators
+        tbd_count = self._count_patterns(self.TBD_PATTERNS)
+        placeholder_count = self._count_patterns(self.PLACEHOLDER_PATTERNS)
+        error_mentions = self._count_patterns(self.ERROR_PATTERNS)
+        edge_mentions = self._count_patterns(self.EDGE_CASE_PATTERNS)
+        version_count = self._count_patterns(
+            self.VERSION_PATTERNS,
+            (deps_section or '') + (ta_section or '')
+        )
+
+        # Detect interactions
+        interaction_types, concrete_count = self._detect_interaction_types()
+
+        # Word counts
+        ta_word_count = len(ta_section.split()) if ta_section else 0
+
+        # Dependencies
+        dep_count = len(re.findall(r'^\s*[-*]', deps_section, re.MULTILINE)) if deps_section else 0
+        deps_have_versions = version_count > 0 if dep_count > 0 else False
+
+        # Generate warnings using data-driven rules
+        warning_rules = [
+            (not has_ac, "CRITICAL: Missing Acceptance Criteria section"),
+            (has_ac and ac_count == 0, "Acceptance Criteria section exists but is empty"),
+            (not has_ta, "CRITICAL: Missing Technical Approach section"),
+            (has_ta and ta_word_count < self.MIN_TECHNICAL_APPROACH_WORDS, f"Technical Approach is very short ({ta_word_count} words) - may lack detail for test plan generation"),
+            (tbd_count > self.MAX_ACCEPTABLE_TBDS, f"High number of TBD markers ({tbd_count}) - indicates incomplete STRAT"),
+            (not interaction_types, "CRITICAL: No concrete interaction mechanisms detected (API, UI, CLI, CRD, etc.) - test plan Section 4 will be empty"),
+            (interaction_types and concrete_count == 0, "Interaction types mentioned but no concrete examples (specific endpoints, commands, CR specs)"),
+            (error_mentions == 0, "No error cases mentioned - test plan will lack error scenario coverage"),
+            (edge_mentions == 0, "No edge cases mentioned - test plan may miss boundary conditions and concurrency scenarios"),
+            (dep_count > 0 and not deps_have_versions, "Dependencies listed but no version requirements specified - test environment will have TBDs"),
+        ]
+
+        warnings = [msg for condition, msg in warning_rules if condition]
+
+        # Build result dict for scoring
+        result_dict = {
+            'has_acceptance_criteria': has_ac,
+            'has_technical_approach': has_ta,
+            'has_dependencies': has_deps,
+            'has_nfrs': has_nfrs,
+            'has_risks': has_risks,
+            'acceptance_criteria_format': ac_format,
+            'acceptance_criteria_count': ac_count,
+            'acceptance_criteria_word_count': ac_word_count,
+            'tbd_count': tbd_count,
+            'placeholder_count': placeholder_count,
+            'error_case_mentions': error_mentions,
+            'edge_case_mentions': edge_mentions,
+            'version_specifications': version_count,
+            'detected_interaction_types': interaction_types,
+            'concrete_interactions_count': concrete_count,
+            'technical_approach_word_count': ta_word_count,
+            'dependency_count': dep_count,
+            'dependencies_have_versions': deps_have_versions,
+            'warnings': warnings,
+            'structural_score': 0,  # Calculate below
+        }
+
+        result_dict['structural_score'] = self._calculate_structural_score(result_dict)
+
+        return StructuralValidationResult(**result_dict)
+
+
+def validate_strat_file(strat_file: str) -> StructuralValidationResult:
+    """Validate a STRAT file and return results"""
+    with open(strat_file, 'r') as f:
+        content = f.read()
+    validator = StratStructuralValidator(content)
+    return validator.validate()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Validate STRAT structure for test plan readiness')
+    parser.add_argument('strat_file', help='Path to STRAT markdown file')
+    args = parser.parse_args()
+
+    result = validate_strat_file(args.strat_file)
+    print(json.dumps(asdict(result), indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_validate_strat_testability.py
+++ b/tests/test_validate_strat_testability.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""Tests for scripts/validate_strat_testability.py"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from validate_strat_testability import StratStructuralValidator
+
+
+# ── Sample Data ───────────────────────────────────────────────────────────────
+
+
+MINIMAL_STRAT = """## Strategy
+
+### Technical Approach
+This is a sample technical approach with sufficient detail to explain what changes
+are being made, where they are being made, and why this approach was chosen over
+alternatives. It includes concrete implementation details.
+
+### Acceptance Criteria
+- [ ] Users can create a new model via the dashboard
+- [ ] Users can delete an existing model
+- [ ] Changes are reflected in the model list
+
+### Dependencies
+- Component A v1.2.0
+- Component B v2.0+
+
+### Non-Functional Requirements
+- Performance: Response time < 500ms
+- Security: RBAC-protected endpoints
+
+### Risks
+- Risk 1: Dependency timing
+- Risk 2: Schema compatibility
+"""
+
+GOOD_STRAT_GWT = """## Strategy
+
+### Technical Approach
+Add `POST /api/v1/models` endpoint to create new models in the catalog. The BFF will
+validate input, call the model-registry API, and return the created model resource.
+Error handling includes validation errors (400), conflicts (409), and backend failures (503).
+
+### Acceptance Criteria
+- Given a user has catalog:write permissions, when they POST to `/api/v1/models` with valid model data, then a new model is created in the registry, measured by the model appearing in GET `/api/v1/models` response within 100ms.
+- Given a user POSTs invalid model data (missing required fields), when the API validates the request, then a 400 error is returned with field-specific error messages, measured by the response containing validation errors for each missing field.
+- Given a model with the same name already exists, when a user POSTs a duplicate, then a 409 Conflict error is returned, measured by the error message indicating the conflicting model name.
+
+### Dependencies
+- model-registry v1.5.0+ (for external model support)
+- PostgreSQL 13+
+- OpenShift 4.14+
+
+### Non-Functional Requirements
+- Performance: p95 latency <200ms for model creation
+- Security: All operations require catalog:write RBAC permission
+- Backwards Compatibility: Existing GET endpoints unchanged
+
+### Risks
+- Risk: model-registry latency spikes under load
+- Risk: Concurrent creation of same model name
+"""
+
+POOR_STRAT = """## Strategy
+
+### Technical Approach
+We will add an API for model management. The system will be performant and reliable.
+
+### Acceptance Criteria
+- Users can manage models easily
+- The system works well
+- Good UX
+
+### Dependencies
+- Some components TBD
+
+### Non-Functional Requirements
+- Should be fast
+- Should be secure
+"""
+
+OPERATOR_STRAT = """## Strategy
+
+### Technical Approach
+Implement MaaSModelRef controller that reconciles ExternalModel provider types. When a
+MaaSModelRef CR is created with `.spec.externalModel`, the controller provisions an
+Istio VirtualService for egress routing.
+
+### Acceptance Criteria
+- Given a platform admin creates a MaaSModelRef CR with `.spec.externalModel.provider=openai`, when the controller reconciles, then an Istio VirtualService is created with routing to api.openai.com, measured by `kubectl get virtualservice` showing the resource.
+
+### Dependencies
+- Istio 1.20+
+- MaaSModelRef CRD v1alpha1
+
+### Non-Functional Requirements
+- Performance: Reconciliation completes within 5s
+
+### Risks
+- Risk: Concurrent reconciliation race conditions
+"""
+
+
+# ── Section Detection ─────────────────────────────────────────────────────────
+
+
+class TestSectionDetection:
+    def test_all_sections_present(self):
+        validator = StratStructuralValidator(MINIMAL_STRAT)
+        result = validator.validate()
+
+        assert result.has_acceptance_criteria
+        assert result.has_technical_approach
+        assert result.has_dependencies
+        assert result.has_nfrs
+        assert result.has_risks
+
+    def test_missing_acceptance_criteria(self):
+        strat = """### Technical Approach
+Content here.
+"""
+        validator = StratStructuralValidator(strat)
+        result = validator.validate()
+
+        assert not result.has_acceptance_criteria
+        assert any("CRITICAL: Missing Acceptance Criteria" in w for w in result.warnings)
+
+    def test_missing_technical_approach(self):
+        strat = """### Acceptance Criteria
+- [ ] Something
+"""
+        validator = StratStructuralValidator(strat)
+        result = validator.validate()
+
+        assert not result.has_technical_approach
+        assert any("CRITICAL: Missing Technical Approach" in w for w in result.warnings)
+
+
+# ── Acceptance Criteria Format ────────────────────────────────────────────────
+
+
+class TestAcceptanceCriteriaFormat:
+    def test_given_when_then_format(self):
+        validator = StratStructuralValidator(GOOD_STRAT_GWT)
+        result = validator.validate()
+
+        assert result.acceptance_criteria_format == "given-when-then"
+        assert result.acceptance_criteria_count == 3
+
+    def test_checkbox_format(self):
+        validator = StratStructuralValidator(MINIMAL_STRAT)
+        result = validator.validate()
+
+        assert result.acceptance_criteria_format == "checkbox"
+        assert result.acceptance_criteria_count == 3
+
+    def test_missing_acceptance_criteria(self):
+        strat = """### Technical Approach
+Content.
+"""
+        validator = StratStructuralValidator(strat)
+        result = validator.validate()
+
+        assert result.acceptance_criteria_format == "none"
+        assert result.acceptance_criteria_count == 0
+
+
+# ── Quality Indicators ────────────────────────────────────────────────────────
+
+
+class TestQualityIndicators:
+    def test_tbd_counting(self):
+        strat = """### Technical Approach
+TBD - will add later. This is TBD. Pending details. To be determined.
+TBD on approach.
+"""
+        validator = StratStructuralValidator(strat)
+        result = validator.validate()
+
+        assert result.tbd_count >= 4
+        assert any("High number of TBD markers" in w for w in result.warnings)
+
+    def test_error_case_detection(self):
+        validator = StratStructuralValidator(GOOD_STRAT_GWT)
+        result = validator.validate()
+
+        # "400 error", "409 Conflict error", "validation errors", "fail"
+        assert result.error_case_mentions >= 4
+
+    def test_edge_case_detection(self):
+        validator = StratStructuralValidator(GOOD_STRAT_GWT)
+        result = validator.validate()
+
+        # "concurrent"
+        assert result.edge_case_mentions >= 1
+
+    def test_version_detection(self):
+        validator = StratStructuralValidator(GOOD_STRAT_GWT)
+        result = validator.validate()
+
+        # "v1.5.0+", "13+", "4.14+"
+        assert result.version_specifications >= 3
+
+
+# ── Interaction Type Detection ────────────────────────────────────────────────
+
+
+class TestInteractionDetection:
+    def test_rest_api_detection(self):
+        validator = StratStructuralValidator(GOOD_STRAT_GWT)
+        result = validator.validate()
+
+        assert 'REST_API' in result.detected_interaction_types
+        assert result.concrete_interactions_count >= 2  # POST, GET
+
+    def test_ui_detection(self):
+        strat = """### Acceptance Criteria
+- User clicks the "Create Model" button on the dashboard
+- User fills in the form and submits
+"""
+        validator = StratStructuralValidator(strat)
+        result = validator.validate()
+
+        assert 'UI' in result.detected_interaction_types
+
+    def test_cli_detection(self):
+        strat = """### Acceptance Criteria
+- Run `kubectl apply -f model.yaml`
+- Run `oc create -f resource.yaml`
+"""
+        validator = StratStructuralValidator(strat)
+        result = validator.validate()
+
+        assert 'CLI' in result.detected_interaction_types
+        assert result.concrete_interactions_count >= 2
+
+    def test_crd_operator_detection(self):
+        validator = StratStructuralValidator(OPERATOR_STRAT)
+        result = validator.validate()
+
+        assert 'CRD' in result.detected_interaction_types
+        assert 'OPERATOR' in result.detected_interaction_types
+        assert 'CLI' in result.detected_interaction_types  # kubectl get
+
+    def test_no_interactions_warning(self):
+        strat = """### Technical Approach
+We will improve the system.
+
+### Acceptance Criteria
+- System works well
+"""
+        validator = StratStructuralValidator(strat)
+        result = validator.validate()
+
+        assert not result.detected_interaction_types
+        assert any("No concrete interaction mechanisms detected" in w for w in result.warnings)
+
+
+# ── Structural Score ──────────────────────────────────────────────────────────
+
+
+class TestStructuralScore:
+    def test_good_strat_high_score(self):
+        validator = StratStructuralValidator(GOOD_STRAT_GWT)
+        result = validator.validate()
+
+        assert result.structural_score >= 8
+
+    def test_poor_strat_low_score(self):
+        validator = StratStructuralValidator(POOR_STRAT)
+        result = validator.validate()
+
+        assert result.structural_score <= 5
+
+    def test_minimal_strat_mid_score(self):
+        validator = StratStructuralValidator(MINIMAL_STRAT)
+        result = validator.validate()
+
+        assert 4 <= result.structural_score <= 7
+
+    def test_empty_strat_zero_score(self):
+        validator = StratStructuralValidator("")
+        result = validator.validate()
+
+        assert result.structural_score == 0
+
+
+# ── Warnings ──────────────────────────────────────────────────────────────────
+
+
+class TestWarnings:
+    def test_short_technical_approach_warning(self):
+        strat = """### Technical Approach
+Add API.
+
+### Acceptance Criteria
+- [ ] API works
+"""
+        validator = StratStructuralValidator(strat)
+        result = validator.validate()
+
+        assert any("Technical Approach is very short" in w for w in result.warnings)
+
+    def test_dependencies_without_versions(self):
+        strat = """### Dependencies
+- model-registry
+- PostgreSQL
+- OpenShift
+"""
+        validator = StratStructuralValidator(strat)
+        result = validator.validate()
+
+        assert result.dependency_count == 3
+        assert not result.dependencies_have_versions
+        assert any("no version requirements specified" in w for w in result.warnings)
+
+    def test_no_error_cases_warning(self):
+        strat = """### Technical Approach
+Add endpoint for model creation.
+
+### Acceptance Criteria
+- [ ] Models can be created successfully
+"""
+        validator = StratStructuralValidator(strat)
+        result = validator.validate()
+
+        assert result.error_case_mentions == 0
+        assert any("No error cases mentioned" in w for w in result.warnings)
+
+    def test_good_strat_no_critical_warnings(self):
+        validator = StratStructuralValidator(GOOD_STRAT_GWT)
+        result = validator.validate()
+
+        critical_warnings = [w for w in result.warnings if "CRITICAL" in w]
+        assert not critical_warnings
+
+
+# ── Edge Cases ────────────────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_empty_content(self):
+        validator = StratStructuralValidator("")
+        result = validator.validate()
+
+        assert result.structural_score == 0
+        assert len(result.warnings) >= 2
+
+    def test_only_headers_no_content(self):
+        strat = """### Technical Approach
+
+### Acceptance Criteria
+
+### Dependencies
+"""
+        validator = StratStructuralValidator(strat)
+        result = validator.validate()
+
+        assert result.has_technical_approach
+        assert result.has_acceptance_criteria
+        assert result.has_dependencies
+        assert result.technical_approach_word_count == 0
+        assert result.acceptance_criteria_count == 0
+
+
+# ── Integration ───────────────────────────────────────────────────────────────
+
+
+class TestRealWorldExample:
+    def test_rhaistrat_1431_style(self):
+        """Test with RHAISTRAT-1431 style content"""
+        # Simplified RHAISTRAT-1431
+        strat = """## Strategy
+
+### Technical Approach
+Deliver a dashboard UI within the existing maas-ui Module Federation plugin for full
+MaaSModelRef lifecycle management. The BFF already implements CRUD endpoints at
+`/api/v1/maasmodel`. Primary work is building frontend views and extending BFF request
+models for ExternalModel fields.
+
+### Acceptance Criteria
+- Given a platform admin is on the AI Hub Models page, when they click the MaaS Model Refs tab, then all MaaSModelRef resources in the selected namespace are listed, measured by the list rendering within 2s for up to 200 resources.
+- Given a platform admin clicks "Register model ref" and selects Internal type, when they pick an existing LLMInferenceService from the dropdown and submit, then a MaaSModelRef CR is created, measured by `kubectl get maasmodelref` output.
+
+### Dependencies
+- RHAISTRAT-1295 (External Model Egress)
+- MaaSModelRef CRD schema
+- maas-api v2.0+
+
+### Non-Functional Requirements
+- Performance: List view < 2s for 200 resources
+- Security: Secret values never returned to UI
+
+### Risks
+- Risk: Delivery timing dependency
+"""
+        validator = StratStructuralValidator(strat)
+        result = validator.validate()
+
+        # Should have all sections
+        assert result.has_acceptance_criteria
+        assert result.has_technical_approach
+        assert result.has_dependencies
+
+        # Should detect Given-When-Then format
+        assert result.acceptance_criteria_format == "given-when-then"
+        assert result.acceptance_criteria_count == 2
+
+        # Should detect multiple interaction types
+        assert 'UI' in result.detected_interaction_types
+        assert 'CRD' in result.detected_interaction_types
+        assert 'CLI' in result.detected_interaction_types  # kubectl
+        assert 'REST_API' in result.detected_interaction_types  # /api/v1/maasmodel
+
+        # Should have concrete examples
+        assert result.concrete_interactions_count >= 2  # /api/v1/maasmodel, kubectl
+
+        # Should detect versions
+        assert result.version_specifications >= 1  # v2.0+
+
+        # Should have good score
+        assert result.structural_score >= 7
+
+        # Should have no critical warnings
+        critical = [w for w in result.warnings if 'CRITICAL' in w]
+        assert not critical


### PR DESCRIPTION
Add script for deterministic validation before LLM semantic review to assess STRAT compatibility with test-plan-create analyzers.

Includes test-plan-compatibility.md checklist with 9 checks across 3 analyzers (Interaction, Risks, Infra) and readiness scoring (Ready/Needs improvement/Not ready).

Integrates validation into strat.review orchestrator (Step 2.5) and testability-review fork to provide targeted semantic assessment.