### PR TITLE
Fix lint-review workflow by using skillsaw GitHub Action

### DIFF
--- a/.github/workflows/lint-review.yml
+++ b/.github/workflows/lint-review.yml
@@ -16,4 +16,4 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Post skillsaw review comments
-      uses: stbenjam/skillsaw/review@d252498eb6260e197c9c395a650643d9c49ae37b # v0
+      uses: stbenjam/skillsaw/review@c2592a0fe1a86345da838fa16fcda6b55f495178 # v0.11.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+    - name: Run skillsaw
+      uses: stbenjam/skillsaw@d252498eb6260e197c9c395a650643d9c49ae37b # v0
+      with:
+        strict: 'true'
+
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
@@ -27,10 +32,17 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ruff skillsaw
+        pip install ruff
         pip install -r requirements-dev.txt
 
-    - name: Run lint
-      run: make lint
-      env:
-        SKILLSAW_BIN: skillsaw
+    - name: Run ruff check
+      run: ruff check .
+
+    - name: Run ruff format check
+      run: ruff format --check --diff .
+
+    - name: Run shellcheck
+      run: find . -name '*.sh' -type f -exec shellcheck {} +
+
+    - name: Run tests
+      run: python3 -m pytest tests/ -v -k "not integration"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Run skillsaw
-      uses: stbenjam/skillsaw@d252498eb6260e197c9c395a650643d9c49ae37b # v0
+      uses: stbenjam/skillsaw@c2592a0fe1a86345da838fa16fcda6b55f495178 # v0.11.2
       with:
         strict: 'true'
 


### PR DESCRIPTION
## Summary
- Use the `stbenjam/skillsaw` GitHub Action in `lint.yml` instead of running skillsaw through `make lint`. The action handles JSON report generation and artifact upload (`skillsaw-report` + `skillsaw-pr-metadata`), which the `lint-review.yml` workflow needs to post inline PR comments.
- Break out ruff, shellcheck, and pytest as individual workflow steps since they no longer run through the Makefile.
- Update skillsaw GitHub Action to v0.11.2 in both `lint.yml` and `lint-review.yml`.

## Test plan
- [ ] CI lint workflow uploads `skillsaw-report` artifact on PR runs
- [ ] CI lint-review workflow successfully downloads artifact and posts comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)