### PR TITLE
Fix stale rubric path in bootstrap-assess-rfe.sh

### DIFF
--- a/scripts/bootstrap-assess-rfe.sh
+++ b/scripts/bootstrap-assess-rfe.sh
@@ -8,7 +8,7 @@ if [ -n "${RFE_SKIP_BOOTSTRAP:-}" ]; then
 fi
 
 CONTEXT_DIR=".context/assess-rfe"
-RUBRIC_FILE="$CONTEXT_DIR/scripts/agent_prompt.md"
+RUBRIC_FILE="$CONTEXT_DIR/skills/assess-rfe/scripts/agent_prompt.md"
 
 if [ ! -d "$CONTEXT_DIR" ]; then
   git clone https://github.com/opendatahub-io/assess-rfe "$CONTEXT_DIR" 2>&1


### PR DESCRIPTION
## Description
The assess-rfe repo moved the rubric file from scripts/agent_prompt.md to skills/assess-rfe/scripts/agent_prompt.md. The bootstrap path check was not updated, causing it to exit before copying skills or agents — breaking rfe.review and any skill that depends on assess-rfe.

Review showed this as the root cause ...https://github.com/opendatahub-io/assess-rfe/pull/5 which moved the rubric file; this PR updates the path reference in rfe-creator to match it now.

## How Has This Been Tested?
Tested on macOS with a fresh clone; deleted .context/assess-rfe/, .claude/agents/rfe-scorer.md, and .claude/skills/assess-rfe/, then ran bash scripts/bootstrap-assess-rfe.sh. Bootstrap completed successfully and all files were copied correctly. Confirmed rfe.review and rfe.intake both work end-to-end after the fix.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal bootstrap script configuration to reference resources from their updated repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->