### PR TITLE
Preserve original reporter when splitting RFEs into child tickets

### DIFF
--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -131,6 +131,7 @@ def create_issue(
     labels=None,
     components=None,
     parent_key=None,
+    reporter_account_id=None,
 ):
     """POST /rest/api/3/issue — returns the created issue key."""
     body = {
@@ -148,6 +149,8 @@ def create_issue(
         body["fields"]["components"] = [{"name": c} for c in components]
     if parent_key:
         body["fields"]["parent"] = {"key": parent_key}
+    if reporter_account_id:
+        body["fields"]["reporter"] = {"accountId": reporter_account_id}
     result = api_call_with_retry(server, "/issue", user, token, body=body)
     return result["key"]
 

--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -149,9 +149,21 @@ def create_issue(
         body["fields"]["components"] = [{"name": c} for c in components]
     if parent_key:
         body["fields"]["parent"] = {"key": parent_key}
-    if reporter_account_id:
-        body["fields"]["reporter"] = {"accountId": reporter_account_id}
-    result = api_call_with_retry(server, "/issue", user, token, body=body)
+    if reporter_account_id and reporter_account_id.strip():
+        body["fields"]["reporter"] = {"accountId": reporter_account_id.strip()}
+    try:
+        result = api_call_with_retry(server, "/issue", user, token, body=body)
+    except urllib.error.HTTPError as e:
+        if e.code in (400, 403) and "reporter" in body["fields"]:
+            print(
+                f"  WARNING: Could not set reporter ({e.code}) — "
+                f"retrying without reporter field.",
+                file=sys.stderr,
+            )
+            del body["fields"]["reporter"]
+            result = api_call_with_retry(server, "/issue", user, token, body=body)
+        else:
+            raise
     return result["key"]
 
 

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -92,6 +92,7 @@ class SubmissionState:
         self.parent_components = []  # inherited by children
         self.parent_labels = []  # non-automation labels inherited
         self.parent_parent_key = None  # Jira parent (e.g. RHAISTRAT) inherited
+        self.parent_reporter_id = None  # original reporter preserved on children
 
 
 def discover_state(server, user, token, parent_key, expected_children):
@@ -121,7 +122,11 @@ def discover_state(server, user, token, parent_key, expected_children):
 
     # 2. Check issue links, components, labels, and Jira parent
     issue = get_issue(
-        server, user, token, parent_key, ["issuelinks", "status", "components", "labels", "parent"]
+        server,
+        user,
+        token,
+        parent_key,
+        ["issuelinks", "status", "components", "labels", "parent", "reporter"],
     )
     for link in issue.get("fields", {}).get("issuelinks", []):
         if link.get("type", {}).get("name") != "Issue split":
@@ -145,6 +150,9 @@ def discover_state(server, user, token, parent_key, expected_children):
     jira_parent = issue.get("fields", {}).get("parent")
     if jira_parent:
         state.parent_parent_key = jira_parent.get("key")
+    reporter = issue.get("fields", {}).get("reporter")
+    if reporter:
+        state.parent_reporter_id = reporter.get("accountId")
 
     # 3. Check parent status
     status_cat = issue.get("fields", {}).get("status", {}).get("statusCategory", {}).get("key", "")
@@ -239,6 +247,8 @@ def phase2_create_link(server, user, token, parent_key, children, state, artifac
                 print(f"           Components: {', '.join(state.parent_components)}")
             if state.parent_parent_key:
                 print(f"           Parent: {state.parent_parent_key}")
+            if state.parent_reporter_id:
+                print(f"           Reporter: {state.parent_reporter_id}")
             print(f"           Would link to {parent_key} via 'Issue split'")
             if attn_reason:
                 print("           Would post needs-attention comment")
@@ -258,6 +268,7 @@ def phase2_create_link(server, user, token, parent_key, children, state, artifac
             labels=labels,
             components=state.parent_components,
             parent_key=state.parent_parent_key,
+            reporter_account_id=state.parent_reporter_id,
         )
         print(f"  Phase 2: Created {child_key} for child {idx}/{total}: {title}")
         print(f"           Labels: {', '.join(labels)}")


### PR DESCRIPTION
## Summary

- When `split_submit.py` creates child tickets during RFE splitting, the reporter defaults to the automation bot account (`rhoaieng-automation@redhat.com`), making it impossible for the original reporter to find their split RFEs using Jira's "Reported by me" filter or `reporter = currentUser()` JQL
- This fix reads the parent ticket's reporter `accountId` during state discovery and passes it to the Jira REST API when creating each child ticket

## Changes

- `scripts/jira_utils.py`: Add optional `reporter_account_id` parameter to `create_issue()` — sets `reporter.accountId` on the created issue when provided
- `scripts/split_submit.py`: Fetch parent's `reporter` field in `discover_state()`, store on `SubmissionState`, and pass to `create_issue()` in `phase2_create_link()`

## Test plan

- [x] All existing tests pass (`test_split_submit.py`: 5 passed, `test_submit.py`: 41 passed)
- [x] Python syntax verified
- [ ] Manual validation: run `split_submit.py --dry-run` against a parent RFE and confirm reporter accountId is logged
- [ ] End-to-end: split an RFE and verify the child ticket's reporter matches the parent's reporter in Jira

## Related

- Fixes [RHOAIENG-66925](https://redhat.atlassian.net/browse/RHOAIENG-66925)
- Examples of the bug: RHAIRFE-2296, RHAIRFE-2295, RHAIRFE-2294 (all show bot as reporter)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Jira child issues now automatically inherit the reporter assignment from their parent issue. When creating linked child issues through batch operations or issue splitting workflows, they will retain the parent's reporter information. This eliminates manual reporter reassignments and ensures consistent ownership across related tickets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->