### PR TITLE
Add architecture context overlay support to review skills

### DIFF
--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -24,6 +24,19 @@ If architecture context is not available, skip this review and output:
 Architecture review skipped — no architecture context available.
 ```
 
+## Architecture Context Overlays
+
+Check for overlay files in `.context/architecture-context/overlays/`. If the directory exists, read all `*.md` files (excluding `README.md`) with `status: active` in their frontmatter. These are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+
+When reviewing a strategy's architecture claims, check whether any active overlay corrects or updates the information the strategy references. If a strategy uses outdated information that an overlay corrects (e.g., references KFP SDK 2.15 when an overlay says 2.16), flag it as a finding. Overlays take precedence over the generated architecture docs when they conflict.
+
+When overlays are applied, print which ones were used:
+
+```
+Overlays applied:
+- 0001: KFP SDK updated to 2.16 in RHOAI 3.4
+```
+
 ## What to Assess
 
 For each strategy:

--- a/.claude/skills/feasibility-review/SKILL.md
+++ b/.claude/skills/feasibility-review/SKILL.md
@@ -19,6 +19,26 @@ If `artifacts/strat-reviews/` exists and contains review files for the strategie
 
 Check for architecture context in `.context/architecture-context/architecture/`. If a `rhoai-*` directory exists, read `PLATFORM.md` and relevant component docs to ground your assessment.
 
+## Architecture Context Overlays
+
+Check for overlay files in `.context/architecture-context/overlays/`. If the directory exists, read all `*.md` files (excluding `README.md`) with `status: active` in their frontmatter. These are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+
+Filter for relevant overlays:
+1. **Status**: `status` must be `active` (ignore `superseded`)
+2. **Release**: `release` list must contain the target RHOAI release or `"all"`
+3. **Component match**: `affects` list must intersect with the components the strategy touches. Overlays with `affects: [platform]` match all strategies.
+
+For each matched overlay, read its `## Fact` and `## Impact on Strategies` sections. Use these to correct or supplement the architecture docs when assessing feasibility. Overlays take precedence over the generated architecture docs when they conflict.
+
+When overlays are applied, print which ones were used:
+
+```
+Overlays applied:
+- 0001: KFP SDK updated to 2.16 in RHOAI 3.4
+```
+
+If no overlays directory exists or no overlays match, proceed without them.
+
 ## What to Assess
 
 For each strategy:

--- a/.claude/skills/rfe-feasibility-review/SKILL.md
+++ b/.claude/skills/rfe-feasibility-review/SKILL.md
@@ -24,6 +24,26 @@ Check for architecture context in `.context/architecture-context/architecture/`.
 
 If no architecture context is available (directory missing or empty), assess feasibility based on the RFE content alone and note that architecture context was not available.
 
+## Architecture Context Overlays
+
+Check for overlay files in `.context/architecture-context/overlays/`. If the directory exists, read all `*.md` files (excluding `README.md`) with `status: active` in their frontmatter. These are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+
+Filter for relevant overlays:
+1. **Status**: `status` must be `active` (ignore `superseded`)
+2. **Release**: `release` list must contain the target RHOAI release or `"all"`
+3. **Component match**: `affects` list must intersect with the components the RFE touches. Overlays with `affects: [platform]` match all RFEs.
+
+For each matched overlay, read its `## Fact` and `## Impact on Strategies` sections. Use these to correct or supplement the architecture docs when assessing feasibility. Overlays take precedence over the generated architecture docs when they conflict.
+
+When overlays are applied, print which ones were used:
+
+```
+Overlays applied:
+- 0001: KFP SDK updated to 2.16 in RHOAI 3.4
+```
+
+If no overlays directory exists or no overlays match, proceed without them.
+
 ## Prior Review
 
 If `artifacts/rfe-review-report.md` exists, read it. This is a re-review after revisions. For each RFE:

--- a/scripts/fetch-architecture-context.sh
+++ b/scripts/fetch-architecture-context.sh
@@ -17,11 +17,11 @@ if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
 fi
 
 if [ -d "$CONTEXT_DIR" ]; then
-  git -C "$CONTEXT_DIR" sparse-checkout set "architecture/$LATEST"
+  git -C "$CONTEXT_DIR" sparse-checkout set "architecture/$LATEST" "overlays"
   git -C "$CONTEXT_DIR" pull --quiet
 else
   git clone --depth 1 --filter=blob:none --sparse https://github.com/opendatahub-io/architecture-context "$CONTEXT_DIR"
-  git -C "$CONTEXT_DIR" sparse-checkout set "architecture/$LATEST"
+  git -C "$CONTEXT_DIR" sparse-checkout set "architecture/$LATEST" "overlays"
 fi
 
 echo "Architecture context ready: $CONTEXT_DIR/architecture/$LATEST"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIFIRST-29

Fetch overlays/ directory in sparse checkout and add overlay awareness to rfe-feasibility-review, feasibility-review, and architecture-review skills so they read and apply human-authored corrections from the architecture-context overlays when assessing feasibility.