### PR TITLE
Update assess-rfe bootstrap to use opendatahub-io org

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ All artifacts are written to `artifacts/`. You can edit any file between steps:
 
 ## assess-rfe Integration
 
-Skills automatically bootstrap the [assess-rfe](https://github.com/n1hility/assess-rfe) plugin from GitHub on first use:
+Skills automatically bootstrap the [assess-rfe](https://github.com/opendatahub-io/assess-rfe) plugin from GitHub on first use:
 
 - **During creation**: The rubric is exported to `artifacts/rfe-rubric.md` and used to guide clarifying questions.
 - **During review**: `/rfe.review` invokes assess-rfe for rubric scoring.

--- a/scripts/bootstrap-assess-rfe.sh
+++ b/scripts/bootstrap-assess-rfe.sh
@@ -11,7 +11,7 @@ CONTEXT_DIR=".context/assess-rfe"
 RUBRIC_FILE="$CONTEXT_DIR/scripts/agent_prompt.md"
 
 if [ ! -d "$CONTEXT_DIR" ]; then
-  git clone https://github.com/n1hility/assess-rfe "$CONTEXT_DIR" 2>&1
+  git clone https://github.com/opendatahub-io/assess-rfe "$CONTEXT_DIR" 2>&1
 else
   git -C "$CONTEXT_DIR" pull --ff-only 2>&1 || echo "WARN: assess-rfe pull failed, using cached version" >&2
 fi


### PR DESCRIPTION
## Summary
- Update the `git clone` URL in `scripts/bootstrap-assess-rfe.sh` from `n1hility/assess-rfe` to `opendatahub-io/assess-rfe`
- Update the corresponding link in `README.md`
- Tested locally — bootstrap clones from the new org successfully

## Test plan
- [x] Ran `/rfe-creator.update-deps` to verify fresh clone from `opendatahub-io/assess-rfe` succeeds
- [x] Skills and rubric installed correctly after bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated assess-rfe integration documentation

* **Chores**
  * Updated assess-rfe plugin bootstrap to source from new repository location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->