### PR TITLE
Auto-approve qualifying child RFEs during split submission

### DIFF
--- a/.claude/skills/rfe.submit/SKILL.md
+++ b/.claude/skills/rfe.submit/SKILL.md
@@ -28,7 +28,7 @@ Check if `JIRA_SERVER`, `JIRA_USER`, and `JIRA_TOKEN` environment variables are 
 ## Step 1: Run Submission
 
 ```bash
-python3 scripts/submit.py --auto-approve [--dry-run] [--artifacts-dir artifacts]
+python3 scripts/submit.py [--dry-run] [--artifacts-dir artifacts]
 ```
 
 ## Step 2: Report Results

--- a/.claude/skills/rfe.submit/SKILL.md
+++ b/.claude/skills/rfe.submit/SKILL.md
@@ -28,7 +28,7 @@ Check if `JIRA_SERVER`, `JIRA_USER`, and `JIRA_TOKEN` environment variables are 
 ## Step 1: Run Submission
 
 ```bash
-python3 scripts/submit.py [--dry-run] [--artifacts-dir artifacts]
+python3 scripts/submit.py --auto-approve [--dry-run] [--artifacts-dir artifacts]
 ```
 
 ## Step 2: Report Results

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -51,6 +51,7 @@ from jira_utils import (  # noqa: E402
     normalize_for_compare,
     require_env,
     text_to_adf_paragraph,
+    transition_issue,
 )
 
 MAX_LEAF_CHILDREN = 6
@@ -189,7 +190,9 @@ def phase1_persist(server, user, token, parent_key, children, state, dry_run):
         print(f"  Phase 1: Posted content for child {idx}/{total}: {title}")
 
 
-def phase2_create_link(server, user, token, parent_key, children, state, artifacts_dir, dry_run):
+def phase2_create_link(
+    server, user, token, parent_key, children, state, artifacts_dir, dry_run, auto_approve=False
+):
     """Create tickets, link to parent, and post confirmation comments."""
     total = len(children)
     for idx, (rfe_id, title, priority, artifact_path) in enumerate(children, 1):
@@ -249,6 +252,14 @@ def phase2_create_link(server, user, token, parent_key, children, state, artifac
                 print(f"           Parent: {state.parent_parent_key}")
             if state.parent_reporter_id:
                 print(f"           Reporter: {state.parent_reporter_id}")
+            qualifies = (
+                auto_approve
+                and review_path
+                and review_rec == "submit"
+                and feas_label == "rfe-creator-feasibility-pass"
+            )
+            if qualifies:
+                print("           Would transition to Approved")
             print(f"           Would link to {parent_key} via 'Issue split'")
             if attn_reason:
                 print("           Would post needs-attention comment")
@@ -292,6 +303,36 @@ def phase2_create_link(server, user, token, parent_key, children, state, artifac
             )
             add_comment(server, user, token, child_key, markdown_to_adf(attn_md))
             print("           Posted needs-attention comment")
+
+        # 5. Auto-approve if qualifying
+        qualifies_for_approve = (
+            auto_approve
+            and review_path
+            and review_rec == "submit"
+            and feas_label == "rfe-creator-feasibility-pass"
+        )
+        if qualifies_for_approve:
+            if transition_issue(
+                server, user, token, child_key, "Approved"
+            ):
+                approve_comment = (
+                    "*[RFE Creator]* This RFE has been automatically "
+                    "transitioned to Approved status based on passing "
+                    "rubric scoring and technical feasibility checks. "
+                    "Approval does not constitute a commitment to "
+                    "customers until this RFE is prioritized into a "
+                    "product release by product management."
+                )
+                add_comment(
+                    server,
+                    user,
+                    token,
+                    child_key,
+                    markdown_to_adf(approve_comment),
+                )
+                print(
+                    f"           Transitioned {child_key} to Approved"
+                )
 
         state.phase2_done[idx] = child_key
 
@@ -406,6 +447,12 @@ def main():
     )
     parser.add_argument(
         "--artifacts-dir", default="artifacts", help="Artifacts directory (default: artifacts)"
+    )
+    parser.add_argument(
+        "--auto-approve",
+        action="store_true",
+        help="Transition qualifying child RFEs to Approved status "
+        "(pass=true + feasibility=feasible)",
     )
     args = parser.parse_args()
 
@@ -542,7 +589,8 @@ def main():
 
     print("Phase 2: Creating tickets and linking...")
     phase2_create_link(
-        server, user, token, args.parent_key, children, state, args.artifacts_dir, args.dry_run
+        server, user, token, args.parent_key, children, state,
+        args.artifacts_dir, args.dry_run, auto_approve=args.auto_approve,
     )
     print()
 

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -230,6 +230,8 @@ def main():
             cmd = [sys.executable, split_script, parent_key, "--artifacts-dir", args.artifacts_dir]
             if args.dry_run:
                 cmd.append("--dry-run")
+            if args.auto_approve:
+                cmd.append("--auto-approve")
             print(f"--- {parent_key} ---")
             result = subprocess.run(cmd)
             if result.returncode == 2:


### PR DESCRIPTION
## Summary

- `split_submit.py` now accepts `--auto-approve` and transitions qualifying child tickets to "Approved" immediately after creation
- `submit.py` passes `--auto-approve` through to `split_submit.py` when the flag is set
- `rfe.submit` skill updated to pass `--auto-approve` by default

## Problem

Two gaps leave qualifying RFEs stuck in "New" status:

1. **`split_submit.py` never auto-approves children.** Child tickets are created and the parent is closed, but children are never transitioned to "Approved" — even when their reviews qualify (pass=true + feasibility=feasible). They sit in "New" until the next CI run picks them up.

2. **Old tickets processed before auto-approve was introduced (May 4) are permanently skipped** by the incremental pipeline. Currently **59 tickets** have both qualifying labels and are still in "New".

## Changes

- `scripts/split_submit.py`: Added `--auto-approve` CLI flag. After creating each child ticket, if the child's review has `recommendation=submit` and `feasibility=feasible`, the ticket is transitioned to "Approved" with the standard approval comment.
- `scripts/submit.py`: Passes `--auto-approve` through to `split_submit.py` subprocess calls.
- `.claude/skills/rfe.submit/SKILL.md`: Updated submit command to include `--auto-approve`.

## Backfill

After merge, the 59 stuck tickets can be approved by running the CI pipeline with `--reprocess`:
```
python3 scripts/snapshot_fetch.py fetch "project = RHAIRFE AND labels = rfe-creator-autofix-rubric-pass AND labels = rfe-creator-feasibility-pass AND status = New" --reprocess --limit 59
```

## Test plan

- [x] All existing tests pass (46 tests)
- [ ] Dry-run split with `--auto-approve` shows "Would transition to Approved" for qualifying children
- [ ] Live split with `--auto-approve` transitions qualifying children to Approved and posts comment

Fixes: RHOAIENG-67033

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--auto-approve` CLI flag to automatically approve qualifying child tickets during submission when the required recommendation and feasibility criteria are met.
  * Applies to both standard and split submissions.
  * Posts an approval confirmation comment on tickets successfully transitioned.
  * In dry-run mode, reports which tickets would be approved without applying changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->