### PR TITLE
Atomic label swap to fix Jira persistence race

### DIFF
--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -179,6 +179,18 @@ def remove_labels(server, user, token, issue_key, labels):
     api_call_with_retry(server, path, user, token, body=body, method="PUT")
 
 
+def swap_labels(server, user, token, issue_key, add, remove):
+    """Atomically add and remove labels in a single PUT to avoid race conditions."""
+    ops = [{"add": label} for label in add] + [{"remove": label} for label in remove]
+    body = {
+        "update": {
+            "labels": ops
+        }
+    }
+    path = f"/issue/{issue_key}"
+    api_call_with_retry(server, path, user, token, body=body, method="PUT")
+
+
 def create_issue_link(server, user, token, type_name, inward_key, outward_key):
     """POST /rest/api/3/issueLink"""
     body = {

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -36,6 +36,7 @@ from jira_utils import (
     update_issue,
     add_labels,
     remove_labels,
+    swap_labels,
     add_comment,
     get_issue,
     transition_issue,
@@ -622,13 +623,14 @@ def main():
                         print(f"  {rfe_id}: Would add labels: "
                               f"{', '.join(labels)}")
                 else:
-                    if remove:
-                        remove_labels(server, user, token, rfe_id, remove)
-                        print(f"  {rfe_id}: Removed labels: "
-                              f"{', '.join(remove)}")
-                    if labels:
-                        add_labels(server, user, token, rfe_id, labels)
-                        print(f"  {rfe_id}: Labels: {', '.join(labels)}")
+                    if remove or labels:
+                        swap_labels(server, user, token, rfe_id,
+                                    labels, remove)
+                        if remove:
+                            print(f"  {rfe_id}: Removed labels: "
+                                  f"{', '.join(remove)}")
+                        if labels:
+                            print(f"  {rfe_id}: Labels: {', '.join(labels)}")
                     update_frontmatter(entry["task_path"],
                                        {"status": "Submitted"},
                                        "rfe-task")
@@ -660,12 +662,13 @@ def main():
                     update_issue(server, user, token, rfe_id, title,
                                  description_adf)
                     print(f"  {rfe_id}: Updated")
-                    if remove:
-                        remove_labels(server, user, token, rfe_id, remove)
-                        print(f"           Removed: {', '.join(remove)}")
-                    if labels:
-                        add_labels(server, user, token, rfe_id, labels)
-                        print(f"           Labels: {', '.join(labels)}")
+                    if remove or labels:
+                        swap_labels(server, user, token, rfe_id,
+                                    labels, remove)
+                        if remove:
+                            print(f"           Removed: {', '.join(remove)}")
+                        if labels:
+                            print(f"           Labels: {', '.join(labels)}")
                     submitted_hashes[rfe_id] = compute_content_hash(
                         description_adf)
                     update_frontmatter(entry["task_path"],

--- a/tests/test_jira_utils_labels.py
+++ b/tests/test_jira_utils_labels.py
@@ -1,0 +1,77 @@
+"""Tests for label operations in jira_utils — add, remove, swap."""
+import json
+from unittest.mock import patch, MagicMock
+
+from scripts.jira_utils import add_labels, remove_labels, swap_labels
+
+SERVER = "https://jira.example.com"
+USER = "u"
+TOKEN = "t"
+KEY = "PROJ-1"
+
+
+def _capture_body(func, *args, **kwargs):
+    """Call a label function and return the JSON body sent to api_call_with_retry."""
+    with patch("scripts.jira_utils.api_call_with_retry") as mock:
+        func(SERVER, USER, TOKEN, KEY, *args, **kwargs)
+        mock.assert_called_once()
+        return mock.call_args
+
+
+class TestAddLabels:
+    def test_body_structure(self):
+        call = _capture_body(add_labels, ["alpha", "beta"])
+        body = call.kwargs.get("body") or call[0][4]
+        assert body == {
+            "update": {
+                "labels": [{"add": "alpha"}, {"add": "beta"}]
+            }
+        }
+
+    def test_uses_put(self):
+        call = _capture_body(add_labels, ["x"])
+        method = call.kwargs.get("method") or call[0][5]
+        assert method == "PUT"
+
+
+class TestRemoveLabels:
+    def test_body_structure(self):
+        call = _capture_body(remove_labels, ["old"])
+        body = call.kwargs.get("body") or call[0][4]
+        assert body == {
+            "update": {
+                "labels": [{"remove": "old"}]
+            }
+        }
+
+
+class TestSwapLabels:
+    def test_body_combines_add_and_remove(self):
+        call = _capture_body(swap_labels, ["new-a", "new-b"], ["old-x"])
+        body = call.kwargs.get("body") or call[0][4]
+        assert body == {
+            "update": {
+                "labels": [
+                    {"add": "new-a"},
+                    {"add": "new-b"},
+                    {"remove": "old-x"},
+                ]
+            }
+        }
+
+    def test_add_only(self):
+        call = _capture_body(swap_labels, ["only-add"], [])
+        ops = (call.kwargs.get("body") or call[0][4])["update"]["labels"]
+        assert ops == [{"add": "only-add"}]
+
+    def test_remove_only(self):
+        call = _capture_body(swap_labels, [], ["only-rm"])
+        ops = (call.kwargs.get("body") or call[0][4])["update"]["labels"]
+        assert ops == [{"remove": "only-rm"}]
+
+    def test_uses_put_on_issue_path(self):
+        call = _capture_body(swap_labels, ["a"], ["b"])
+        path = call[0][1]
+        method = call.kwargs.get("method") or call[0][5]
+        assert path == f"/issue/{KEY}"
+        assert method == "PUT"


### PR DESCRIPTION
## Summary
- Adds `swap_labels()` to `jira_utils.py` — combines add and remove label ops into a single atomic PUT request
- Replaces two back-to-back `remove_labels()`/`add_labels()` call sites in `submit.py` ("Label only" and "Update existing" branches) with `swap_labels()`
- Adds unit tests for `swap_labels`, `add_labels`, and `remove_labels` body structure

## Motivation
Back-to-back label API calls race against Jira's persistence. When a remove and add land at the same timestamp, the server may not have committed the first before processing the second — causing stale labels to reappear. 
Observed in production, for example:

<img width="1039" height="504" alt="Screenshot 2026-05-18 at 14 23 05" src="https://github.com/user-attachments/assets/a0065b56-97a2-49af-a66a-78466ef3e564" />

here I want to Add label `-invoked` and remove label `-start`

1. at first the Add label works,
2. but the Remove label seems to act on a stale status

fixed with:

https://github.com/tarilabs/doc-creator/commit/b8f072665b9a09c42607d383b262a8d6d0f07c56

and added as well jira-emulator with

https://github.com/tarilabs/doc-creator/commit/4d8dfb35b1851d9a15195df59a467a8de784a4e5

## Test plan
- [x] `pytest tests/test_jira_utils_labels.py` — 7 tests covering body structure, HTTP method, and edge cases (add-only, remove-only)
- [x] `pytest tests/test_submit.py` — all 41 existing unit tests pass