### PR TITLE
Fix rfe.speedrun to handle single-dict input files

### DIFF
--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -55,9 +55,11 @@ When the user doesn't specify, use these defaults:
 Count entries and pre-allocate all IDs upfront:
 
 ```bash
-N=$(python3 -c "import yaml; print(len(yaml.safe_load(open('batch.yaml'))))")
+N=$(python3 -c "import yaml; d=yaml.safe_load(open('INPUT_FILE')); print(len(d) if isinstance(d, list) else 1)")
 python3 scripts/next_rfe_id.py $N   # prints RFE-001 through RFE-<N>
 ```
+
+If the input is a single dict (not a list), treat it as one entry — extract its `prompt`, `priority`, and optional `clarifying_context` fields.
 
 For each entry, launch an Agent to invoke `/rfe.create`. Pass the pre-assigned ID so each Agent knows which ID to use:
 


### PR DESCRIPTION
## Summary
- Fix batch input parser in `rfe.speedrun` SKILL.md to handle single-dict YAML input files (not just lists)
- Add guidance to treat a single dict as one entry, extracting `prompt`, `priority`, and `clarifying_context` fields

## Problem
The `len()` call on a YAML dict returns the number of keys, not 1. Eval cases using `input.yaml` with a single dict entry (no list wrapper) caused incorrect ID allocation.

## Test plan
- [ ] Run `rfe.speedrun` with a single-dict input YAML — should allocate 1 RFE ID
- [ ] Run `rfe.speedrun` with a list input YAML — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML batch mode to correctly count and process input entries, now supporting both list and single dictionary input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->