### PR TITLE
fix: avoid headless permission denials from chained/substituted Bash

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -79,6 +79,8 @@ python3 scripts/pipeline_state.py set-phase BATCH_START
 
 **CRITICAL: You MUST run the loop to completion.** Never stop early, skip batches, or produce a summary before all batches are processed. Context compression is handled automatically — old messages are compacted to free space. Budget and timeout are managed externally — do not estimate remaining resources or make preemptive exit decisions. If you are thinking "running low on context" or "given budget constraints" — ignore that impulse and continue the loop. The pipeline MUST reach phase `DONE` naturally.
 
+**Bash discipline:** Issue exactly one operation per Bash call. Never use command substitution `$(...)` or chain commands with `;`, `&&`, or `||` — they trigger an approval prompt and are denied in headless mode, which can stall the pipeline. Instead, pass a value between commands by writing it to a `tmp/` file with `scripts/state.py` and reading it back in a separate call.
+
 Repeat until phase is `DONE`:
 
 ### Step 1: Get next action
@@ -133,7 +135,7 @@ agents:
 After phase reaches `DONE`:
 
 ```bash
-python3 scripts/batch_summary.py --counts-only $(python3 scripts/state.py read-ids tmp/pipeline-all-ids.txt)
+python3 scripts/batch_summary.py --counts-only --ids-file tmp/pipeline-all-ids.txt
 ```
 
 $ARGUMENTS

--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -164,7 +164,7 @@ Sleep for the `NEXT_POLL` seconds reported by the script before polling again. W
 **Post-processing: fix auto_revised flag.** The revise agent may run out of budget before setting `auto_revised=true`. After all agents complete, run the batch check which compares originals to task files and sets the flag directly in review frontmatter:
 
 ```bash
-python3 scripts/check_revised.py --batch $(python3 scripts/state.py read-ids tmp/rfe-poll-revise.txt)
+python3 scripts/check_revised.py --batch --ids-file tmp/rfe-poll-revise.txt
 ```
 
 ## Review Step 4: Re-assess if Revised (max 2 cycles)
@@ -178,7 +178,7 @@ python3 scripts/state.py read-ids tmp/review-all-ids.txt
 After all revise agents complete, check which IDs need re-assessment:
 
 ```bash
-python3 scripts/collect_recommendations.py --reassess $(python3 scripts/state.py read-ids tmp/review-all-ids.txt)
+python3 scripts/collect_recommendations.py --reassess --ids-file tmp/review-all-ids.txt
 ```
 
 Parse output for `REASSESS=` line. For each ID needing re-assessment (auto_revised=true, pass=false), initialize the cycle counter on disk (set-default is safe if compression causes re-entry — it won't reset an existing counter):
@@ -232,7 +232,7 @@ Launch all assess agents in parallel.
 Re-read reassess IDs from disk, write poll file, and poll using `NEXT_POLL` interval:
 
 ```bash
-python3 scripts/state.py write-ids tmp/rfe-poll-reassess-assess.txt $(python3 scripts/state.py read-ids tmp/review-reassess-ids.txt)
+python3 scripts/state.py copy-ids tmp/review-reassess-ids.txt tmp/rfe-poll-reassess-assess.txt
 python3 scripts/check_review_progress.py --phase assess --id-file tmp/rfe-poll-reassess-assess.txt
 ```
 
@@ -255,7 +255,7 @@ Launch all review agents in parallel.
 Re-read reassess IDs from disk, write poll file, and poll using `NEXT_POLL` interval:
 
 ```bash
-python3 scripts/state.py write-ids tmp/rfe-poll-reassess-review.txt $(python3 scripts/state.py read-ids tmp/review-reassess-ids.txt)
+python3 scripts/state.py copy-ids tmp/review-reassess-ids.txt tmp/rfe-poll-reassess-review.txt
 python3 scripts/check_review_progress.py --phase review --id-file tmp/rfe-poll-reassess-review.txt
 ```
 
@@ -280,7 +280,7 @@ python3 scripts/filter_for_revision.py <all_reassess_IDs_from_file>
 Launch revise agents for the IDs returned (if any). Wait for all to complete, then run the batch auto_revised flag fix:
 
 ```bash
-python3 scripts/check_revised.py --batch $(python3 scripts/state.py read-ids tmp/review-reassess-ids.txt)
+python3 scripts/check_revised.py --batch --ids-file tmp/review-reassess-ids.txt
 ```
 
 After cycle 2, stop regardless of results.
@@ -315,7 +315,7 @@ Do not summarize or stop.
 **If interactive (no `--headless`)**: Re-read ID list and present summary:
 
 ```bash
-python3 scripts/batch_summary.py $(python3 scripts/state.py read-ids tmp/review-all-ids.txt)
+python3 scripts/batch_summary.py --ids-file tmp/review-all-ids.txt
 ```
 
 Based on the output:

--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -55,8 +55,7 @@ When the user doesn't specify, use these defaults:
 Count entries and pre-allocate all IDs upfront:
 
 ```bash
-N=$(python3 -c "import yaml; print(len(yaml.safe_load(open('batch.yaml'))))")
-python3 scripts/next_rfe_id.py $N   # prints RFE-001 through RFE-<N>
+python3 scripts/next_rfe_id.py --from-batch <input_file>   # input_file = the --input path; prints one RFE ID per entry
 ```
 
 For each entry, launch an Agent to invoke `/rfe.create`. Pass the pre-assigned ID so each Agent knows which ID to use:
@@ -104,6 +103,8 @@ Build the auto-fix command using flags from the config file:
 Pass `--headless` and `--announce-complete` through if set in the config. **Always** pass `--batch-size <batch_size>` using the value from `tmp/speedrun-config.yaml` — never omit it, never let auto-fix's own default take over. The speedrun default (5) was already pinned in Step 0; relying on it here is what makes runs reproducible.
 
 Auto-fix handles: assessment, feasibility checks, review, auto-revision, re-assessment, splitting oversized RFEs, retry queue, and report generation. Wait for it to complete. **Do NOT stop, summarize, or skip remaining batches early** — the pipeline must process every ID through all phases. Never emit a text-only response (no tool call) during pipeline execution — this terminates the CI process.
+
+**Bash discipline:** Issue exactly one operation per Bash call. Never use command substitution `$(...)` or chain commands with `;`, `&&`, or `||` — they trigger an approval prompt and are denied in headless mode. Instead, pass a value between commands by writing it to a `tmp/` file with `scripts/state.py` and reading it back in a separate call.
 
 After auto-fix returns, verify all RFEs were processed:
 

--- a/.claude/skills/rfe.split/SKILL.md
+++ b/.claude/skills/rfe.split/SKILL.md
@@ -103,7 +103,7 @@ python3 scripts/state.py read tmp/split-config.yaml
 If `correction_cycle` is 1 or higher, stop and report remaining right-sizing concerns. Otherwise, re-derive child IDs:
 
 ```bash
-python3 scripts/collect_children.py $(python3 scripts/state.py read-ids tmp/split-all-ids.txt)
+python3 scripts/collect_children.py --ids-file tmp/split-all-ids.txt
 ```
 
 Check right-sized scores. For each child:

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -12,6 +12,40 @@ import sys
 
 import yaml
 
+
+def read_ids_file(path):
+    """Read RFE IDs from a file (one per line), deduped, order-preserved.
+
+    Mirrors the format written by `state.py write-ids`. Lets scripts accept
+    an --ids-file argument instead of forcing skills to use $(...) command
+    substitution, which triggers headless permission denials.
+    """
+    if not os.path.isfile(path):
+        print(
+            f"IDs file not found: {path} — was it persisted in a prior step?",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    try:
+        with open(path) as f:
+            ids = [line.strip() for line in f if line.strip()]
+    except OSError as e:
+        print(f"Could not read IDs file {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+    return list(dict.fromkeys(ids))
+
+
+def resolve_ids(positional, ids_file):
+    """Combine positional IDs with --ids-file IDs, deduped, order-preserved.
+
+    Positional IDs come first so explicit args take precedence in ordering.
+    """
+    combined = list(positional or [])
+    if ids_file:
+        combined.extend(read_ids_file(ids_file))
+    return list(dict.fromkeys(combined))
+
+
 # ─── Schema Definitions ────────────────────────────────────────────────────────
 
 # Each schema is a dict of field_name -> field_spec.

--- a/scripts/batch_summary.py
+++ b/scripts/batch_summary.py
@@ -7,26 +7,33 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from artifact_utils import read_frontmatter
+from artifact_utils import read_frontmatter, resolve_ids
 
 
 def main():
     parser = argparse.ArgumentParser(
         description="Aggregate RFE review results for batch summaries."
     )
-    parser.add_argument("ids", nargs="+", help="RFE IDs (e.g. RHAIRFE-100)")
+    parser.add_argument("ids", nargs="*", help="RFE IDs (e.g. RHAIRFE-100)")
+    parser.add_argument(
+        "--ids-file", help="Read RFE IDs from a file (one per line) instead of positional args"
+    )
     parser.add_argument(
         "--counts-only", action="store_true", help="Print only the counts line, no per-ID details"
     )
     args = parser.parse_args()
 
+    ids = resolve_ids(args.ids, args.ids_file)
+    if not ids:
+        parser.error("no RFE IDs provided (pass positionally or via --ids-file)")
+
     artifacts_dir = os.path.join(os.getcwd(), "artifacts")
     reviews_dir = os.path.join(artifacts_dir, "rfe-reviews")
 
     # Expand to include split children
-    all_ids = list(args.ids)
+    all_ids = list(ids)
     id_set = set(all_ids)
-    for rfe_id in args.ids:
+    for rfe_id in ids:
         task_path = os.path.join(artifacts_dir, "rfe-tasks", f"{rfe_id}.md")
         try:
             data, _ = read_frontmatter(task_path)

--- a/scripts/check_revised.py
+++ b/scripts/check_revised.py
@@ -18,7 +18,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from artifact_utils import find_review_file, read_frontmatter, update_frontmatter
+from artifact_utils import find_review_file, read_frontmatter, read_ids_file, update_frontmatter
 
 
 def strip_frontmatter(text):
@@ -77,10 +77,38 @@ def batch_mode(ids, artifacts_dir="artifacts"):
     print(f"UPDATED={changed}")
 
 
+def _extract_ids_file(argv):
+    """Pull an --ids-file <path> pair (or --ids-file=<path>) out of argv.
+
+    Returns (remaining_argv, ids_from_file). Lets --batch read IDs from a
+    file instead of forcing the skill to use $(...) command substitution.
+    """
+    remaining = []
+    ids = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--ids-file":
+            if i + 1 >= len(argv):
+                print("Error: --ids-file requires a path argument", file=sys.stderr)
+                sys.exit(2)
+            ids.extend(read_ids_file(argv[i + 1]))
+            i += 2
+            continue
+        if arg.startswith("--ids-file="):
+            ids.extend(read_ids_file(arg.split("=", 1)[1]))
+            i += 1
+            continue
+        remaining.append(arg)
+        i += 1
+    return remaining, ids
+
+
 def main():
     if "--batch" in sys.argv:
-        args = [a for a in sys.argv[1:] if a != "--batch"]
-        batch_mode(args)
+        rest, file_ids = _extract_ids_file(sys.argv[1:])
+        args = [a for a in rest if a != "--batch"]
+        batch_mode(args + file_ids)
         return
 
     if len(sys.argv) != 3:

--- a/scripts/collect_children.py
+++ b/scripts/collect_children.py
@@ -7,28 +7,36 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from artifact_utils import scan_task_files
+from artifact_utils import resolve_ids, scan_task_files
 
 
 def main():
     parser = argparse.ArgumentParser(description="Find child RFEs by parent_key")
     parser.add_argument(
-        "parent_ids", nargs="+", help="One or more parent RFE IDs (e.g. RHAIRFE-100)"
+        "parent_ids", nargs="*", help="One or more parent RFE IDs (e.g. RHAIRFE-100)"
+    )
+    parser.add_argument(
+        "--ids-file",
+        help="Read parent RFE IDs from a file (one per line) instead of positional args",
     )
     args = parser.parse_args()
+
+    parent_ids = resolve_ids(args.parent_ids, args.ids_file)
+    if not parent_ids:
+        parser.error("no parent RFE IDs provided (pass positionally or via --ids-file)")
 
     artifacts_dir = os.path.join(os.getcwd(), "artifacts")
     tasks = scan_task_files(artifacts_dir)
 
     # Build parent -> children mapping
-    children_by_parent = {pid: [] for pid in args.parent_ids}
+    children_by_parent = {pid: [] for pid in parent_ids}
     for _path, data in tasks:
         parent = data.get("parent_key")
         if parent and parent in children_by_parent:
             if data.get("status") != "Archived":
                 children_by_parent[parent].append(data["rfe_id"])
 
-    for pid in args.parent_ids:
+    for pid in parent_ids:
         kids = ",".join(children_by_parent[pid])
         print(f"{pid}:{kids}")
 

--- a/scripts/collect_recommendations.py
+++ b/scripts/collect_recommendations.py
@@ -8,7 +8,7 @@ import sys
 import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from artifact_utils import read_frontmatter
+from artifact_utils import read_frontmatter, resolve_ids
 
 ARTIFACTS_DIR = os.path.join(os.getcwd(), "artifacts")
 
@@ -74,19 +74,26 @@ def collect_errors(ids):
 
 def main():
     parser = argparse.ArgumentParser(description="Group RFE IDs by review recommendation.")
-    parser.add_argument("ids", nargs="+", help="RFE IDs to check")
+    parser.add_argument("ids", nargs="*", help="RFE IDs to check")
+    parser.add_argument(
+        "--ids-file", help="Read RFE IDs from a file (one per line) instead of positional args"
+    )
     parser.add_argument(
         "--reassess", action="store_true", help="Collect re-assess candidates instead"
     )
     parser.add_argument("--errors", action="store_true", help="Collect IDs with error field set")
     args = parser.parse_args()
 
+    ids = resolve_ids(args.ids, args.ids_file)
+    if not ids:
+        parser.error("no RFE IDs provided (pass positionally or via --ids-file)")
+
     if args.errors:
-        collect_errors(args.ids)
+        collect_errors(ids)
     elif args.reassess:
-        collect_reassess(args.ids)
+        collect_reassess(ids)
     else:
-        collect_default(args.ids)
+        collect_default(ids)
 
 
 if __name__ == "__main__":

--- a/scripts/next_rfe_id.py
+++ b/scripts/next_rfe_id.py
@@ -9,6 +9,9 @@ Usage:
     # RFE-012
     # RFE-013
     # RFE-014
+
+    python3 scripts/next_rfe_id.py --from-batch batch.yaml
+    # allocates one ID per entry in the YAML batch file (avoids N=$(...) in skills)
 """
 
 import fcntl
@@ -34,12 +37,30 @@ def get_highest_rfe_number():
     return highest
 
 
+def count_batch_entries(path):
+    """Return the number of entries in a YAML batch file."""
+    import yaml
+
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, list):
+        print(f"Batch file {path} must contain a YAML list", file=sys.stderr)
+        sys.exit(2)
+    return len(data)
+
+
 def main():
     if len(sys.argv) < 2:
-        print("Usage: next_rfe_id.py <count>", file=sys.stderr)
+        print("Usage: next_rfe_id.py <count> | --from-batch <batch.yaml>", file=sys.stderr)
         sys.exit(2)
 
-    count = int(sys.argv[1])
+    if sys.argv[1] == "--from-batch":
+        if len(sys.argv) < 3:
+            print("Usage: next_rfe_id.py --from-batch <batch.yaml>", file=sys.stderr)
+            sys.exit(2)
+        count = count_batch_entries(sys.argv[2])
+    else:
+        count = int(sys.argv[1])
     if count < 1:
         print("Count must be >= 1", file=sys.stderr)
         sys.exit(2)

--- a/scripts/state.py
+++ b/scripts/state.py
@@ -142,6 +142,27 @@ def cmd_read_ids(args):
     print(" ".join(ids))
 
 
+def cmd_copy_ids(args):
+    """Copy IDs from one file to another (one per line, deduped).
+
+    Avoids `write-ids DST $(read-ids SRC)` command substitution, which
+    triggers headless permission denials.
+    """
+    if len(args) != 2:
+        print("Usage: state.py copy-ids <src-file> <dst-file>", file=sys.stderr)
+        sys.exit(1)
+    src, dst = args
+    # Route through the shared reader so copy-ids and --ids-file parse IDs identically.
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from artifact_utils import read_ids_file
+
+    ids = read_ids_file(src)
+    os.makedirs(os.path.dirname(dst) or "tmp", exist_ok=True)
+    with open(dst, "w") as f:
+        for id_ in ids:
+            f.write(f"{id_}\n")
+
+
 def cmd_timestamp(args):
     """Print current UTC timestamp in ISO 8601 format."""
     from datetime import datetime, timezone
@@ -177,6 +198,7 @@ COMMANDS = {
     "read": cmd_read,
     "write-ids": cmd_write_ids,
     "read-ids": cmd_read_ids,
+    "copy-ids": cmd_copy_ids,
     "timestamp": cmd_timestamp,
     "clean": cmd_clean,
 }


### PR DESCRIPTION
## Problem

In headless mode, Claude Code flags Bash commands that **chain operations** (`;`, `&&`) or use **command substitution** `$(...)` for approval, then auto-denies them — *regardless* of the per-script permission allowlist. Several skills relied on this pattern, e.g.:

```bash
python3 scripts/batch_summary.py --counts-only $(python3 scripts/state.py read-ids tmp/pipeline-all-ids.txt)
```

This surfaced during an `rfe.speedrun` eval as 4 permission denials. They were benign (each self-recovered) but noisy, and a denial on a load-bearing command could stall the pipeline. Interactive users hit the same approval prompts. There were **9 such substitution sites** across the skills.

## Fix

Eliminate the pattern at the source so it can't trigger under any permission mode:

- **`--ids-file <path>`** added to `batch_summary.py`, `check_revised.py`, `collect_recommendations.py`, `collect_children.py` — reads IDs from a file instead of forcing `$(read-ids ...)`. Positional args still work, via a shared `resolve_ids` / `read_ids_file` helper in `artifact_utils.py`.
- **`state.py copy-ids SRC DST`** — replaces `write-ids DST $(read-ids SRC)`.
- **`next_rfe_id.py --from-batch <yaml>`** — replaces `N=$(python3 -c ...)` in speedrun.
- **9 substitution sites rewritten** in `rfe.auto-fix`, `rfe.review`, `rfe.split`, `rfe.speedrun` to use the file-based flags.
- **"Bash discipline" note** added to the orchestrating skills (`rfe.auto-fix`, `rfe.speedrun`): one operation per Bash call, no `;`/`&&`/`$(...)`; pass data between commands via `tmp/` files. This also curbs orchestrator-improvised compound commands. Aligns with the existing `CLAUDE.md` convention to use `scripts/state.py` instead of inline bash to avoid auth prompts.

## Verification

- All modified scripts pass `python3 -m py_compile`.
- Smoke-tested `--ids-file`, `copy-ids`, `--from-batch`, backward-compatible positional args, and the empty-IDs error path.
- `grep` confirms no `$(...)` command substitution remains in any skill bash block.
- No change to pipeline output; scripts stay backward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multiple scripts now support loading RFE IDs via `--ids-file` option for batch operations
  * Added batch YAML file support for RFE ID pre-allocation
  * New state command for ID file management

* **Documentation**
  * Updated skill guides with new "Bash discipline" requirements for cleaner command execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->