### PR TITLE
Rename local draft prefix from RFE-NNN to DRAFT-NNN

### DIFF
--- a/.ambient/ambient.json
+++ b/.ambient/ambient.json
@@ -1,9 +1,9 @@
 {
   "name": "RFE Creator",
-  "description": "Create, review, and submit RFEs to RHAIRFE.",
-  "systemPrompt": "You are an RFE creation assistant. Help users create well-formed RFEs (WHAT/WHY).\n\nUse the available skills:\n- /rfe.create — Create RFEs from a problem statement\n- /rfe.review — Validate RFEs (rubric + technical feasibility)\n- /rfe.submit — Submit to Jira as RHAIRFEs\n- /rfe.speedrun — Run the full RFE pipeline\n\nAll artifacts are written to the artifacts/ directory. Structured metadata is stored in YAML frontmatter — use scripts/frontmatter.py to read and write it.",
+  "description": "Create, review, and submit RFEs to Jira.",
+  "systemPrompt": "You are an RFE creation assistant. Help users create well-formed RFEs (WHAT/WHY).\n\nUse the available skills:\n- /rfe.create — Create RFEs from a problem statement\n- /rfe.review — Validate RFEs (rubric + technical feasibility)\n- /rfe.submit — Submit to Jira\n- /rfe.speedrun — Run the full RFE pipeline\n\nAll artifacts are written to the artifacts/ directory. Structured metadata is stored in YAML frontmatter — use scripts/frontmatter.py to read and write it.",
   "startupPrompt": "Greet the user and introduce yourself as their RFE assistant. List the available skills. Inform them to run /rfe.create to start, or /rfe.speedrun for the full pipeline with minimal interaction.",
-  "greeting": "Welcome to RFE Creator! I help you turn ideas into well-formed RFEs.\n\nAvailable skills:\n• /rfe.create — Create RFEs from a problem statement\n• /rfe.review — Validate (rubric + technical feasibility)\n• /rfe.submit — Submit to Jira as RHAIRFEs\n• /rfe.speedrun — Full pipeline, minimal interaction\n\nFor strategy skills, see https://github.com/ederign/strat-creator\n\nType /rfe.create to get started.",
+  "greeting": "Welcome to RFE Creator! I help you turn ideas into well-formed RFEs.\n\nAvailable skills:\n• /rfe.create — Create RFEs from a problem statement\n• /rfe.review — Validate (rubric + technical feasibility)\n• /rfe.submit — Submit to Jira\n• /rfe.speedrun — Full pipeline, minimal interaction\n\nFor strategy skills, see https://github.com/ederign/strat-creator\n\nType /rfe.create to get started.",
   "results": {
     "RFE Index": "artifacts/rfes.md",
     "RFE Tasks": "artifacts/rfe-tasks/*.md",

--- a/.claude/skills/rfe-feasibility-review/SKILL.md
+++ b/.claude/skills/rfe-feasibility-review/SKILL.md
@@ -53,10 +53,10 @@ If `artifacts/rfe-review-report.md` exists, read it. This is a re-review after r
 
 ## Output
 
-Write your assessment to `artifacts/rfe-reviews/{ID}-feasibility.md` where `{ID}` is exactly the RFE ID passed to you (e.g., `RFE-005` or `RHAIRFE-1234`). Create the directory if needed.
+Write your assessment to `artifacts/rfe-reviews/{ID}-feasibility.md` where `{ID}` is exactly the RFE ID passed to you (e.g., `DRAFT-005` or `RHAIRFE-1234`). Create the directory if needed.
 
 ```
-### RFE-NNN: <title>
+### DRAFT-NNN: <title>
 **Feasibility**: <feasible / infeasible / indeterminate>
 **Strategy considerations**: <none / list of items for /strat.refine>
 **Blockers**: <none / list>

--- a/.claude/skills/rfe-feasibility-review/SKILL.md
+++ b/.claude/skills/rfe-feasibility-review/SKILL.md
@@ -53,7 +53,7 @@ If `artifacts/rfe-review-report.md` exists, read it. This is a re-review after r
 
 ## Output
 
-Write your assessment to `artifacts/rfe-reviews/{ID}-feasibility.md` where `{ID}` is exactly the RFE ID passed to you (e.g., `DRAFT-005` or `RHAIRFE-1234`). Create the directory if needed.
+Write your assessment to `artifacts/rfe-reviews/{ID}-feasibility.md` where `{ID}` is exactly the RFE ID passed to you (e.g., `DRAFT-005` or `PROJ-1234`). Create the directory if needed.
 
 ```
 ### DRAFT-NNN: <title>

--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -21,7 +21,7 @@ Run:
 python3 scripts/resolve_project.py
 ```
 
-If it exits non-zero, ask the user: "What Jira project key should I use? (e.g., RHAIRFE, MYPROJECT)" Then export `JIRA_PROJECT=<answer>` and re-run to confirm.
+If it exits non-zero, ask the user: "What Jira project key should I use? ?" Then export `JIRA_PROJECT=<answer>` and re-run to confirm.
 
 ### 1. Init
 

--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -14,6 +14,15 @@ Parse `$ARGUMENTS` for:
 - `--headless`, `--announce-complete`, `--reprocess`, `--random N`
 - Remaining arguments: explicit RFE IDs
 
+### Resolve Jira Project
+
+Run:
+```bash
+python3 scripts/resolve_project.py
+```
+
+If it exits non-zero, ask the user: "What Jira project key should I use? (e.g., RHAIRFE, MYPROJECT)" Then export `JIRA_PROJECT=<answer>` and re-run to confirm.
+
 ### 1. Init
 
 ```bash
@@ -122,12 +131,12 @@ agents:
   - subagent_type: rfe-scorer
     prompt_file: .claude/skills/rfe.review/prompts/assess-agent.md
     vars: |
-      DATA_FILE=/tmp/rfe-assess/single/RHAIRFE-1234.md
+      DATA_FILE=/tmp/rfe-assess/single/PROJ-1234.md
       RUN_DIR=/tmp/rfe-assess/single
       PROMPT_PATH=.context/assess-rfe/scripts/agent_prompt.md
   - prompt_file: .claude/skills/rfe-feasibility-review/SKILL.md
     vars: |
-      ID=RHAIRFE-1234
+      ID=PROJ-1234
 ```
 
 ## Teardown

--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -33,7 +33,7 @@ Run:
 python3 scripts/resolve_project.py
 ```
 
-If it exits non-zero, ask the user: "What Jira project key should I use? (e.g., RHAIRFE, MYPROJECT)" Then export `JIRA_PROJECT=<answer>` and re-run to confirm.
+If it exits non-zero, ask the user: "What Jira project key should I use? ?" Then export `JIRA_PROJECT=<answer>` and re-run to confirm.
 
 For each ID, check if `artifacts/rfe-tasks/<id>.md` already exists locally (use Glob, don't read the file). Separate IDs into:
 - **Local**: task file exists — skip fetch

--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rfe.review
-description: Review and improve RFEs. Accepts one or more Jira keys (e.g., /rfe.review RHAIRFE-1234 RHAIRFE-5678) to fetch and review existing RFEs, or reviews local artifacts from /rfe.create. Runs rubric scoring, technical feasibility checks, and auto-revises issues it finds.
+description: Review and improve RFEs. Accepts one or more Jira keys (e.g., /rfe.review PROJ-1234 PROJ-5678) to fetch and review existing RFEs, or reviews local artifacts from /rfe.create. Runs rubric scoring, technical feasibility checks, and auto-revises issues it finds.
 user-invocable: true
 allowed-tools: Glob, Bash, Agent, AskUserQuestion
 ---
@@ -12,7 +12,7 @@ You are an RFE review orchestrator. Your job is to coordinate reviews and revisi
 Parse `$ARGUMENTS` for flags and IDs:
 - Strip `--headless` flag if present (suppresses end-of-run summary)
 - Strip `--caller <name>` flag if present (identifies calling skill for headless return)
-- Remaining arguments are one or more space-separated RFE IDs (RHAIRFE-NNNN or RFE-NNN)
+- Remaining arguments are one or more space-separated RFE IDs (Jira key or RFE-NNN)
 
 Persist parsed flags (survives context compression):
 
@@ -25,6 +25,15 @@ Persist all IDs to disk (survives context compression):
 ```bash
 python3 scripts/state.py write-ids tmp/review-all-ids.txt <all_IDs>
 ```
+
+## Review Step 0.5: Resolve Jira Project
+
+Run:
+```bash
+python3 scripts/resolve_project.py
+```
+
+If it exits non-zero, ask the user: "What Jira project key should I use? (e.g., RHAIRFE, MYPROJECT)" Then export `JIRA_PROJECT=<answer>` and re-run to confirm.
 
 For each ID, check if `artifacts/rfe-tasks/<id>.md` already exists locally (use Glob, don't read the file). Separate IDs into:
 - **Local**: task file exists — skip fetch

--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -32,7 +32,7 @@ Run:
 python3 scripts/resolve_project.py
 ```
 
-If it exits non-zero, ask the user: "What Jira project key should I use? (e.g., RHAIRFE, MYPROJECT)" Then export `JIRA_PROJECT=<answer>` and re-run to confirm.
+If it exits non-zero, ask the user: "What Jira project key should I use? ?" Then export `JIRA_PROJECT=<answer>` and re-run to confirm.
 
 Determine pipeline mode:
 - **Mode A (Batch YAML)**: `--input` flag present → batch create + auto-fix + submit

--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -63,16 +63,16 @@ If this exits nonzero, stop and report the printed `ERROR:`/`WARNING:` lines to 
 Count entries and pre-allocate all IDs upfront:
 
 ```bash
-python3 scripts/next_rfe_id.py --from-batch <input_file>   # input_file = the --input path; prints one RFE ID per entry
+python3 scripts/next_rfe_id.py --from-batch <input_file>   # input_file = the --input path; prints one DRAFT ID per entry
 ```
 
 For each entry, launch an Agent to invoke `/rfe.create`. Pass the pre-assigned ID so each Agent knows which ID to use:
 
 ```
-Agent for entry 1:  /rfe.create --headless --rfe-id RFE-001 [--priority <priority>] <prompt>
-Agent for entry 2:  /rfe.create --headless --rfe-id RFE-002 [--priority <priority>] <prompt>
+Agent for entry 1:  /rfe.create --headless --rfe-id DRAFT-001 [--priority <priority>] <prompt>
+Agent for entry 2:  /rfe.create --headless --rfe-id DRAFT-002 [--priority <priority>] <prompt>
 ...
-Agent for entry N:  /rfe.create --headless --rfe-id RFE-<N> [--priority <priority>] <prompt>
+Agent for entry N:  /rfe.create --headless --rfe-id DRAFT-<N> [--priority <priority>] <prompt>
 ```
 
 Each entry is a single business need — `/rfe.create` must produce exactly one RFE per invocation. Wait for all N agents to complete. You must have exactly N RFE IDs — if fewer were created, retry the missing entries. **Never delete or re-create task files during Phase 1** — quality issues are addressed in Phase 2 (Auto-fix).
@@ -120,7 +120,7 @@ After auto-fix returns, verify all RFEs were processed:
 python3 scripts/check_autofix_complete.py
 ```
 
-If incomplete (exit code 1), the output shows `MISSING_IDS=RFE-006,RFE-007,...`. Re-invoke auto-fix with only the missing IDs:
+If incomplete (exit code 1), the output shows `MISSING_IDS=DRAFT-006,DRAFT-007,...`. Re-invoke auto-fix with only the missing IDs:
 
 ```text
 /rfe.auto-fix [--headless] [--batch-size N] <missing_IDs>

--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -15,7 +15,7 @@ Parse `$ARGUMENTS` for:
 - `--announce-complete`: Print completion marker when done (for CI / eval harnesses)
 - `--dry-run`: Skip Jira writes in submit
 - `--batch-size N`: Override batch size (default 5), passed to auto-fix
-- Remaining arguments: either a single Jira key (RHAIRFE-NNNN) or a free-text idea
+- Remaining arguments: either a single Jira key or a free-text idea
 
 Clean temp state and persist parsed flags. `batch_size` MUST always be a concrete integer — if the user did not pass `--batch-size`, substitute the speedrun default of `5`. Do not write `<N>`, `null`, or omit the field.
 
@@ -25,9 +25,18 @@ python3 scripts/prep_assess.py --clean-all
 python3 scripts/state.py init tmp/speedrun-config.yaml headless=<true/false> announce_complete=<true/false> dry_run=<true/false> batch_size=<N or 5> input_file=<path or null>
 ```
 
+### Resolve Jira Project
+
+Run:
+```bash
+python3 scripts/resolve_project.py
+```
+
+If it exits non-zero, ask the user: "What Jira project key should I use? (e.g., RHAIRFE, MYPROJECT)" Then export `JIRA_PROJECT=<answer>` and re-run to confirm.
+
 Determine pipeline mode:
 - **Mode A (Batch YAML)**: `--input` flag present → batch create + auto-fix + submit
-- **Mode B (Existing RFE)**: argument is a Jira key (RHAIRFE-NNNN) → skip create, auto-fix + submit
+- **Mode B (Existing RFE)**: argument is a Jira key → skip create, auto-fix + submit
 - **Mode C (Single idea)**: free-text argument, no `--input` → single create + auto-fix + submit
 
 If no arguments provided, stop with usage instructions.
@@ -184,7 +193,7 @@ If headless, output a brief machine-readable summary. If interactive, output:
 - Split: N (into M children)
 
 ### Submitted
-- RHAIRFE-NNNN: <title> [created/updated/dry-run]
+- <PROJECT>-NNNN: <title> [created/updated/dry-run]
 
 ### Reports
 - Run report: artifacts/auto-fix-runs/<timestamp>.yaml

--- a/.claude/skills/rfe.split/SKILL.md
+++ b/.claude/skills/rfe.split/SKILL.md
@@ -34,7 +34,7 @@ Run:
 python3 scripts/resolve_project.py
 ```
 
-If it exits non-zero, ask the user: "What Jira project key should I use? (e.g., RHAIRFE, MYPROJECT)" Then export `JIRA_PROJECT=<answer>` and re-run to confirm.
+If it exits non-zero, ask the user: "What Jira project key should I use? ?" Then export `JIRA_PROJECT=<answer>` and re-run to confirm.
 
 For each ID, verify the task file exists via Glob (`artifacts/rfe-tasks/<ID>.md`). If missing, report and skip.
 

--- a/.claude/skills/rfe.split/SKILL.md
+++ b/.claude/skills/rfe.split/SKILL.md
@@ -159,8 +159,8 @@ Returning to **Step 3d: Between-Batch Summary** of `/rfe.auto-fix`. Re-read the 
 
 Original: RHAIRFE-1234 (archived)
 New RFEs:
-- RFE-003: <title> (Priority: Normal) — PASS
-- RFE-004: <title> (Priority: Normal) — PASS
+- DRAFT-003: <title> (Priority: Normal) — PASS
+- DRAFT-004: <title> (Priority: Normal) — PASS
 
 Coverage: All original scope items covered
 Review: All new RFEs passed

--- a/.claude/skills/rfe.split/SKILL.md
+++ b/.claude/skills/rfe.split/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rfe.split
-description: Split oversized RFEs into smaller, right-sized RFEs. Accepts one or more IDs (e.g., /rfe.split RHAIRFE-1234 RHAIRFE-5678). Runs non-interactively — decomposes, generates new RFEs, reviews them, self-corrects, and checks coverage.
+description: Split oversized RFEs into smaller, right-sized RFEs. Accepts one or more IDs (e.g., /rfe.split PROJ-1234 PROJ-5678). Runs non-interactively — decomposes, generates new RFEs, reviews them, self-corrects, and checks coverage.
 user-invocable: true
 allowed-tools: Glob, Bash, Agent, Skill, AskUserQuestion
 ---
@@ -11,7 +11,7 @@ You are an RFE splitting orchestrator. Your job is to coordinate RFE decompositi
 
 Parse `$ARGUMENTS` for flags and IDs:
 - Strip `--headless` flag if present (suppresses end-of-run summary)
-- Remaining arguments are one or more space-separated RFE IDs (RHAIRFE-NNNN or RFE-NNN)
+- Remaining arguments are one or more space-separated RFE IDs (Jira key or RFE-NNN)
 
 Persist parsed flags (survives context compression):
 
@@ -26,6 +26,15 @@ Persist all IDs to disk (survives context compression):
 ```bash
 python3 scripts/state.py write-ids tmp/split-all-ids.txt <all_IDs>
 ```
+
+## Split Step 0.5: Resolve Jira Project
+
+Run:
+```bash
+python3 scripts/resolve_project.py
+```
+
+If it exits non-zero, ask the user: "What Jira project key should I use? (e.g., RHAIRFE, MYPROJECT)" Then export `JIRA_PROJECT=<answer>` and re-run to confirm.
 
 For each ID, verify the task file exists via Glob (`artifacts/rfe-tasks/<ID>.md`). If missing, report and skip.
 
@@ -157,7 +166,7 @@ Returning to **Step 3d: Between-Batch Summary** of `/rfe.auto-fix`. Re-read the 
 ```
 ## Split Complete
 
-Original: RHAIRFE-1234 (archived)
+Original: PROJ-1234 (archived)
 New RFEs:
 - DRAFT-003: <title> (Priority: Normal) — PASS
 - DRAFT-004: <title> (Priority: Normal) — PASS

--- a/.claude/skills/rfe.split/prompts/split-agent.md
+++ b/.claude/skills/rfe.split/prompts/split-agent.md
@@ -149,7 +149,7 @@ Always write `artifacts/rfe-reviews/{ID}-split-status.yaml` as your final step:
 status: completed
 action: split
 reason: "split into N children"
-children: [RFE-001, RFE-002]
+children: [DRAFT-001, DRAFT-002]
 ```
 
 Or if no split was needed:

--- a/.claude/skills/rfe.split/prompts/split-agent.md
+++ b/.claude/skills/rfe.split/prompts/split-agent.md
@@ -105,9 +105,9 @@ Using the recommended decomposition:
 python3 scripts/next_rfe_id.py <number_of_children>
 ```
 
-This prints one RFE-NNN ID per line. Use these IDs in order for your children. The script locks to prevent races — do NOT scan the directory yourself.
+This prints one DRAFT-NNN ID per line. Use these IDs in order for your children. The script locks to prevent races — do NOT scan the directory yourself.
 
-5. Write each to `artifacts/rfe-tasks/RFE-NNN.md`
+5. Write each to `artifacts/rfe-tasks/DRAFT-NNN.md`
 6. Set frontmatter on each child:
 
 ```bash

--- a/.claude/skills/rfe.split/prompts/split-agent.md
+++ b/.claude/skills/rfe.split/prompts/split-agent.md
@@ -10,7 +10,7 @@ Review file: {REVIEW_FILE}
 
 Read the task file and the review file. The review file's right-sizing feedback explains why this RFE needs splitting.
 
-**Before proceeding, check the Right-sized score.** If the score is **1/2** ("slightly broad at 1-2 strategy features"), splitting may not be appropriate. An RFE that maps to 2 tightly-coupled strategy features is acceptable — the decomposition into strategy features happens at the RHAISTRAT level, not the RHAIRFE level. Only proceed with splitting if:
+**Before proceeding, check the Right-sized score.** If the score is **1/2** ("slightly broad at 1-2 strategy features"), splitting may not be appropriate. An RFE that maps to 2 tightly-coupled strategy features is acceptable — the decomposition into strategy features happens at the strategy level, not the RFE level. Only proceed with splitting if:
 - The Right-sized score is **0/2** (clearly needs 3+ features), OR
 - The score is 1/2 AND the capabilities serve genuinely different customer segments or user scenarios that could be independently prioritized without harm
 

--- a/.claude/skills/rfe.submit/SKILL.md
+++ b/.claude/skills/rfe.submit/SKILL.md
@@ -29,7 +29,7 @@ Also verify `JIRA_PROJECT` is set by running `python3 scripts/resolve_project.py
 
 > Set your Jira project key:
 > ```
-> export JIRA_PROJECT=RHAIRFE
+> export JIRA_PROJECT=YOURPROJECT
 > ```
 
 ## Step 1: Run Submission

--- a/.claude/skills/rfe.submit/SKILL.md
+++ b/.claude/skills/rfe.submit/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: rfe.submit
-description: Submit or update RFEs in Jira. Creates new RHAIRFE tickets for new RFEs, or updates existing tickets for RFEs fetched from Jira. Use after /rfe.review.
+description: Submit or update RFEs in Jira. Creates new Jira tickets for new RFEs, or updates existing tickets for RFEs fetched from Jira. Use after /rfe.review.
 user-invocable: true
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash
 ---
 
-You are an RFE submission assistant. Your job is to create or update RHAIRFE Jira tickets from reviewed RFE artifacts.
+You are an RFE submission assistant. Your job is to create or update Jira tickets from reviewed RFE artifacts.
 
 All submission goes through Python scripts that use the Jira REST API directly with Basic Auth (`JIRA_SERVER`, `JIRA_USER`, `JIRA_TOKEN` env vars), not the Atlassian MCP server. This ensures the exact sequence of Jira API calls is deterministic and not dependent on LLM tool-calling decisions.
 
@@ -24,6 +24,13 @@ Check if `JIRA_SERVER`, `JIRA_USER`, and `JIRA_TOKEN` environment variables are 
 > To create an API token, go to https://id.atlassian.com/manage-profile/security/api-tokens
 >
 > After environment variables are set, re-run `/rfe.submit`.
+
+Also verify `JIRA_PROJECT` is set by running `python3 scripts/resolve_project.py`. If it exits non-zero, tell the user:
+
+> Set your Jira project key:
+> ```
+> export JIRA_PROJECT=RHAIRFE
+> ```
 
 ## Step 1: Run Submission
 

--- a/.fullsend/README.md
+++ b/.fullsend/README.md
@@ -1,0 +1,118 @@
+# RFE Creator Agent
+
+Reviews, scores, and improves RFEs (Requests for Enhancement) in Jira,
+then submits the results. Runs the `rfe.speedrun` skill in a sandboxed
+environment with no direct Jira access.
+
+## How the agent works
+
+The rfe-creator agent processes a single Jira issue through the full RFE
+pipeline: assess, review, revise, and (if it passes) submit.
+
+1. **Pre-script** extracts the issue key from `FULLSEND_WORK_ITEM_URL`,
+   fetches the issue from Jira via `scripts/fetch_issue.py`, and writes
+   the task, original, and comment artifacts into the workspace.
+2. **Sandbox** — the agent runs `/rfe.speedrun --headless --dry-run` on
+   the pre-fetched artifacts. The skill scores the RFE against a rubric,
+   checks technical feasibility against architecture context, and
+   auto-revises to improve quality. If the RFE is oversized, it splits
+   it into smaller pieces. The agent has no Jira credentials and cannot
+   contact Jira — it works entirely on local files.
+3. **Validation** — `validate-artifacts.sh` checks that all task and
+   review files have valid frontmatter, that every `rfe_id` belongs to
+   the expected `JIRA_PROJECT` (or is a `DRAFT-NNN` split child), and
+   that recommendations are parseable.
+4. **Post-script** reads review recommendations via
+   `collect_recommendations.py --from-reviews` and calls `submit.py`
+   to create or update issues in Jira for RFEs recommended for
+   submission. RFEs recommended for rejection produce no Jira writes.
+
+Jira credentials never enter the sandbox. The LLM sees the issue content
+but cannot make API calls. All Jira reads happen in the pre-script and
+all writes happen in the post-script, both running on the host.
+
+## Running locally
+
+To test the harness end-to-end on a real issue:
+
+```bash
+export JIRA_SERVER=https://issues.redhat.com
+export JIRA_USER=you@example.com
+export JIRA_TOKEN=your-api-token
+export JIRA_PROJECT=RHAIRFE
+
+FULLSEND_WORK_ITEM_URL=https://issues.redhat.com/browse/RHAIRFE-1234 \
+  fullsend run rfe-creator
+```
+
+To do a dry run (no Jira writes from the post-script), omit the Jira
+credentials. The pre-script will fail, so you would need to pre-stage
+the artifacts manually and run only the sandbox + validation steps.
+
+## How it helps
+
+- RFEs get a thorough quality review and revision without manual effort.
+- Oversized RFEs are automatically split into right-sized pieces.
+- Jira writes are deterministic (handled by `submit.py`, not the LLM).
+- The sandbox boundary prevents accidental or malicious Jira mutations.
+
+## Triggers
+
+The rfe-creator agent does not use GitHub labels or slash commands. It is
+triggered by providing a Jira issue URL.
+
+| Trigger | Mechanism | Status |
+|---------|-----------|--------|
+| Manual | `FULLSEND_WORK_ITEM_URL=... fullsend run rfe-creator` | Available now |
+| Jira poll | `fullsend poll` with a `jira-poll` input driver | Coming — [ADR 63](https://github.com/fullsend-ai/fullsend/blob/main/docs/ADRs/0063-polling-based-work-discovery.md) |
+| Jira webhook | Jira webhook → fullsend dispatch | Coming — [fullsend#3812](https://github.com/fullsend-ai/fullsend/pull/3812) |
+
+Once polling and webhook triggers land, this harness will add a `trigger`
+key ([ADR 61](https://github.com/fullsend-ai/fullsend/blob/main/docs/ADRs/0061-harness-cel-dispatch.md))
+with a CEL expression to match Jira work-item events for the target project.
+
+## Variables
+
+| Variable | Required | Where | Purpose |
+|----------|----------|-------|---------|
+| `FULLSEND_WORK_ITEM_URL` | yes | runner + sandbox | Jira issue URL (e.g., `https://issues.redhat.com/browse/RHAIRFE-1234`) |
+| `JIRA_SERVER` | yes | runner only | Jira server base URL |
+| `JIRA_USER` | yes | runner only | Jira username / email |
+| `JIRA_TOKEN` | yes | runner only | Jira API token |
+| `JIRA_PROJECT` | yes | runner only | Expected Jira project key (e.g., `RHAIRFE`). Validation rejects artifacts with IDs outside this project. |
+
+## File layout
+
+```
+.fullsend/
+  agents/
+    rfe-creator.md              # Agent definition (adapter to rfe.speedrun)
+  harnesses/
+    rfe-creator.yaml            # Harness config (entry point)
+  scripts/
+    pre-fetch.sh                # Fetches issue from Jira into artifacts/
+    post-submit.sh              # Submits passing RFEs via submit.py
+    validate-artifacts.sh       # Validates frontmatter, project IDs, recommendations
+```
+
+The harness file (`.fullsend/harnesses/rfe-creator.yaml`) is the main entry
+point. It wires together the agent definition, pre/post scripts, validation,
+sandbox policy, and environment variables.
+
+## Adding to your fullsend installation
+
+Register the agent in your `.fullsend/config.yaml`:
+
+```yaml
+agents:
+  - name: rfe-creator
+    harness: https://github.com/opendatahub-io/rfe-creator/blob/main/.fullsend/harnesses/rfe-creator.yaml
+```
+
+For Jira polling, add a `jira-poll` input driver to your poll configuration
+that queries the target project. The poll driver emits
+`FULLSEND_WORK_ITEM_URL` automatically per ADR 63.
+
+## Source
+
+[`.fullsend/harnesses/rfe-creator.yaml`](harnesses/rfe-creator.yaml)

--- a/.fullsend/README.md
+++ b/.fullsend/README.md
@@ -39,9 +39,9 @@ To test the harness end-to-end on a real issue:
 export JIRA_SERVER=https://issues.redhat.com
 export JIRA_USER=you@example.com
 export JIRA_TOKEN=your-api-token
-export JIRA_PROJECT=RHAIRFE
+export JIRA_PROJECT=MYPROJECT
 
-FULLSEND_WORK_ITEM_URL=https://issues.redhat.com/browse/RHAIRFE-1234 \
+FULLSEND_WORK_ITEM_URL=https://issues.redhat.com/browse/MYPROJECT-1234 \
   fullsend run rfe-creator
 ```
 
@@ -75,11 +75,11 @@ with a CEL expression to match Jira work-item events for the target project.
 
 | Variable | Required | Where | Purpose |
 |----------|----------|-------|---------|
-| `FULLSEND_WORK_ITEM_URL` | yes | runner + sandbox | Jira issue URL (e.g., `https://issues.redhat.com/browse/RHAIRFE-1234`) |
+| `FULLSEND_WORK_ITEM_URL` | yes | runner + sandbox | Jira issue URL (e.g., `https://issues.redhat.com/browse/PROJ-1234`) |
 | `JIRA_SERVER` | yes | runner only | Jira server base URL |
 | `JIRA_USER` | yes | runner only | Jira username / email |
 | `JIRA_TOKEN` | yes | runner only | Jira API token |
-| `JIRA_PROJECT` | yes | runner only | Expected Jira project key (e.g., `RHAIRFE`). Validation rejects artifacts with IDs outside this project. |
+| `JIRA_PROJECT` | yes | runner only | Expected Jira project key (e.g., `MYPROJECT`). Validation rejects artifacts with IDs outside this project. |
 
 ## File layout
 

--- a/.fullsend/agents/rfe-creator.md
+++ b/.fullsend/agents/rfe-creator.md
@@ -1,0 +1,15 @@
+# RFE Creator Agent
+
+You are an RFE review and improvement agent. Your workspace contains
+a pre-fetched RFE in `artifacts/rfe-tasks/`. Your job is to review,
+score, and improve it.
+
+## Instructions
+
+1. Identify the RFE file in `artifacts/rfe-tasks/`
+2. Run `/rfe.speedrun --headless --dry-run <ISSUE_KEY>` where ISSUE_KEY
+   is the `rfe_id` from the file's frontmatter
+3. Do not contact Jira. All artifacts are local. Jira submission is
+   handled externally after you complete.
+4. When the skill completes, your work is done. The artifacts you
+   produced will be validated and submitted by external tooling.

--- a/.fullsend/harnesses/rfe-creator.yaml
+++ b/.fullsend/harnesses/rfe-creator.yaml
@@ -1,0 +1,29 @@
+agent: agents/rfe-creator.md
+model: opus
+policy: fullsend-ai/agents:policies/base.yaml
+timeout_minutes: 30
+
+skills:
+  - .claude/skills/rfe.speedrun
+  - .claude/skills/rfe.create
+  - .claude/skills/rfe.review
+  - .claude/skills/rfe.auto-fix
+  - .claude/skills/rfe.split
+  - .claude/skills/rfe.submit
+
+pre_script: .fullsend/scripts/pre-fetch.sh
+post_script: .fullsend/scripts/post-submit.sh
+
+validation_loop:
+  script: .fullsend/scripts/validate-artifacts.sh
+  max_iterations: 1
+
+env:
+  runner:
+    FULLSEND_WORK_ITEM_URL: "${FULLSEND_WORK_ITEM_URL}"
+    JIRA_SERVER: "${JIRA_SERVER}"
+    JIRA_USER: "${JIRA_USER}"
+    JIRA_TOKEN: "${JIRA_TOKEN}"
+    JIRA_PROJECT: "${JIRA_PROJECT}"
+  sandbox:
+    FULLSEND_WORK_ITEM_URL: "${FULLSEND_WORK_ITEM_URL}"

--- a/.fullsend/scripts/post-submit.sh
+++ b/.fullsend/scripts/post-submit.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Get recommendations — outputs lines like SUBMIT=RHAIRFE-1234,DRAFT-001
+# Get recommendations — outputs lines like SUBMIT=PROJ-1234,DRAFT-001
 eval "$(python3 scripts/collect_recommendations.py --from-reviews)"
 
 if [[ -z "${SUBMIT:-}" ]]; then

--- a/.fullsend/scripts/post-submit.sh
+++ b/.fullsend/scripts/post-submit.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get recommendations — outputs lines like SUBMIT=RHAIRFE-1234,DRAFT-001
+eval "$(python3 scripts/collect_recommendations.py --from-reviews)"
+
+if [[ -z "${SUBMIT:-}" ]]; then
+    echo "No RFEs recommended for submission. Done."
+    exit 0
+fi
+
+# Submit all passing RFEs
+python3 scripts/submit.py --ids "$SUBMIT" --artifacts-dir artifacts

--- a/.fullsend/scripts/pre-fetch.sh
+++ b/.fullsend/scripts/pre-fetch.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Extract issue key from URL
-# e.g., https://issues.redhat.com/browse/RHAIRFE-1234 -> RHAIRFE-1234
+# e.g., https://issues.redhat.com/browse/PROJ-1234 -> PROJ-1234
 ISSUE_KEY="${FULLSEND_WORK_ITEM_URL##*/}"
 
 # Fetch issue and write all artifact files (task, original, comments)

--- a/.fullsend/scripts/pre-fetch.sh
+++ b/.fullsend/scripts/pre-fetch.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Extract issue key from URL
+# e.g., https://issues.redhat.com/browse/RHAIRFE-1234 -> RHAIRFE-1234
+ISSUE_KEY="${FULLSEND_WORK_ITEM_URL##*/}"
+
+# Fetch issue and write all artifact files (task, original, comments)
+python3 scripts/fetch_issue.py "$ISSUE_KEY" --fetch-all artifacts

--- a/.fullsend/scripts/validate-artifacts.sh
+++ b/.fullsend/scripts/validate-artifacts.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+errors=0
+
+# Validate all task files
+for f in artifacts/rfe-tasks/*.md; do
+    [[ "$(basename "$f")" == *-comments.md ]] && continue
+    python3 scripts/frontmatter.py read "$f" > /dev/null || errors=$((errors + 1))
+done
+
+# Validate all review files
+for f in artifacts/rfe-reviews/*-review.md; do
+    python3 scripts/frontmatter.py read "$f" > /dev/null || errors=$((errors + 1))
+done
+
+# Verify all rfe_ids belong to expected project or are DRAFT-NNN (split children)
+for f in artifacts/rfe-tasks/*.md; do
+    [[ "$(basename "$f")" == *-comments.md ]] && continue
+    rfe_id=$(python3 scripts/frontmatter.py read "$f" \
+        | python3 -c "import sys,json; print(json.load(sys.stdin)['rfe_id'])")
+    # shellcheck disable=SC2254
+    case "$rfe_id" in
+        DRAFT-*) ;;
+        "${JIRA_PROJECT}"-*) ;;
+        *) echo "ERROR: unexpected project in rfe_id: $rfe_id"
+           errors=$((errors + 1)) ;;
+    esac
+done
+
+# Collect recommendations (exits non-zero if review files missing/broken)
+python3 scripts/collect_recommendations.py --from-reviews || errors=$((errors + 1))
+
+exit "$errors"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,14 +16,14 @@ artifacts/
     RHAIRFE-1595-comments.md # Companion: stakeholder comment history
     RHAIRFE-1595-removed-context.yaml  # Companion: structured removed content with type classification
     RHAIRFE-1595-removed-context.md  # Legacy companion (markdown, being phased out)
-    RFE-001.md               # New RFE (pre-submission, renamed on submit)
+    DRAFT-001.md             # New RFE (pre-submission, renamed on submit)
 
   rfe-originals/            # Raw Jira descriptions at time of fetch (not templated)
     RHAIRFE-1595.md          # Baseline for before/after analysis and submit-time conflict detection
 
   rfe-reviews/              # Per-issue review files with YAML frontmatter
     RHAIRFE-1595-review.md
-    RFE-001-review.md
+    DRAFT-001-review.md
 
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # RFE Creator
 
-Skills for creating, reviewing, and submitting RFEs to the RHAIRFE Jira project.
+Skills for creating, reviewing, and submitting RFEs to Jira.
 
 ## Artifact Conventions
 
@@ -12,17 +12,17 @@ artifacts/
   rfes.md                   # Generated index — rebuilt from frontmatter, not a source of truth
 
   rfe-tasks/                # Individual RFE files with YAML frontmatter
-    RHAIRFE-1595.md          # Existing Jira issue (keyed by Jira key)
-    RHAIRFE-1595-comments.md # Companion: stakeholder comment history
-    RHAIRFE-1595-removed-context.yaml  # Companion: structured removed content with type classification
-    RHAIRFE-1595-removed-context.md  # Legacy companion (markdown, being phased out)
+    PROJ-1595.md          # Existing Jira issue (keyed by Jira key)
+    PROJ-1595-comments.md # Companion: stakeholder comment history
+    PROJ-1595-removed-context.yaml  # Companion: structured removed content with type classification
+    PROJ-1595-removed-context.md  # Legacy companion (markdown, being phased out)
     DRAFT-001.md             # New RFE (pre-submission, renamed on submit)
 
   rfe-originals/            # Raw Jira descriptions at time of fetch (not templated)
-    RHAIRFE-1595.md          # Baseline for before/after analysis and submit-time conflict detection
+    PROJ-1595.md          # Baseline for before/after analysis and submit-time conflict detection
 
   rfe-reviews/              # Per-issue review files with YAML frontmatter
-    RHAIRFE-1595-review.md
+    PROJ-1595-review.md
     DRAFT-001-review.md
 
 ```
@@ -65,9 +65,9 @@ Each skill uses distinct file prefixes to avoid collisions during nested calls: 
 
 ### File Naming
 
-- **Existing Jira issues**: Use Jira key as filename and `rfe_id` (e.g., `RHAIRFE-1595.md` with `rfe_id: RHAIRFE-1595`)
+- **Existing Jira issues**: Use Jira key as filename and `rfe_id` (e.g., `PROJ-1595.md` with `rfe_id: PROJ-1595`)
 - **New RFEs (pre-submission)**: Use `RFE-NNN.md` naming with `rfe_id: RFE-NNN`
-- **On submit**: `RFE-NNN.md` files are renamed to `RHAIRFE-NNNN.md`, and `rfe_id` is updated to the Jira key
+- **On submit**: `RFE-NNN.md` files are renamed to `<JIRA_PROJECT>-NNNN.md`, and `rfe_id` is updated to the Jira key
 - **Companion files**: Same prefix as main file with `-comments.md` or `-removed-context.md` suffix
 - **Archived RFEs**: Set `status: Archived` in frontmatter (no filename changes)
 
@@ -83,6 +83,8 @@ Required environment variables:
 JIRA_SERVER=https://your-site.atlassian.net
 JIRA_USER=your-email@example.com
 JIRA_TOKEN=your-api-token
+JIRA_PROJECT=RHAIRFE                     # Required: Jira project key
+JIRA_ISSUE_TYPE=Feature Request          # Optional: defaults to "Feature Request"
 ```
 
 To create an API token: https://id.atlassian.com/manage-profile/security/api-tokens
@@ -98,9 +100,9 @@ Skills that only work with local artifacts (`/rfe.create`) do not require Jira a
 
 ## Jira Field Mappings
 
-### RHAIRFE Project
-- **Project**: `RHAIRFE`
-- **Issue Type**: `Feature Request`
+### Jira Project Configuration
+- **Project**: Set via `JIRA_PROJECT` environment variable (required)
+- **Issue Type**: Set via `JIRA_ISSUE_TYPE` environment variable (default: `Feature Request`)
 - **Priority values** (use these exactly): Blocker, Critical, Major, Normal, Minor, Undefined
 - **Status on creation**: `New`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Required environment variables:
 JIRA_SERVER=https://your-site.atlassian.net
 JIRA_USER=your-email@example.com
 JIRA_TOKEN=your-api-token
-JIRA_PROJECT=RHAIRFE                     # Required: Jira project key
+JIRA_PROJECT=YOURPROJECT                     # Required: Jira project key
 JIRA_ISSUE_TYPE=Feature Request          # Optional: defaults to "Feature Request"
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The strategy skills have moved to a dedicated repo: [ederign/strat-creator](http
 
 All artifacts are written to `artifacts/`. You can edit any file between steps:
 
-- Edit an RFE in `artifacts/rfe-tasks/RFE-001-*.md`, then re-run `/rfe.review`
+- Edit an RFE in `artifacts/rfe-tasks/DRAFT-001-*.md`, then re-run `/rfe.review`
 - Re-run `/rfe.create` to start over from scratch
 
 ## assess-rfe Integration

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ export JIRA_USER=your-email@example.com
 export JIRA_TOKEN=your-api-token
 
 # Set the Jira project key (required)
-export JIRA_PROJECT=RHAIRFE
+export JIRA_PROJECT=YOURPROJECT
 
 # Optionally set the issue type (default: Feature Request)
 export JIRA_ISSUE_TYPE='Feature Request'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RFE Creator
 
-Claude Code skills for creating, reviewing, and submitting RFEs to the RHAIRFE Jira project.
+Claude Code skills for creating, reviewing, and submitting RFEs to Jira.
 
 Inspired by the [PRD/RFE workflow](https://github.com/ambient-code/workflows/tree/main/workflows/prd-rfe-workflow) in ambient, which established the pipeline pattern and multi-perspective review concept.
 
@@ -16,15 +16,15 @@ Inspired by the [PRD/RFE workflow](https://github.com/ambient-code/workflows/tre
 /rfe.auto-fix   # Batch review+revise+split pipeline (non-interactive)
 
 # Improve an existing Jira RFE
-/rfe.review RHAIRFE-1234      # Fetch, review, and auto-revise
-/rfe.split RHAIRFE-1234       # Fetch and split an oversized RFE
-/rfe.speedrun RHAIRFE-1234    # Fetch, review, revise, and update in one step
+/rfe.review PROJ-1234      # Fetch, review, and auto-revise
+/rfe.split PROJ-1234       # Fetch and split an oversized RFE
+/rfe.speedrun PROJ-1234    # Fetch, review, revise, and update in one step
 
 # Batch operations
 /rfe.speedrun --input batch.yaml --headless --dry-run              # Batch create + review from YAML
 /rfe.speedrun --input batch.yaml --headless --announce-complete    # Print completion marker for CI
-/rfe.auto-fix --jql "project = RHAIRFE AND ..."         # Batch review from JQL query
-/rfe.auto-fix RHAIRFE-1234 RHAIRFE-5678                 # Batch review explicit IDs
+/rfe.auto-fix --jql "project = $JIRA_PROJECT AND ..."         # Batch review from JQL query
+/rfe.auto-fix PROJ-1234 PROJ-5678                 # Batch review explicit IDs
 
 # Maintenance
 /rfe-creator.update-deps   # Force update vendored dependencies
@@ -45,10 +45,10 @@ Inspired by the [PRD/RFE workflow](https://github.com/ambient-code/workflows/tre
 ### Existing Jira RFEs
 
 ```
-/rfe.review RHAIRFE-1234 → /rfe.submit
+/rfe.review PROJ-1234 → /rfe.submit
 ```
 
-Or in one step: `/rfe.speedrun RHAIRFE-1234`
+Or in one step: `/rfe.speedrun PROJ-1234`
 
 ### Batch Operations
 
@@ -71,8 +71,8 @@ YAML format:
 Review a batch of existing Jira RFEs:
 
 ```
-/rfe.auto-fix --jql "project = RHAIRFE AND status = New" --limit 20
-/rfe.auto-fix RHAIRFE-1234 RHAIRFE-5678 RHAIRFE-9012
+/rfe.auto-fix --jql "project = $JIRA_PROJECT AND status = New" --limit 20
+/rfe.auto-fix PROJ-1234 PROJ-5678 PROJ-9012
 ```
 
 Auto-fix processes in batches (default 5), handles review, revision, splitting, retry, and report generation.
@@ -87,7 +87,7 @@ The strategy skills have moved to a dedicated repo: [ederign/strat-creator](http
 2. **Review**: Scores RFEs against the assess-rfe rubric, checks technical feasibility, and auto-revises issues. Accepts Jira keys to review existing RFEs. Supports `--headless` for non-interactive use.
 3. **Split**: Decompose an oversized RFE into right-sized pieces. Runs review on new RFEs, self-corrects right-sizing (up to 3 cycles), and checks scope coverage. Supports `--headless`.
 4. **Auto-fix**: Batch pipeline that orchestrates review + revision + split + retry across many RFEs. Accepts explicit IDs or a `--jql` query. Processes in configurable batches (`--batch-size N`, default 5). Generates run reports and HTML review reports.
-5. **Submit**: Creates new RHAIRFE tickets or updates existing ones in Jira. Supports `--dry-run` to validate without writing to Jira.
+5. **Submit**: Creates new Jira tickets or updates existing ones in Jira. Supports `--dry-run` to validate without writing to Jira.
 6. **Speedrun**: End-to-end pipeline (create → auto-fix → submit). Supports `--input <yaml>` for batch creation, `--headless` for CI, `--announce-complete` for completion signaling, `--dry-run` to skip Jira writes, and `--batch-size N`.
 
 ## Editing Between Steps
@@ -119,6 +119,12 @@ Submission uses the Jira REST API directly via Python scripts (not the MCP serve
 export JIRA_SERVER=https://your-site.atlassian.net
 export JIRA_USER=your-email@example.com
 export JIRA_TOKEN=your-api-token
+
+# Set the Jira project key (required)
+export JIRA_PROJECT=RHAIRFE
+
+# Optionally set the issue type (default: Feature Request)
+export JIRA_ISSUE_TYPE='Feature Request'
 ```
 
 The Atlassian MCP server is used for read operations (fetching issues, comments) when available, with a REST API fallback.

--- a/design-proposals/plan-a-thin-dispatcher.md
+++ b/design-proposals/plan-a-thin-dispatcher.md
@@ -672,10 +672,10 @@ BATCH_DONE → BATCH_START: batch=3/3 reason="more batches remain"
 Batch 3/3 complete: submit=45 revise=2 split=0 errors=3
 BATCH_DONE → ERROR_COLLECT: errors=3 retry_cycle=0/1 reason="error IDs found, retry not yet attempted"
 
-ERROR_COLLECT: retry batch 4 with 3 error IDs [RHAIRFE-1501, RHAIRFE-1522, RHAIRFE-1540]
-  RHAIRFE-1501: review_failed (original error preserved)
-  RHAIRFE-1522: revise_failed → task file restored from original
-  RHAIRFE-1540: split_failed → partial children cleaned
+ERROR_COLLECT: retry batch 4 with 3 error IDs [PROJ-1501, PROJ-1522, PROJ-1540]
+  PROJ-1501: review_failed (original error preserved)
+  PROJ-1522: revise_failed → task file restored from original
+  PROJ-1540: split_failed → partial children cleaned
   cleanup verified: 0 stale artifacts remain
 ERROR_COLLECT → BATCH_START: batch=4/4
 
@@ -714,7 +714,7 @@ retry_cycle: 0
 
 ```bash
 python3 scripts/verify_phase.py --phase assess --ids-file tmp/pipeline-active-ids.txt
-# stdout: FAILED=RHAIRFE-1501,RHAIRFE-1522
+# stdout: FAILED=PROJ-1501,PROJ-1522
 # (empty FAILED= if all passed)
 ```
 
@@ -792,8 +792,8 @@ This script is the fan-in join point for the split correction loop: all children
 Add `--errors` flag. Takes IDs as positional args (scopes which IDs to check). Reads review frontmatter for each ID and returns those with a non-null `error` field. Output:
 
 ```bash
-python3 scripts/collect_recommendations.py --errors RHAIRFE-1501 RHAIRFE-1522 RHAIRFE-1540
-# stdout: ERRORS=RHAIRFE-1501,RHAIRFE-1522
+python3 scripts/collect_recommendations.py --errors PROJ-1501 PROJ-1522 PROJ-1540
+# stdout: ERRORS=PROJ-1501,PROJ-1522
 # (empty ERRORS= if none have errors)
 ```
 

--- a/docs/snapshot-incremental-fetch.md
+++ b/docs/snapshot-incremental-fetch.md
@@ -63,15 +63,15 @@ timestamp: "2026-04-02T19:54:37Z"
 bootstrapped_from: "20260402-195436"   # only present on bootstrap snapshots
 issues:
   # Current format (dict with processed flag)
-  RHAIRFE-1234:
+  PROJ-1234:
     hash: "a1b2c3..."
     processed: true
-  RHAIRFE-5678:
+  PROJ-5678:
     hash: "d4e5f6..."
     processed: false
 
   # Legacy format (plain string, still readable — treated as processed: true)
-  RHAIRFE-9999: "g7h8i9..."
+  PROJ-9999: "g7h8i9..."
 ```
 
 ## Content Hashing Pipeline

--- a/docs/state-machine/pipeline-correctness-reference.md
+++ b/docs/state-machine/pipeline-correctness-reference.md
@@ -57,7 +57,7 @@ read/write. Score ranges (0-10, 0-2) are agent-enforced conventions, not schema-
 
 | Field | Type | Required | Constraints | Default | Code Location |
 |---|---|---|---|---|---|
-| `rfe_id` | string | yes | pattern: `^(RFE-\d+\|RHAIRFE-\d+)$` | — | `artifact_utils.py:29-33` |
+| `rfe_id` | string | yes | pattern: `^(RFE-\d+\|[A-Z]+-\d+)$` | — | `artifact_utils.py:29-33` |
 | `title` | string | yes | — | — | `artifact_utils.py:34-36` |
 | `priority` | string | yes | enum: Blocker/Critical/Major/Normal/Minor/Undefined | — | `artifact_utils.py:37-43` |
 | `status` | string | yes | enum: Draft/Ready/Submitted/Archived | — | `artifact_utils.py:44-49` |
@@ -149,7 +149,7 @@ exclusion, and split parent detection. The `rfe_id` pattern constraint causes
 | `SS_PHASE1_PERSIST` | Post archival comments on parent with child content; Phase 2 refuses if incomplete | `split_submit.py:153-174` |
 | `SS_PHASE2_CREATE_LINK` | Create child Jira tickets + "Issue split" links + post confirmation | `split_submit.py:176-262` |
 | `SS_PHASE3_CLOSE` | Label parent with split-original, transition to Closed (resolution: Obsolete); skips gracefully if no Closed transition | `split_submit.py:295-347` |
-| `SS_RENAME` | Post-submit: rename RFE-NNN.md -> RHAIRFE-NNNN.md, update frontmatter | `split_submit.py:507-518` |
+| `SS_RENAME` | Post-submit: rename RFE-NNN.md -> PROJ-NNNN.md, update frontmatter | `split_submit.py:507-518` |
 
 ### 1.10 Snapshot Per-Issue States
 
@@ -280,10 +280,10 @@ The `parent_key` exclusion ensures split children are only processed by
 | **SKIP (no changes)** | Content unchanged, no new labels needed | None | Marked processed |
 | **Label only** | Content unchanged but labels needed (existing label triggers OR new feasibility label needed OR stale feasibility label present in `original_labels`) | `remove_labels()` (if any) then `add_labels()` (if any) | Marked processed, but NO content hash recorded |
 | **Create** | `rfe_id` starts with `RFE-` | `create_issue()` + `rename_to_jira_key()` | Content hash recorded |
-| **Update** | Existing `RHAIRFE-` with content changes | `update_issue()` | Content hash recorded |
+| **Update** | Existing Jira key with content changes | `update_issue()` | Content hash recorded |
 
 Split parent detection requires ALL THREE conditions: `status=Archived` AND
-`rfe_id.startswith("RHAIRFE-")` AND `rfe_id` referenced by at least one task's
+`is_jira_key(rfe_id)` AND `rfe_id` referenced by at least one task's
 `parent_key`. Split parents are processed via `split_submit.py` in Phase 1,
 before regular submissions.
 
@@ -658,7 +658,7 @@ stateDiagram-v2
             SS_Create --> SS_Link : Phase 2: child tickets created
             SS_Link --> SS_Close : Issue split links created
             SS_Close --> SS_Rename : Phase 3: parent labeled +\ntransitioned to Closed
-            SS_Rename --> SS_Done : rename RFE-NNN.md →\nRHAIRFE-NNNN.md
+            SS_Rename --> SS_Done : rename RFE-NNN.md →\nPROJ-NNNN.md
         }
 
         Sub_Phase1 --> Sub_SplitSubmit
@@ -667,7 +667,7 @@ stateDiagram-v2
 
         state "Phase 2: Regular Submit" as Sub_RegularSubmit {
             RS_ConflictCheck --> RS_Create : new RFE (RFE- prefix)
-            RS_ConflictCheck --> RS_Update : existing (RHAIRFE- prefix)
+            RS_ConflictCheck --> RS_Update : existing (Jira key)
             RS_ConflictCheck --> RS_Skip : Jira conflict detected
             RS_Create --> RS_Rename : create_issue() succeeds
             RS_Rename --> RS_Done : rename_to_jira_key()\nstatus=Submitted
@@ -809,7 +809,7 @@ failures that may not surface until production runs.
 - **Content preservation filtering:** `submit.py` only posts `genuine`/`unclassified` removed-context blocks to Jira; `reworded`/`non-substantive` silently dropped (see 1.19).
 - **"Remove labels" path does NOT set `status=Submitted`** — exception to the label-only pattern. Only calls `remove_labels()` and marks processed.
 - **Conflict check is fail-open on exceptions** — Jira API error during conflict check → proceed with submission, not skip. Only content mismatch triggers skip.
-- **Phase 2 re-scans task files after Phase 1 splits** — `split_submit.py` may have renamed `RFE-NNN.md → RHAIRFE-NNNN.md`, so the task file set changes between phases.
+- **Phase 2 re-scans task files after Phase 1 splits** — `split_submit.py` may have renamed `RFE-NNN.md → PROJ-NNNN.md`, so the task file set changes between phases.
 - **Phase 3 completion guard:** `split_submit.py` Phase 3 refuses to close parent if any child not yet created in Jira (analogous to Phase 1 archival comment guard).
 - **`_collect_leaves()` recursively walks parent-child tree** for multi-level splits; intermediary Archived children are traversed (not submitted), only leaf children are submitted.
 - **Component and non-automation label inheritance:** Split children inherit the parent's component field and non-`rfe-creator-*` labels from the parent issue.
@@ -818,7 +818,7 @@ failures that may not surface until production runs.
 - **Needs-attention Jira comments:** Both `submit.py` and `split_submit.py` post explanatory Jira comments when `needs_attention=true`, with a deduplication guard: `_post_needs_attention_comment()` skips posting if `rfe-creator-needs-attention` is already in `original_labels`. Split refusals (exit codes 2/3) post on the parent; `split_submit.py` Phase 2 posts on the newly created child ticket.
 - **Phase 3 summary comment:** `split_submit.py` Phase 3 posts an ADF summary comment on the parent ticket with inlineCard smart links to all child tickets (`build_split_summary_adf()`).
 - **`split_submit.py` conflict check is also fail-open:** Same fail-open behavior as `submit.py` (catches non-`SystemExit` exceptions, prints warning, proceeds). The `SystemExit` re-raise at `split_submit.py:463-464` ensures `sys.exit(3)` from conflict detection is not swallowed.
-- **No originals file bypasses conflict AND content-change checks:** When `rfe-originals/{ID}.md` doesn't exist for an existing RHAIRFE, both checks are skipped and the RFE proceeds unconditionally to Create/Update (`submit.py:371,407`).
+- **No originals file bypasses conflict AND content-change checks:** When `rfe-originals/{ID}.md` doesn't exist for an existing Jira issue, both checks are skipped and the RFE proceeds unconditionally to Create/Update (`submit.py:371,407`).
 - **Phase 2 early exit:** When no submittable RFEs remain after filtering (all Archived/Submitted/parent_key), `submit.py` rebuilds the index and returns, skipping `SB_SNAPSHOT_REGULAR` and `SB_REPORT` (`submit.py:309-316`).
 
 ### 4.4 Cross-Concern Invariants
@@ -829,7 +829,7 @@ failures that may not surface until production runs.
 - **File prefix namespacing** (`autofix-`, `review-`, `split-`, `speedrun-`) prevents collisions during nested skill calls.
 - **Jira API retry policy:** All Jira HTTP operations use `api_call_with_retry` (`jira_utils.py:51-82`): max 3 retries, 429 rate-limiting (respects `Retry-After` header), 502/503/504 server errors (exponential backoff: 1s, 4s, 16s), and `URLError` network errors (same backoff). After exhausting retries, last error is re-raised. All requests have a 60-second timeout (`jira_utils.py:36`).
 - **`scan_task_files()` is the sole discovery mechanism for submit** — no ID list is passed. Excludes companion files, skips validation failures.
-- **Split parent detection requires triple condition:** `status=Archived` AND `rfe_id.startswith("RHAIRFE-")` AND referenced by a child's `parent_key` (see 1.18).
+- **Split parent detection requires triple condition:** `status=Archived` AND `is_jira_key(rfe_id)` AND referenced by a child's `parent_key` (see 1.18).
 
 ---
 

--- a/docs/superpowers/plans/2026-07-13-configurable-jira-project.md
+++ b/docs/superpowers/plans/2026-07-13-configurable-jira-project.md
@@ -1,0 +1,907 @@
+# Configurable Jira Project Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace all hardcoded `RHAIRFE` project key and `Feature Request` issue type references with configurable `JIRA_PROJECT` and `JIRA_ISSUE_TYPE` environment variables.
+
+**Architecture:** A new `scripts/resolve_project.py` validates env vars. A new `is_jira_key()` helper in `artifact_utils.py` replaces all `.startswith("RHAIRFE-")` checks. Schema patterns are generalized to accept any Jira key format. Skills call `resolve_project.py` at startup and prompt the user if `JIRA_PROJECT` is unset.
+
+**Tech Stack:** Python 3, pytest, markdown skill files
+
+---
+
+### Task 1: Add `is_jira_key()` helper and generalize schema patterns in `artifact_utils.py`
+
+**Files:**
+- Modify: `scripts/artifact_utils.py`
+- Test: `tests/test_artifact_utils.py`
+
+- [ ] **Step 1: Write tests for `is_jira_key()`**
+
+Add to `tests/test_artifact_utils.py`:
+
+```python
+class TestIsJiraKey:
+    def test_standard_jira_key(self):
+        from artifact_utils import is_jira_key
+        assert is_jira_key("RHAIRFE-1234") is True
+
+    def test_other_project_key(self):
+        from artifact_utils import is_jira_key
+        assert is_jira_key("MYPROJ-42") is True
+
+    def test_single_letter_project(self):
+        from artifact_utils import is_jira_key
+        assert is_jira_key("X-1") is True
+
+    def test_draft_is_not_jira_key(self):
+        from artifact_utils import is_jira_key
+        assert is_jira_key("DRAFT-001") is False
+
+    def test_lowercase_is_not_jira_key(self):
+        from artifact_utils import is_jira_key
+        assert is_jira_key("rhairfe-1234") is False
+
+    def test_no_number_is_not_jira_key(self):
+        from artifact_utils import is_jira_key
+        assert is_jira_key("RHAIRFE-") is False
+
+    def test_empty_string(self):
+        from artifact_utils import is_jira_key
+        assert is_jira_key("") is False
+
+    def test_alphanumeric_project(self):
+        from artifact_utils import is_jira_key
+        assert is_jira_key("ABC123-456") is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest tests/test_artifact_utils.py::TestIsJiraKey -v`
+Expected: FAIL — `is_jira_key` not found
+
+- [ ] **Step 3: Implement `is_jira_key()` and update schema patterns**
+
+In `scripts/artifact_utils.py`, add at module level (after imports, before SCHEMAS):
+
+```python
+_JIRA_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]+-\d+$")
+
+
+def is_jira_key(identifier):
+    """True if identifier looks like a Jira issue key (e.g., PROJ-1234)."""
+    return bool(_JIRA_KEY_RE.match(identifier))
+```
+
+In the same file, update the three schema pattern fields — change `RHAIRFE-\d+` to `[A-Z][A-Z0-9]+-\d+`:
+
+Line 65: `"pattern": r"^(DRAFT-\d+|[A-Z][A-Z0-9]+-\d+)$",`
+Line 90: `"pattern": r"^(DRAFT-\d+|[A-Z][A-Z0-9]+-\d+)$",`
+Line 103: `"pattern": r"^(DRAFT-\d+|[A-Z][A-Z0-9]+-\d+)$",`
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest tests/test_artifact_utils.py -v`
+Expected: ALL PASS (including existing tests — the generalized pattern still accepts RHAIRFE-*)
+
+- [ ] **Step 5: Lint**
+
+Run: `cd /home/rbean/code/rfe-creator && ruff check scripts/artifact_utils.py tests/test_artifact_utils.py && ruff format --check scripts/artifact_utils.py tests/test_artifact_utils.py`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/artifact_utils.py tests/test_artifact_utils.py
+git commit -S -s -m "$(cat <<'EOF'
+Add is_jira_key() helper and generalize schema patterns
+
+Replace hardcoded RHAIRFE regex patterns with generic Jira key
+pattern [A-Z][A-Z0-9]+-\d+ in schema validation. Add is_jira_key()
+helper for runtime checks.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Replace `.startswith("RHAIRFE-")` with `is_jira_key()` in `artifact_utils.py`
+
+**Files:**
+- Modify: `scripts/artifact_utils.py`
+- Test: `tests/test_artifact_utils.py`
+
+- [ ] **Step 1: Write test for find_artifact_file with non-RHAIRFE key**
+
+Add to `tests/test_artifact_utils.py`:
+
+```python
+class TestFindArtifactFileGenericKey:
+    def test_finds_generic_jira_key(self, tmp_path):
+        from artifact_utils import find_artifact_file, write_frontmatter
+        tasks_dir = tmp_path / "rfe-tasks"
+        tasks_dir.mkdir()
+        task_path = tasks_dir / "MYPROJ-42.md"
+        write_frontmatter(
+            str(task_path),
+            {"rfe_id": "MYPROJ-42", "title": "Test", "priority": "Normal", "status": "Ready"},
+            "rfe-task",
+        )
+        result = find_artifact_file(str(tmp_path), "MYPROJ-42")
+        assert result is not None
+        assert "MYPROJ-42.md" in result
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest tests/test_artifact_utils.py::TestFindArtifactFileGenericKey -v`
+Expected: FAIL — function returns None because `.startswith("RHAIRFE-")` doesn't match MYPROJ-42
+
+- [ ] **Step 3: Replace all `.startswith("RHAIRFE-")` in artifact_utils.py**
+
+In `scripts/artifact_utils.py`, replace every `identifier.startswith("RHAIRFE-")` with `is_jira_key(identifier)`. These are at lines 495, 528, 549, 570, 594. Each follows the same pattern — the function checks `startswith("RHAIRFE-")` and `startswith("DRAFT-")` as two branches. After the change, the DRAFT branch stays as-is, and the RHAIRFE branch becomes `is_jira_key(identifier)`.
+
+For example, in `find_artifact_file` (line 495):
+```python
+        # Match by Jira key (exact: PROJ-1595.md)
+        if is_jira_key(identifier):
+            if filename == f"{identifier}.md":
+```
+
+Apply the same change at lines 528, 549, 570, 594.
+
+- [ ] **Step 4: Run all artifact_utils tests**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest tests/test_artifact_utils.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+ruff check scripts/artifact_utils.py tests/test_artifact_utils.py && ruff format --check scripts/artifact_utils.py tests/test_artifact_utils.py
+git add scripts/artifact_utils.py tests/test_artifact_utils.py
+git commit -S -s -m "$(cat <<'EOF'
+Replace .startswith("RHAIRFE-") with is_jira_key() in artifact_utils
+
+All artifact discovery functions now accept any Jira key format,
+not just RHAIRFE-*.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Create `scripts/resolve_project.py`
+
+**Files:**
+- Create: `scripts/resolve_project.py`
+- Create: `tests/test_resolve_project.py`
+
+- [ ] **Step 1: Write tests**
+
+Create `tests/test_resolve_project.py`:
+
+```python
+"""Tests for resolve_project.py."""
+
+import os
+import subprocess
+import sys
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "resolve_project.py")
+
+
+class TestResolveProject:
+    def test_both_set(self, monkeypatch):
+        monkeypatch.setenv("JIRA_PROJECT", "MYPROJ")
+        monkeypatch.setenv("JIRA_ISSUE_TYPE", "Bug")
+        result = subprocess.run(
+            [sys.executable, SCRIPT],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "JIRA_PROJECT": "MYPROJ", "JIRA_ISSUE_TYPE": "Bug"},
+        )
+        assert result.returncode == 0
+        assert "JIRA_PROJECT=MYPROJ" in result.stdout
+        assert "JIRA_ISSUE_TYPE=Bug" in result.stdout
+
+    def test_project_only_defaults_issue_type(self):
+        env = {k: v for k, v in os.environ.items() if k != "JIRA_ISSUE_TYPE"}
+        env["JIRA_PROJECT"] = "RHAIRFE"
+        result = subprocess.run(
+            [sys.executable, SCRIPT], capture_output=True, text=True, env=env
+        )
+        assert result.returncode == 0
+        assert "JIRA_PROJECT=RHAIRFE" in result.stdout
+        assert "JIRA_ISSUE_TYPE=Feature Request" in result.stdout
+
+    def test_missing_project_exits_nonzero(self):
+        env = {k: v for k, v in os.environ.items() if k not in ("JIRA_PROJECT", "JIRA_ISSUE_TYPE")}
+        result = subprocess.run(
+            [sys.executable, SCRIPT], capture_output=True, text=True, env=env
+        )
+        assert result.returncode == 1
+        assert "JIRA_PROJECT" in result.stderr
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest tests/test_resolve_project.py -v`
+Expected: FAIL — script doesn't exist
+
+- [ ] **Step 3: Implement `scripts/resolve_project.py`**
+
+Create `scripts/resolve_project.py`:
+
+```python
+#!/usr/bin/env python3
+"""Resolve Jira project configuration from environment variables.
+
+Prints JIRA_PROJECT and JIRA_ISSUE_TYPE as KEY=VALUE lines.
+Exits non-zero if JIRA_PROJECT is not set.
+
+Usage:
+    python3 scripts/resolve_project.py
+"""
+
+import os
+import sys
+
+
+def main():
+    project = os.environ.get("JIRA_PROJECT")
+    issue_type = os.environ.get("JIRA_ISSUE_TYPE", "Feature Request")
+
+    if not project:
+        print(
+            "ERROR: JIRA_PROJECT is not set.\n"
+            "Set the Jira project key for this RFE workflow:\n"
+            "  export JIRA_PROJECT=RHAIRFE\n"
+            "Optionally set the issue type (default: Feature Request):\n"
+            "  export JIRA_ISSUE_TYPE='Feature Request'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"JIRA_PROJECT={project}")
+    print(f"JIRA_ISSUE_TYPE={issue_type}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest tests/test_resolve_project.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+ruff check scripts/resolve_project.py tests/test_resolve_project.py && ruff format --check scripts/resolve_project.py tests/test_resolve_project.py
+git add scripts/resolve_project.py tests/test_resolve_project.py
+git commit -S -s -m "$(cat <<'EOF'
+Add resolve_project.py for Jira project env var validation
+
+Centralizes JIRA_PROJECT and JIRA_ISSUE_TYPE resolution. Skills
+call this at startup; exits non-zero if JIRA_PROJECT is unset.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Update `submit.py` to use env vars instead of hardcoded values
+
+**Files:**
+- Modify: `scripts/submit.py`
+- Test: `tests/test_submit.py`
+
+- [ ] **Step 1: Write test for env-var-based project key**
+
+Add to `tests/test_submit.py`:
+
+```python
+class TestProjectEnvVar:
+    """submit.py reads JIRA_PROJECT and JIRA_ISSUE_TYPE from env."""
+
+    def test_uses_jira_project_env(self, tmp_path, monkeypatch):
+        """Dry-run output uses JIRA_PROJECT, not hardcoded RHAIRFE."""
+        monkeypatch.setenv("JIRA_PROJECT", "TESTPROJ")
+        monkeypatch.setenv("JIRA_ISSUE_TYPE", "Story")
+        art_dir = str(tmp_path)
+        _write(
+            f"{art_dir}/rfe-tasks/DRAFT-001.md",
+            "---\nrfe_id: DRAFT-001\ntitle: Test\npriority: Normal\nstatus: Draft\n---\n\nBody.\n",
+        )
+        _write(
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_FM.format(rfe_id="DRAFT-001", auto_revised="false"),
+        )
+        out = _run_submit(art_dir, dry_run=True)
+        assert "Would create TESTPROJ ticket" in out
+        assert "RHAIRFE" not in out
+```
+
+Note: `_write`, `_run_submit`, and `REVIEW_FM` are existing test helpers in `tests/test_submit.py`. Check the existing test file for their exact definitions and import them or use them as-is.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest tests/test_submit.py::TestProjectEnvVar -v`
+Expected: FAIL — output still says "RHAIRFE"
+
+- [ ] **Step 3: Update `scripts/submit.py`**
+
+Make these changes in `scripts/submit.py`:
+
+1. **Line 698** — change dry-run message:
+```python
+                    project = os.environ.get("JIRA_PROJECT", "UNKNOWN")
+                    print(f"  {rfe_id}: Would create {project} ticket: {title}")
+                    results[rfe_id] = f"{project}-DRY"
+```
+
+2. **Lines 701-706** — change `create_issue` call:
+```python
+                    new_key = create_issue(
+                        server,
+                        user,
+                        token,
+                        os.environ["JIRA_PROJECT"],
+                        os.environ.get("JIRA_ISSUE_TYPE", "Feature Request"),
+                        title,
+                        description_adf,
+                        entry["priority"],
+                        labels=labels,
+                    )
+```
+
+3. **Line 746** — change dry-run key check:
+```python
+                if new_key and not new_key.endswith("-DRY"):
+```
+
+4. **Lines 193, 199, 214, 218, 327** — replace all `.startswith("RHAIRFE-")` with `is_jira_key()`:
+
+Add to imports (around line 49):
+```python
+from artifact_utils import (  # noqa: E402
+    ValidationError,
+    find_removed_context_yaml,
+    find_review_file,
+    is_jira_key,
+    read_frontmatter_validated,
+    rebuild_index,
+    rename_to_jira_key,
+    scan_task_files,
+    update_frontmatter,
+)
+```
+
+Then replace:
+- Line 199: `and is_jira_key(data["rfe_id"])` (was `.startswith("RHAIRFE-")`)
+- Line 218: `if is_jira_key(pk):` (was `pk.startswith("RHAIRFE-")`)
+- Line 327: `if is_jira_key(rfe_id):` (was `rfe_id.startswith("RHAIRFE-")`)
+- Line 390: `is_existing = is_jira_key(rfe_id)` (was `rfe_id.startswith("RHAIRFE-")`)
+
+5. **Update comments/docstring** — line 5: change `(RHAIRFE with status: Archived)` to `(Jira issues with status: Archived)`; line 193 comment, line 206 comment, line 355 comment, line 357-358 comments: replace `RHAIRFE` with generic references.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest tests/test_submit.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+ruff check scripts/submit.py tests/test_submit.py && ruff format --check scripts/submit.py tests/test_submit.py
+git add scripts/submit.py tests/test_submit.py
+git commit -S -s -m "$(cat <<'EOF'
+Use JIRA_PROJECT and JIRA_ISSUE_TYPE env vars in submit.py
+
+Replace hardcoded "RHAIRFE" project key and "Feature Request"
+issue type with environment variable lookups.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Update `split_submit.py` to use env vars
+
+**Files:**
+- Modify: `scripts/split_submit.py`
+- Test: `tests/test_split_submit.py`
+
+- [ ] **Step 1: Write test for env-var-based project key in split_submit**
+
+Add to `tests/test_split_submit.py`:
+
+```python
+class TestSplitProjectEnvVar:
+    def test_dry_run_uses_jira_project(self, tmp_path, monkeypatch):
+        """Dry-run output uses JIRA_PROJECT, not hardcoded RHAIRFE."""
+        monkeypatch.setenv("JIRA_PROJECT", "TESTPROJ")
+        # ... set up parent + child artifacts with TESTPROJ-1000 as parent ...
+        # Run split_submit.py TESTPROJ-1000 --dry-run
+        # Assert "Would create TESTPROJ ticket" in output
+        # Assert "RHAIRFE" not in output
+```
+
+Note: Check `tests/test_split_submit.py` for existing test structure and helpers. The test should follow the same pattern.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest tests/test_split_submit.py::TestSplitProjectEnvVar -v`
+
+- [ ] **Step 3: Update `scripts/split_submit.py`**
+
+1. **Line 242** — change dry-run message:
+```python
+                f"  Phase 2: Would create {os.environ.get('JIRA_PROJECT', 'UNKNOWN')} ticket for child "
+```
+
+2. **Line 255** — change dry-run key:
+```python
+            state.phase2_done[idx] = f"{os.environ.get('JIRA_PROJECT', 'UNKNOWN')}-DRY"
+```
+
+3. **Lines 263-264** — change `create_issue` call:
+```python
+            "RHAIRFE",      ->  os.environ["JIRA_PROJECT"],
+            "Feature Request",  ->  os.environ.get("JIRA_ISSUE_TYPE", "Feature Request"),
+```
+
+4. **Line 556** — change dry-run key check:
+```python
+        if not assigned_key or assigned_key.endswith("-DRY"):
+```
+
+5. **Line 442** — update comment: `RHAIRFE parent` -> `Jira parent`
+
+6. **Line 13** — update docstring usage example: `RHAIRFE-XXXX` -> `PROJ-XXXX`
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest tests/test_split_submit.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+ruff check scripts/split_submit.py tests/test_split_submit.py && ruff format --check scripts/split_submit.py tests/test_split_submit.py
+git add scripts/split_submit.py tests/test_split_submit.py
+git commit -S -s -m "$(cat <<'EOF'
+Use JIRA_PROJECT and JIRA_ISSUE_TYPE env vars in split_submit.py
+
+Replace hardcoded project key and issue type with environment
+variable lookups.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Update remaining scripts with `.startswith("RHAIRFE-")` checks
+
+**Files:**
+- Modify: `scripts/check_conflicts.py`
+- Modify: `scripts/generate_review_pdf.py`
+- Modify: `scripts/jira_utils.py`
+
+- [ ] **Step 1: Update `scripts/check_conflicts.py`**
+
+Line 104: change `if not rfe_id.startswith("RHAIRFE-"):` to:
+
+```python
+        if not is_jira_key(rfe_id):
+```
+
+Add import at top (after existing imports from artifact_utils, line 35):
+```python
+from artifact_utils import is_jira_key, scan_task_files
+```
+
+(Replace the existing `from artifact_utils import scan_task_files` line.)
+
+- [ ] **Step 2: Update `scripts/generate_review_pdf.py`**
+
+Lines 1304 and 1310: change `rfe_id.startswith("RHAIRFE-")` to:
+
+```python
+        if jira_server and is_jira_key(rfe_id):
+```
+
+Add import. Find the existing imports from artifact_utils or add near top:
+```python
+from artifact_utils import is_jira_key
+```
+
+Note: `generate_review_pdf.py` is a large file. Check existing imports from artifact_utils and add `is_jira_key` to them.
+
+- [ ] **Step 3: Update `scripts/jira_utils.py`**
+
+Line 701: change the title heading regex:
+```python
+        if re.match(r"^#\s+(DRAFT-\d+|[A-Z][A-Z0-9]+-\d+):", line):
+```
+
+Also update the comment on line 678:
+```python
+    - Title headings (# DRAFT-NNN: / # PROJ-NNN:)
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+ruff check scripts/check_conflicts.py scripts/generate_review_pdf.py scripts/jira_utils.py && ruff format --check scripts/check_conflicts.py scripts/generate_review_pdf.py scripts/jira_utils.py
+git add scripts/check_conflicts.py scripts/generate_review_pdf.py scripts/jira_utils.py
+git commit -S -s -m "$(cat <<'EOF'
+Replace remaining RHAIRFE checks in scripts with is_jira_key()
+
+Update check_conflicts.py, generate_review_pdf.py, and
+jira_utils.py strip_metadata to use generic Jira key patterns.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Update docstrings and help text in scripts (no logic changes)
+
+**Files:**
+- Modify: `scripts/split_submit.py` (if not done in Task 5)
+- Modify: `scripts/fetch_issue.py`
+- Modify: `scripts/prep_assess.py`
+- Modify: `scripts/check_revised.py`
+- Modify: `scripts/check_resume.py`
+- Modify: `scripts/jql_query.py`
+- Modify: `scripts/cleanup_partial_split.py`
+- Modify: `scripts/collect_children.py`
+- Modify: `scripts/batch_summary.py`
+- Modify: `scripts/collect_recommendations.py`
+
+- [ ] **Step 1: Update docstring/help examples**
+
+In each file, replace `RHAIRFE-XXXX` or `RHAIRFE-1234` in docstrings, help text, and comments with generic equivalents like `PROJ-1234` or `<KEY>`. These are documentation-only changes — no logic.
+
+Files and specific lines:
+
+- `scripts/fetch_issue.py` lines 9, 14, 148: `RHAIRFE-1234` -> `PROJ-1234`
+- `scripts/prep_assess.py` line 8: `RHAIRFE-1234` -> `PROJ-1234`
+- `scripts/check_revised.py` line 14: `RHAIRFE-1504 RHAIRFE-1510` -> `PROJ-1504 PROJ-1510`
+- `scripts/check_resume.py` line 22: `RHAIRFE-1234 RHAIRFE-5678` -> `PROJ-1234 PROJ-5678`
+- `scripts/jql_query.py` lines 5, 9, 10: `RHAIRFE` -> `PROJ`
+- `scripts/cleanup_partial_split.py` line 24: `RHAIRFE-100` -> `PROJ-100`
+- `scripts/collect_children.py` line 16: `RHAIRFE-100` -> `PROJ-100`
+- `scripts/batch_summary.py` line 17: `RHAIRFE-100` -> `PROJ-100`
+- `scripts/collect_recommendations.py` line 84 comment: `RHAIRFE-1234-review.md` -> `PROJ-1234-review.md`
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest -v`
+Expected: ALL PASS (docs-only changes)
+
+- [ ] **Step 3: Lint and commit**
+
+```bash
+ruff check scripts/fetch_issue.py scripts/prep_assess.py scripts/check_revised.py scripts/check_resume.py scripts/jql_query.py scripts/cleanup_partial_split.py scripts/collect_children.py scripts/batch_summary.py scripts/collect_recommendations.py
+git add scripts/fetch_issue.py scripts/prep_assess.py scripts/check_revised.py scripts/check_resume.py scripts/jql_query.py scripts/cleanup_partial_split.py scripts/collect_children.py scripts/batch_summary.py scripts/collect_recommendations.py
+git commit -S -s -m "$(cat <<'EOF'
+Update script docstrings to use generic Jira project examples
+
+Replace RHAIRFE-* examples in help text and comments with
+generic PROJ-* placeholders.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Update tests to not depend on hardcoded RHAIRFE
+
+**Files:**
+- Modify: `tests/conftest.py`
+- Modify: `tests/test_submit.py`
+- Modify: `tests/test_split_submit.py`
+- Modify: `tests/test_artifact_utils.py`
+- Modify: other test files as needed
+
+- [ ] **Step 1: Update `tests/conftest.py`**
+
+Lines 106-111: The jira emulator fixture patches `RHAIRFE Workflow`. This is emulator-internal config — keep the workflow name as-is since it matches the emulator's seed data. But update the docstring example on line 88 from `RHAIRFE-1` to a generic example.
+
+The `jira.create()` helper on line 126 derives the project from the key (`key.split("-")[0]`), so it already works with any project key. No code changes needed, just the docstring.
+
+- [ ] **Step 2: Update `tests/test_submit.py`**
+
+Set `JIRA_PROJECT` in tests that exercise the create path. Add `monkeypatch.setenv("JIRA_PROJECT", "RHAIRFE")` at the top of test methods that call `_run_submit` with `dry_run=False` or that check for RHAIRFE in output. Alternatively, add it to the test class setup.
+
+For tests that already use `RHAIRFE-1234` as fixture data — these are fine since the schema now accepts any Jira key. The key change is ensuring `JIRA_PROJECT` is set in tests that exercise `submit.py`'s create path (which now reads the env var).
+
+- [ ] **Step 3: Update other test files**
+
+For each test file with RHAIRFE references (`test_split_submit.py`, `test_pipeline_state.py`, `test_generate_run_report.py`, `test_check_review_progress.py`, `test_state.py`, `test_snapshot_fetch.py`, `test_snapshot_fetch_integration.py`, `test_markdown_to_adf.py`, `test_clone_results_repo.py`, `test_check_revised.py`, `test_check_resume.py`, `test_bootstrap_snapshot.py`, `test_draft_prefix.py`):
+
+Most of these use `RHAIRFE-*` as fixture data for IDs — these still work because `is_jira_key()` and the schema accept any Jira key. Only fix tests that:
+1. Assert on `RHAIRFE` appearing in output (update to match the env var or use the fixture ID)
+2. Need `JIRA_PROJECT` set to run `submit.py` or `split_submit.py`
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+git add tests/
+git commit -S -s -m "$(cat <<'EOF'
+Update tests for configurable JIRA_PROJECT
+
+Set JIRA_PROJECT env var in tests that exercise submit paths.
+Existing RHAIRFE-* fixture data still works with generalized
+schema patterns.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: Update skills to call `resolve_project.py` at startup
+
+**Files:**
+- Modify: `.claude/skills/rfe.review/SKILL.md`
+- Modify: `.claude/skills/rfe.submit/SKILL.md`
+- Modify: `.claude/skills/rfe.split/SKILL.md`
+- Modify: `.claude/skills/rfe.speedrun/SKILL.md`
+- Modify: `.claude/skills/rfe.auto-fix/SKILL.md`
+- Modify: `.claude/skills/rfe-feasibility-review/SKILL.md`
+- Modify: `.claude/skills/rfe.split/prompts/split-agent.md`
+
+- [ ] **Step 1: Add resolve-project gate to each skill**
+
+For `rfe.review`, `rfe.split`, `rfe.speedrun`, `rfe.auto-fix` — add before the first step (after argument parsing):
+
+```markdown
+### Resolve Jira Project
+
+Before any Jira interaction, run:
+
+```bash
+python3 scripts/resolve_project.py
+```
+
+If it exits non-zero, ask the user:
+> What Jira project key should I use? (e.g., RHAIRFE, MYPROJECT)
+
+Then export:
+```bash
+export JIRA_PROJECT=<answer>
+```
+
+Optionally ask about issue type (default: Feature Request). Re-run `resolve_project.py` to confirm.
+```
+
+For `rfe.submit` — replace the existing "Step 0: Check Credentials" to also check `JIRA_PROJECT`:
+
+```markdown
+## Step 0: Check Configuration
+
+Run `python3 scripts/resolve_project.py` to verify `JIRA_PROJECT` is set.
+If it exits non-zero, tell the user:
+
+> RFE submission requires a Jira project. Set:
+> ```
+> export JIRA_PROJECT=RHAIRFE
+> ```
+
+Then check `JIRA_SERVER`, `JIRA_USER`, `JIRA_TOKEN` as before.
+```
+
+For `rfe-feasibility-review` — this is a subagent skill that doesn't interact with Jira directly. Only update the example on line 56: `RHAIRFE-1234` -> `PROJ-1234`.
+
+- [ ] **Step 2: Update RHAIRFE references in skill descriptions and examples**
+
+In each skill file:
+
+- `rfe.review/SKILL.md` line 3: `RHAIRFE-1234 RHAIRFE-5678` -> `PROJ-1234 PROJ-5678`; line 15: `RHAIRFE-NNNN` -> Jira key
+- `rfe.submit/SKILL.md` line 3: `Creates new RHAIRFE tickets` -> `Creates new Jira tickets`; line 8: `create or update RHAIRFE Jira tickets` -> `create or update Jira tickets`
+- `rfe.split/SKILL.md` line 3: `RHAIRFE-1234 RHAIRFE-5678` -> `PROJ-1234 PROJ-5678`; line 14: `RHAIRFE-NNNN` -> Jira key; line 160: `RHAIRFE-1234` -> `PROJ-1234`
+- `rfe.speedrun/SKILL.md` line 18: `RHAIRFE-NNNN` -> Jira key; line 30: `RHAIRFE-NNNN` -> Jira key; line 187: `RHAIRFE-NNNN` -> `<JIRA_PROJECT>-NNNN`
+- `rfe.auto-fix/SKILL.md` lines 125, 130: `RHAIRFE-1234` -> `PROJ-1234`
+- `rfe.split/prompts/split-agent.md` line 13: `RHAIRFE level` -> `RFE level`; `RHAISTRAT level` -> `strategy level`
+
+- [ ] **Step 3: Run skillsaw lint if available**
+
+Run: `cd /home/rbean/code/rfe-creator && make skillsaw 2>/dev/null || echo "skillsaw not available"`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/
+git commit -S -s -m "$(cat <<'EOF'
+Add resolve_project.py gate to skills and remove RHAIRFE refs
+
+Each skill now calls resolve_project.py at startup and prompts
+the user if JIRA_PROJECT is unset. Skill descriptions and
+examples updated to use generic project references.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 10: Update documentation (README, AGENTS.md, CLAUDE.md)
+
+**Files:**
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update `README.md`**
+
+Replace all `RHAIRFE-*` examples with generic equivalents. Key changes:
+
+- Line 3: `to the RHAIRFE Jira project` -> `to Jira`
+- Lines 19-21: `RHAIRFE-1234` -> `PROJ-1234`
+- Lines 26-27: `project = RHAIRFE AND ...` -> `project = $JIRA_PROJECT AND ...`; `RHAIRFE-1234 RHAIRFE-5678` -> `PROJ-1234 PROJ-5678`
+- Lines 48, 51: `RHAIRFE-1234` -> `PROJ-1234`
+- Lines 74-75: same treatment
+- Line 90: `Creates new RHAIRFE tickets` -> `Creates new Jira tickets`
+- Add to the Jira Integration section (after the env vars block):
+
+```markdown
+# Set the Jira project key (required)
+export JIRA_PROJECT=RHAIRFE
+
+# Optionally set the issue type (default: Feature Request)
+export JIRA_ISSUE_TYPE='Feature Request'
+```
+
+- [ ] **Step 2: Update `AGENTS.md`**
+
+- Line 3: `to the RHAIRFE Jira project` -> `to Jira`
+- Lines 15-18: `RHAIRFE-1595` -> `PROJ-1595`
+- Line 22: same
+- Lines 25, 68, 70: same
+- Lines 99-105: Replace the "RHAIRFE Project" section with a generic "Jira Project Configuration" section:
+
+```markdown
+## Jira Project Configuration
+- **Project**: Set via `JIRA_PROJECT` environment variable (required)
+- **Issue Type**: Set via `JIRA_ISSUE_TYPE` environment variable (default: `Feature Request`)
+- **Priority values** (use these exactly): Blocker, Critical, Major, Normal, Minor, Undefined
+- **Status on creation**: `New`
+```
+
+- Add `JIRA_PROJECT` and `JIRA_ISSUE_TYPE` to the env vars block.
+
+- [ ] **Step 3: Update `CLAUDE.md`**
+
+The CLAUDE.md is also the basis for the system prompt. Apply the same changes as AGENTS.md (they share most content). The key section is the "Jira Field Mappings" / "RHAIRFE Project" block.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md AGENTS.md CLAUDE.md
+git commit -S -s -m "$(cat <<'EOF'
+Update docs for configurable JIRA_PROJECT
+
+Replace RHAIRFE references in README, AGENTS.md, and CLAUDE.md
+with generic project references and document the new JIRA_PROJECT
+and JIRA_ISSUE_TYPE environment variables.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 11: Update config files (eval, fullsend, ambient)
+
+**Files:**
+- Modify: `eval.yaml`
+- Modify: `eval.md`
+- Modify: `.fullsend/scripts/post-submit.sh`
+- Modify: `.fullsend/README.md`
+- Modify: `.ambient/ambient.json`
+
+- [ ] **Step 1: Update `eval.yaml`**
+
+Line 92: `RHAIRFE-NNNN.md (fetched)` -> `<PROJECT>-NNNN.md (fetched)`
+
+- [ ] **Step 2: Update `eval.md`**
+
+Lines 47, 50: `RHAIRFE` -> generic references. These are analysis docs describing the pipeline — update examples to use `PROJ-NNNN` or `$JIRA_PROJECT`.
+
+- [ ] **Step 3: Update `.fullsend/scripts/post-submit.sh`**
+
+Line 4 comment: `SUBMIT=RHAIRFE-1234,DRAFT-001` -> `SUBMIT=PROJ-1234,DRAFT-001`
+
+- [ ] **Step 4: Update `.fullsend/README.md`**
+
+Replace any `RHAIRFE` references with generic equivalents.
+
+- [ ] **Step 5: Update `.ambient/ambient.json`**
+
+Line 3: `"Submit to Jira as RHAIRFEs"` -> `"Submit to Jira"`
+Line 4 systemPrompt: `"Submit to Jira as RHAIRFEs"` -> `"Submit to Jira"`
+Line 6 greeting: `"Submit to Jira as RHAIRFEs"` -> `"Submit to Jira"`
+
+- [ ] **Step 6: Update `docs/` files with RHAIRFE references**
+
+Check `docs/superpowers/plans/2026-07-13-fullsend-harness.md`, `docs/superpowers/specs/2026-07-13-fullsend-harness-design.md`, `docs/state-machine/pipeline-correctness-reference.md`, `docs/snapshot-incremental-fetch.md` — update any RHAIRFE references to generic form. These are internal docs, so use `PROJ-NNNN` or `$JIRA_PROJECT` as appropriate.
+
+Also update `design-proposals/plan-a-thin-dispatcher.md`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add eval.yaml eval.md .fullsend/ .ambient/ docs/ design-proposals/
+git commit -S -s -m "$(cat <<'EOF'
+Update config and docs for configurable JIRA_PROJECT
+
+Replace RHAIRFE references in eval configs, fullsend harness,
+ambient config, and internal docs with generic project references.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 12: Final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd /home/rbean/code/rfe-creator && python -m pytest -v`
+Expected: ALL PASS
+
+- [ ] **Step 2: Run linter**
+
+Run: `cd /home/rbean/code/rfe-creator && make lint`
+Expected: PASS
+
+- [ ] **Step 3: Verify no remaining RHAIRFE in code (except test fixtures)**
+
+Run: `cd /home/rbean/code/rfe-creator && grep -rn "RHAIRFE" --include="*.py" --include="*.md" --include="*.yaml" --include="*.json" --include="*.sh" | grep -v "^tests/" | grep -v "^docs/superpowers/specs/2026-07-13-configurable-jira-project" | grep -v "^docs/superpowers/plans/2026-07-13-configurable-jira-project"`
+
+Expected: Zero results (or only in test fixtures and the design/plan docs themselves). Any remaining hits need to be addressed.
+
+- [ ] **Step 4: Verify RHAIRFE in tests is only fixture data, not logic**
+
+Run: `cd /home/rbean/code/rfe-creator && grep -rn "RHAIRFE" tests/ | grep -v "RHAIRFE-" | head -20`
+
+Expected: Only the jira emulator workflow name reference in `conftest.py` (which is emulator-internal config).
+
+- [ ] **Step 5: Commit any remaining fixes**
+
+If Step 3 or 4 found issues, fix and commit.

--- a/docs/superpowers/plans/2026-07-13-fullsend-harness.md
+++ b/docs/superpowers/plans/2026-07-13-fullsend-harness.md
@@ -1,0 +1,462 @@
+# Fullsend Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a fullsend harness so `FULLSEND_WORK_ITEM_URL=... fullsend run rfe-creator` processes a Jira issue end-to-end with no skill code changes.
+
+**Architecture:** Pre-script fetches the issue from Jira into `artifacts/`. The agent runs `/rfe.speedrun --headless --dry-run` on local files in a sandbox with no Jira network access. A validation script checks artifact integrity. The post-script reads review recommendations and calls `submit.py` to write results to Jira.
+
+**Tech Stack:** Bash (pre/post/validation scripts), Python (existing `scripts/`), fullsend harness YAML
+
+**Spec:** `docs/superpowers/specs/2026-07-13-fullsend-harness-design.md`
+
+---
+
+### Task 1: Add `--from-reviews` flag to `collect_recommendations.py`
+
+**Files:**
+- Modify: `scripts/collect_recommendations.py:75-100`
+- Test: `tests/test_collect_recommendations.py`
+
+This is the only change to existing code. The validation and post scripts
+need `collect_recommendations.py` to discover IDs by globbing review files
+rather than requiring explicit IDs.
+
+- [ ] **Step 1: Write the failing test for `--from-reviews`**
+
+Add to `tests/test_collect_recommendations.py`:
+
+```python
+class TestFromReviews:
+    def test_discovers_ids_from_review_files(self, art_dir):
+        _write(
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_TEMPLATE.format(
+                rfe_id="DRAFT-001",
+                score=9,
+                pass_val="true",
+                recommendation="submit",
+                auto_revised="false",
+            ),
+        )
+        _write(
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-002-review.md",
+            REVIEW_TEMPLATE.format(
+                rfe_id="DRAFT-002",
+                score=3,
+                pass_val="false",
+                recommendation="reject",
+                auto_revised="false",
+            ),
+        )
+        out, _, rc = _run(["--from-reviews"])
+        assert rc == 0
+        groups = _parse_output(out)
+        assert "DRAFT-001" in groups["SUBMIT"]
+        assert "DRAFT-002" in groups["REJECT"]
+
+    def test_no_review_files_exits_nonzero(self, art_dir):
+        _, _, rc = _run(["--from-reviews"])
+        assert rc != 0
+
+    def test_from_reviews_with_reassess(self, art_dir):
+        _write(
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_TEMPLATE.format(
+                rfe_id="DRAFT-001",
+                score=5,
+                pass_val="false",
+                recommendation="revise",
+                auto_revised="true",
+            ),
+        )
+        out, _, rc = _run(["--from-reviews", "--reassess"])
+        assert rc == 0
+        groups = _parse_output(out)
+        assert "DRAFT-001" in groups["REASSESS"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_collect_recommendations.py::TestFromReviews -v`
+Expected: FAIL — `--from-reviews` is not a recognized argument.
+
+- [ ] **Step 3: Implement `--from-reviews`**
+
+In `scripts/collect_recommendations.py`, add a function to discover IDs
+from review files and wire it into the argument parser:
+
+```python
+def discover_ids_from_reviews():
+    """Glob review files and extract IDs from filenames."""
+    import glob
+
+    review_dir = os.path.join(ARTIFACTS_DIR, "rfe-reviews")
+    pattern = os.path.join(review_dir, "*-review.md")
+    ids = []
+    for path in sorted(glob.glob(pattern)):
+        basename = os.path.basename(path)
+        # DRAFT-001-review.md -> DRAFT-001
+        # PROJ-1234-review.md -> PROJ-1234
+        rfe_id = basename.rsplit("-review.md", 1)[0]
+        ids.append(rfe_id)
+    return ids
+```
+
+Update `main()` — add the `--from-reviews` argument and adjust the ID
+resolution logic:
+
+```python
+def main():
+    parser = argparse.ArgumentParser(description="Group RFE IDs by review recommendation.")
+    parser.add_argument("ids", nargs="*", help="RFE IDs to check")
+    parser.add_argument(
+        "--ids-file", help="Read RFE IDs from a file (one per line) instead of positional args"
+    )
+    parser.add_argument(
+        "--from-reviews",
+        action="store_true",
+        help="Discover IDs by globbing artifacts/rfe-reviews/*-review.md",
+    )
+    parser.add_argument(
+        "--reassess", action="store_true", help="Collect re-assess candidates instead"
+    )
+    parser.add_argument("--errors", action="store_true", help="Collect IDs with error field set")
+    args = parser.parse_args()
+
+    if args.from_reviews:
+        ids = discover_ids_from_reviews()
+        if not ids:
+            print("ERROR: no review files found in artifacts/rfe-reviews/", file=sys.stderr)
+            sys.exit(1)
+    else:
+        ids = resolve_ids(args.ids, args.ids_file)
+        if not ids:
+            parser.error("no RFE IDs provided (pass positionally or via --ids-file)")
+
+    if args.errors:
+        collect_errors(ids)
+    elif args.reassess:
+        collect_reassess(ids)
+    else:
+        collect_default(ids)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_collect_recommendations.py -v`
+Expected: All tests pass, including existing ones.
+
+- [ ] **Step 5: Run linter**
+
+Run: `ruff check scripts/collect_recommendations.py && ruff format --check scripts/collect_recommendations.py`
+Expected: No issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/collect_recommendations.py tests/test_collect_recommendations.py
+git commit -S -s -m "$(cat <<'EOF'
+Add --from-reviews flag to collect_recommendations.py
+
+Discovers RFE IDs by globbing artifacts/rfe-reviews/*-review.md
+instead of requiring explicit IDs. Needed by fullsend harness
+validation and post-submit scripts.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Create the harness config
+
+**Files:**
+- Create: `.fullsend/harnesses/rfe-creator.yaml`
+
+- [ ] **Step 1: Create the harness file**
+
+```yaml
+agent: agents/rfe-creator.md
+model: opus
+policy: fullsend-ai/agents:policies/base.yaml
+timeout_minutes: 30
+
+skills:
+  - .claude/skills/rfe.speedrun
+  - .claude/skills/rfe.create
+  - .claude/skills/rfe.review
+  - .claude/skills/rfe.auto-fix
+  - .claude/skills/rfe.split
+  - .claude/skills/rfe.submit
+
+pre_script: .fullsend/scripts/pre-fetch.sh
+post_script: .fullsend/scripts/post-submit.sh
+
+validation_loop:
+  script: .fullsend/scripts/validate-artifacts.sh
+  max_iterations: 1
+
+env:
+  runner:
+    FULLSEND_WORK_ITEM_URL: "${FULLSEND_WORK_ITEM_URL}"
+    JIRA_SERVER: "${JIRA_SERVER}"
+    JIRA_USER: "${JIRA_USER}"
+    JIRA_TOKEN: "${JIRA_TOKEN}"
+    JIRA_PROJECT: "${JIRA_PROJECT}"
+  sandbox:
+    FULLSEND_WORK_ITEM_URL: "${FULLSEND_WORK_ITEM_URL}"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .fullsend/harnesses/rfe-creator.yaml
+git commit -S -s -m "$(cat <<'EOF'
+Add fullsend harness config for rfe-creator
+
+Wires agent definition, pre/post scripts, validation, env vars,
+and timeout. Jira credentials stay on the runner; the sandbox
+gets only FULLSEND_WORK_ITEM_URL.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Create the agent definition
+
+**Files:**
+- Create: `.fullsend/agents/rfe-creator.md`
+
+- [ ] **Step 1: Create the agent definition**
+
+```markdown
+# RFE Creator Agent
+
+You are an RFE review and improvement agent. Your workspace contains
+a pre-fetched RFE in `artifacts/rfe-tasks/`. Your job is to review,
+score, and improve it.
+
+## Instructions
+
+1. Identify the RFE file in `artifacts/rfe-tasks/`
+2. Run `/rfe.speedrun --headless --dry-run <ISSUE_KEY>` where ISSUE_KEY
+   is the `rfe_id` from the file's frontmatter
+3. Do not contact Jira. All artifacts are local. Jira submission is
+   handled externally after you complete.
+4. When the skill completes, your work is done. The artifacts you
+   produced will be validated and submitted by external tooling.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .fullsend/agents/rfe-creator.md
+git commit -S -s -m "$(cat <<'EOF'
+Add fullsend agent definition for rfe-creator
+
+Adapter layer between fullsend and the rfe.speedrun skill.
+Instructs the agent to work on pre-fetched local artifacts
+with --headless --dry-run; no Jira contact from the sandbox.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Create the pre-fetch script
+
+**Files:**
+- Create: `.fullsend/scripts/pre-fetch.sh`
+
+- [ ] **Step 1: Create the script**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Extract issue key from URL
+# e.g., https://issues.redhat.com/browse/PROJ-1234 -> PROJ-1234
+ISSUE_KEY="${FULLSEND_WORK_ITEM_URL##*/}"
+
+# Fetch issue and write all artifact files (task, original, comments)
+python3 scripts/fetch_issue.py "$ISSUE_KEY" --fetch-all artifacts
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run: `chmod +x .fullsend/scripts/pre-fetch.sh`
+
+- [ ] **Step 3: Run shellcheck**
+
+Run: `shellcheck .fullsend/scripts/pre-fetch.sh`
+Expected: No issues.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .fullsend/scripts/pre-fetch.sh
+git commit -S -s -m "$(cat <<'EOF'
+Add fullsend pre-fetch script
+
+Extracts issue key from FULLSEND_WORK_ITEM_URL and runs
+fetch_issue.py --fetch-all to stage artifacts for the agent.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Create the validation script
+
+**Files:**
+- Create: `.fullsend/scripts/validate-artifacts.sh`
+
+- [ ] **Step 1: Create the script**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+errors=0
+
+# Validate all task files
+for f in artifacts/rfe-tasks/*.md; do
+    [[ "$(basename "$f")" == *-comments.md ]] && continue
+    python3 scripts/frontmatter.py read "$f" > /dev/null || errors=$((errors + 1))
+done
+
+# Validate all review files
+for f in artifacts/rfe-reviews/*-review.md; do
+    python3 scripts/frontmatter.py read "$f" > /dev/null || errors=$((errors + 1))
+done
+
+# Verify all rfe_ids belong to expected project or are DRAFT-NNN (split children)
+for f in artifacts/rfe-tasks/*.md; do
+    [[ "$(basename "$f")" == *-comments.md ]] && continue
+    rfe_id=$(python3 scripts/frontmatter.py read "$f" \
+        | python3 -c "import sys,json; print(json.load(sys.stdin)['rfe_id'])")
+    case "$rfe_id" in
+        DRAFT-*) ;;
+        "${JIRA_PROJECT}"-*) ;;
+        *) echo "ERROR: unexpected project in rfe_id: $rfe_id"
+           errors=$((errors + 1)) ;;
+    esac
+done
+
+# Collect recommendations (exits non-zero if review files missing/broken)
+python3 scripts/collect_recommendations.py --from-reviews || errors=$((errors + 1))
+
+exit "$errors"
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run: `chmod +x .fullsend/scripts/validate-artifacts.sh`
+
+- [ ] **Step 3: Run shellcheck**
+
+Run: `shellcheck .fullsend/scripts/validate-artifacts.sh`
+Expected: No issues. If shellcheck flags the `${JIRA_PROJECT}` in the case
+pattern, add a `# shellcheck disable=SC2254` above that case statement (variable
+in case pattern is intentional here).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .fullsend/scripts/validate-artifacts.sh
+git commit -S -s -m "$(cat <<'EOF'
+Add fullsend artifact validation script
+
+Validates frontmatter on all task and review files, checks that
+rfe_ids belong to the expected JIRA_PROJECT or are DRAFT-NNN
+split children, and verifies recommendations are parseable.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Create the post-submit script
+
+**Files:**
+- Create: `.fullsend/scripts/post-submit.sh`
+
+- [ ] **Step 1: Create the script**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get recommendations — outputs lines like SUBMIT=PROJ-1234,DRAFT-001
+eval "$(python3 scripts/collect_recommendations.py --from-reviews)"
+
+if [[ -z "${SUBMIT:-}" ]]; then
+    echo "No RFEs recommended for submission. Done."
+    exit 0
+fi
+
+# Submit all passing RFEs
+python3 scripts/submit.py --ids "$SUBMIT" --artifacts-dir artifacts
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run: `chmod +x .fullsend/scripts/post-submit.sh`
+
+- [ ] **Step 3: Run shellcheck**
+
+Run: `shellcheck .fullsend/scripts/post-submit.sh`
+Expected: No issues. If shellcheck flags the `eval`, add
+`# shellcheck disable=SC2046` — the eval of collect_recommendations output
+is intentional and controlled (we own the script producing the output).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .fullsend/scripts/post-submit.sh
+git commit -S -s -m "$(cat <<'EOF'
+Add fullsend post-submit script
+
+Reads review recommendations via collect_recommendations.py
+--from-reviews and calls submit.py for RFEs recommended for
+submission. Exits cleanly when nothing is recommended.
+
+Assisted-by: Claude claude-opus-4-6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Run full lint and verify
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run the full lint suite**
+
+Run: `make lint`
+Expected: All checks pass — skillsaw, ruff, shellcheck, pytest.
+
+- [ ] **Step 2: Verify the file layout**
+
+Run: `find .fullsend -type f | sort`
+Expected:
+```
+.fullsend/agents/rfe-creator.md
+.fullsend/harnesses/rfe-creator.yaml
+.fullsend/scripts/post-submit.sh
+.fullsend/scripts/pre-fetch.sh
+.fullsend/scripts/validate-artifacts.sh
+```

--- a/docs/superpowers/specs/2026-07-13-configurable-jira-project-design.md
+++ b/docs/superpowers/specs/2026-07-13-configurable-jira-project-design.md
@@ -1,0 +1,154 @@
+# Configurable Jira Project Key
+
+**Date:** 2026-07-13
+**Status:** Draft
+
+## Problem
+
+The Jira project key `RHAIRFE` and issue type `Feature Request` are hardcoded across 53 files (989 occurrences). This couples the tooling to a single Jira project, preventing reuse with other projects.
+
+## Solution
+
+Replace all hardcoded references with:
+
+- `JIRA_PROJECT` environment variable (required)
+- `JIRA_ISSUE_TYPE` environment variable (optional, defaults to `Feature Request`)
+
+A centralized script (`scripts/resolve_project.py`) validates these at skill startup. If `JIRA_PROJECT` is unset, the skill asks the user and exports it.
+
+## Components
+
+### 1. `scripts/resolve_project.py` (new)
+
+Reads `JIRA_PROJECT` and `JIRA_ISSUE_TYPE` from environment. Prints them as `KEY=VALUE` lines on success. Exits non-zero with a descriptive message if `JIRA_PROJECT` is unset. `JIRA_ISSUE_TYPE` defaults to `Feature Request` if unset.
+
+```
+$ JIRA_PROJECT=RHAIRFE python3 scripts/resolve_project.py
+JIRA_PROJECT=RHAIRFE
+JIRA_ISSUE_TYPE=Feature Request
+
+$ python3 scripts/resolve_project.py
+ERROR: JIRA_PROJECT is not set. ...
+(exit 1)
+```
+
+### 2. Schema patterns in `artifact_utils.py`
+
+Change hardcoded `RHAIRFE` in regex patterns to accept any Jira-style project key:
+
+```python
+# Before
+"pattern": r"^(DRAFT-\d+|RHAIRFE-\d+)$"
+
+# After
+"pattern": r"^(DRAFT-\d+|[A-Z][A-Z0-9]+-\d+)$"
+```
+
+Applies to three fields: `rfe_id` (rfe-task), `parent_key` (rfe-task), `rfe_id` (rfe-review).
+
+### 3. Helper function: `is_jira_key()`
+
+Add to `artifact_utils.py`:
+
+```python
+_JIRA_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]+-\d+$")
+
+def is_jira_key(identifier):
+    """True if identifier looks like a Jira issue key (e.g., RHAIRFE-1234)."""
+    return bool(_JIRA_KEY_RE.match(identifier))
+```
+
+All `.startswith("RHAIRFE-")` checks across scripts become `is_jira_key()` calls. This removes the env var dependency from code that just needs to distinguish Jira keys from DRAFT IDs.
+
+### 4. Scripts using the project key for Jira API calls
+
+These scripts pass the project key to `create_issue()`:
+
+- **`submit.py`** — replace `"RHAIRFE"` literal with `os.environ["JIRA_PROJECT"]`; replace `"Feature Request"` literal with `os.environ.get("JIRA_ISSUE_TYPE", "Feature Request")`
+- **`split_submit.py`** — same treatment
+
+These are the only two scripts that need the env var at runtime. All other scripts use `is_jira_key()` pattern matching instead.
+
+### 5. Scripts with `.startswith("RHAIRFE-")` checks
+
+Replace with `is_jira_key()` (imported from `artifact_utils`):
+
+- `submit.py` — line 199, 218, 327, 390
+- `split_submit.py` — line 556
+- `check_conflicts.py` — line 104
+- `generate_review_pdf.py` — lines 1304, 1310
+- `artifact_utils.py` — lines 495, 528, 549, 570, 594
+
+### 6. `jira_utils.py` `strip_metadata`
+
+Generalize the title heading regex:
+
+```python
+# Before
+if re.match(r"^#\s+(DRAFT-\d+|RHAIRFE-\d+|STRAT-\d+|RHAISTRAT-\d+):", line):
+
+# After
+if re.match(r"^#\s+(DRAFT-\d+|[A-Z][A-Z0-9]+-\d+):", line):
+```
+
+This also covers `STRAT-` and `RHAISTRAT-` since they match the general pattern.
+
+### 7. Skills
+
+Each skill's SKILL.md gets an early-gate block:
+
+```markdown
+**Before any other work**, run:
+    python3 scripts/resolve_project.py
+If it exits non-zero, ask the user for their Jira project key (and optionally
+issue type), then export JIRA_PROJECT=<answer> (and JIRA_ISSUE_TYPE if given).
+Re-run to confirm.
+```
+
+Affected skills:
+- `rfe.review`
+- `rfe.submit`
+- `rfe.split`
+- `rfe.speedrun`
+- `rfe.auto-fix`
+- `rfe-feasibility-review`
+
+### 8. Documentation
+
+- **`CLAUDE.md`** — update env vars section to list `JIRA_PROJECT` and `JIRA_ISSUE_TYPE`; replace `RHAIRFE` in examples with generic placeholders or `$JIRA_PROJECT` references
+- **`AGENTS.md`** — same treatment
+- **`README.md`** — update examples to use generic project keys (e.g., `MYPROJECT-1234`)
+- **Snapshot/pipeline docs** — update any `RHAIRFE` examples
+
+### 9. Tests
+
+Tests that reference `RHAIRFE`:
+- Set `JIRA_PROJECT=TESTPROJ` in test fixtures/conftest where the env var is needed
+- Replace `RHAIRFE-` prefixes in test data with `TESTPROJ-` for consistency
+- Update assertions accordingly
+
+### 10. Eval/fullsend config
+
+- **`eval.yaml`** — update pattern references from `RHAIRFE-NNNN.md` to generic
+- **`.fullsend/scripts/pre-fetch.sh`** — use `$JIRA_PROJECT`
+- **`.fullsend/scripts/post-submit.sh`** — use `$JIRA_PROJECT`
+- **`.ambient/ambient.json`** — update references
+
+## What stays the same
+
+- `JIRA_SERVER`, `JIRA_USER`, `JIRA_TOKEN` env vars — unchanged
+- `DRAFT-NNN` naming convention — unchanged
+- File/directory structure (artifacts/, rfe-tasks/, etc.) — unchanged
+- All Jira API logic in `jira_utils.py` — unchanged (already parameterized)
+- `create_issue()` signature — already takes `project` as a parameter
+
+## Defaults
+
+| Variable | Required | Default |
+|----------|----------|---------|
+| `JIRA_PROJECT` | Yes | (none — must ask user) |
+| `JIRA_ISSUE_TYPE` | No | `Feature Request` |
+
+## Migration
+
+No data migration needed. Existing artifact files with `RHAIRFE-` prefixes will continue to work because `is_jira_key()` accepts any valid Jira key pattern. Users just need to set `JIRA_PROJECT=RHAIRFE` to get the current behavior.

--- a/docs/superpowers/specs/2026-07-13-fullsend-harness-design.md
+++ b/docs/superpowers/specs/2026-07-13-fullsend-harness-design.md
@@ -1,0 +1,283 @@
+# Fullsend Harness for RFE Creator
+
+Date: 2026-07-13
+
+## Problem
+
+The rfe.speedrun skill works well interactively but has no fullsend integration.
+We want `fullsend run rfe-creator` to process a Jira issue end-to-end: fetch,
+review, revise, and submit. The skill itself must remain usable outside fullsend
+with no code changes.
+
+## Design Principles
+
+1. **Skill stays clean.** No fullsend awareness in skill code. The agent
+   definition is the only adapter layer.
+2. **No Jira from the sandbox.** The LLM never contacts Jira. Pre-script
+   fetches, post-script submits. Jira credentials exist only on the runner.
+3. **Artifacts are the contract.** No intermediate JSON schema between agent
+   and post-script. The artifact files (task frontmatter, review frontmatter)
+   are the structured representation. Existing scripts (`collect_recommendations.py`,
+   `submit.py`) already read them.
+4. **Deterministic Jira writes.** `submit.py` and `split_submit.py` handle all
+   Jira API calls, consistent with the existing project convention that write
+   operations are not LLM-dependent.
+
+## Invocation
+
+```bash
+# Manual PoC
+FULLSEND_WORK_ITEM_URL=https://issues.redhat.com/browse/PROJ-1234 \
+  fullsend run rfe-creator
+```
+
+`FULLSEND_WORK_ITEM_URL` is the canonical input per ADR 63 (polling-based work
+discovery). The polling dispatch model and Jira webhook trigger will provide
+this variable automatically once they land. For now, manual invocation suffices.
+
+## File Layout
+
+```
+.fullsend/
+  agents/
+    rfe-creator.md              # Agent definition
+  harnesses/
+    rfe-creator.yaml            # Harness config
+  scripts/
+    pre-fetch.sh                # Fetch issue from Jira into artifacts/
+    post-submit.sh              # Read recommendations, call submit.py
+    validate-artifacts.sh       # Check frontmatter, project IDs, recommendations
+```
+
+No local policy file. The harness references the base policy from
+`fullsend-ai/agents`.
+
+## Harness Config
+
+File: `.fullsend/harnesses/rfe-creator.yaml`
+
+```yaml
+agent: agents/rfe-creator.md
+model: opus
+policy: fullsend-ai/agents:policies/base.yaml
+timeout_minutes: 30
+
+skills:
+  - .claude/skills/rfe.speedrun
+  - .claude/skills/rfe.create
+  - .claude/skills/rfe.review
+  - .claude/skills/rfe.auto-fix
+  - .claude/skills/rfe.split
+  - .claude/skills/rfe.submit
+
+pre_script: .fullsend/scripts/pre-fetch.sh
+post_script: .fullsend/scripts/post-submit.sh
+
+validation_loop:
+  script: .fullsend/scripts/validate-artifacts.sh
+  max_iterations: 1
+
+env:
+  runner:
+    FULLSEND_WORK_ITEM_URL: "${FULLSEND_WORK_ITEM_URL}"
+    JIRA_SERVER: "${JIRA_SERVER}"
+    JIRA_USER: "${JIRA_USER}"
+    JIRA_TOKEN: "${JIRA_TOKEN}"
+    JIRA_PROJECT: "${JIRA_PROJECT}"
+  sandbox:
+    FULLSEND_WORK_ITEM_URL: "${FULLSEND_WORK_ITEM_URL}"
+```
+
+Key decisions:
+
+- **Jira credentials in `runner` only.** The sandbox has no way to contact Jira.
+- **`FULLSEND_WORK_ITEM_URL` in both.** The sandbox gets it for context (the
+  agent knows what issue it is working on) but does not use it for network
+  access.
+- **`JIRA_PROJECT` in `runner`.** Used by the validation script to verify
+  artifact IDs belong to the expected project.
+- **`max_iterations: 1` on validation.** Malformed artifacts are a hard stop,
+  not a retry. Retrying the agent on bad output is unlikely to help.
+
+## Agent Definition
+
+File: `.fullsend/agents/rfe-creator.md`
+
+```markdown
+# RFE Creator Agent
+
+You are an RFE review and improvement agent. Your workspace contains
+a pre-fetched RFE in `artifacts/rfe-tasks/`. Your job is to review,
+score, and improve it.
+
+## Instructions
+
+1. Identify the RFE file in `artifacts/rfe-tasks/`
+2. Run `/rfe.speedrun --headless --dry-run <ISSUE_KEY>` where ISSUE_KEY
+   is the `rfe_id` from the file's frontmatter
+3. Do not contact Jira. All artifacts are local. Jira submission is
+   handled externally after you complete.
+4. When the skill completes, your work is done. The artifacts you
+   produced will be validated and submitted by external tooling.
+```
+
+The `--dry-run` flag ensures the skill skips Phase 3 (submit) even though there
+are no Jira credentials in the sandbox. Belt and suspenders.
+
+## Pre-Script
+
+File: `.fullsend/scripts/pre-fetch.sh`
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Extract issue key from URL
+# e.g., https://issues.redhat.com/browse/PROJ-1234 -> PROJ-1234
+ISSUE_KEY="${FULLSEND_WORK_ITEM_URL##*/}"
+
+# Fetch issue and write all artifact files (task, original, comments)
+python3 scripts/fetch_issue.py "$ISSUE_KEY" --fetch-all artifacts
+```
+
+`fetch_issue.py --fetch-all` already creates:
+
+- `artifacts/rfe-tasks/PROJ-1234.md` with YAML frontmatter
+- `artifacts/rfe-originals/PROJ-1234.md` as baseline for diff
+- `artifacts/rfe-tasks/PROJ-1234-comments.md` with stakeholder history
+
+The agent wakes up to a workspace that looks like someone fetched the issue
+manually. No special fullsend awareness needed in the skill.
+
+## Validation Script
+
+File: `.fullsend/scripts/validate-artifacts.sh`
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+errors=0
+
+# Validate all task files
+for f in artifacts/rfe-tasks/*.md; do
+    [[ "$(basename "$f")" == *-comments.md ]] && continue
+    python3 scripts/frontmatter.py read "$f" > /dev/null || errors=$((errors + 1))
+done
+
+# Validate all review files
+for f in artifacts/rfe-reviews/*-review.md; do
+    python3 scripts/frontmatter.py read "$f" > /dev/null || errors=$((errors + 1))
+done
+
+# Verify all rfe_ids belong to expected project or are DRAFT-NNN (split children)
+for f in artifacts/rfe-tasks/*.md; do
+    [[ "$(basename "$f")" == *-comments.md ]] && continue
+    rfe_id=$(python3 scripts/frontmatter.py read "$f" \
+        | python3 -c "import sys,json; print(json.load(sys.stdin)['rfe_id'])")
+    case "$rfe_id" in
+        DRAFT-*) ;;                    # Split children, pre-submission
+        ${JIRA_PROJECT}-*) ;;          # Original issue or existing keys
+        *) echo "ERROR: unexpected project in rfe_id: $rfe_id"
+           errors=$((errors + 1)) ;;
+    esac
+done
+
+# Collect recommendations (exits non-zero if review files missing/broken)
+python3 scripts/collect_recommendations.py --from-reviews || errors=$((errors + 1))
+
+exit $errors
+```
+
+Validates:
+
+- All task files have valid frontmatter (required fields, value ranges)
+- All review files have valid frontmatter (scores, recommendations)
+- Every `rfe_id` is either `DRAFT-NNN` (split children) or `${JIRA_PROJECT}-*`
+  (the original issue). Anything else fails.
+- Recommendations are parseable
+
+## Post-Script
+
+File: `.fullsend/scripts/post-submit.sh`
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get recommendations — outputs lines like SUBMIT=PROJ-1234,DRAFT-001
+eval "$(python3 scripts/collect_recommendations.py --from-reviews)"
+
+if [[ -z "${SUBMIT:-}" ]]; then
+    echo "No RFEs recommended for submission. Done."
+    exit 0
+fi
+
+# Submit all passing RFEs
+python3 scripts/submit.py --ids "$SUBMIT" --artifacts-dir artifacts
+```
+
+`submit.py` handles the full complexity: updates existing issues, creates
+new tickets for split children, handles the split workflow (archive parent,
+create children, link, close parent) via `split_submit.py`. The post-script
+just passes IDs through.
+
+A `REJECT` recommendation for everything is a valid outcome (the agent
+reviewed the RFE and decided it is fine as-is or infeasible). The post-script
+exits cleanly with no Jira writes.
+
+## Data Flow
+
+```
+pre-fetch.sh                sandbox (no Jira network)         post-submit.sh
+────────────                ─────────────────────────         ──────────────
+                            Agent reads artifacts/
+fetch_issue.py    ────►     /rfe.speedrun --headless
+  writes:                     --dry-run PROJ-1234
+  rfe-tasks/                                                  validate-artifacts.sh
+  rfe-originals/            Skill writes:                       checks frontmatter
+  comments                    rfe-tasks/ (revised)              checks project IDs
+                              rfe-reviews/                      checks recommendations
+                              rfe-originals/              ─►
+                              auto-fix-runs/              ─►  collect_recommendations.py
+                                                              submit.py
+                                                                creates/updates in Jira
+```
+
+## Splits
+
+The skill can split an oversized RFE into multiple smaller ones during Phase 2
+(auto-fix). When this happens:
+
+- The original `PROJ-1234.md` gets `status: Archived` in frontmatter
+- New `DRAFT-001.md`, `DRAFT-002.md`, etc. are created as children
+- Corresponding review files are created for each child
+
+The validation script handles this by validating all files, not just the
+original issue key. The post-script handles it because `submit.py` already
+understands splits: it detects archived parents, calls `split_submit.py` for
+the transactional workflow, and creates/links children in Jira.
+
+## What Does Not Change
+
+- No modifications to any skill (`rfe.speedrun`, `rfe.create`, `rfe.review`,
+  `rfe.auto-fix`, `rfe.split`, `rfe.submit`)
+- No modifications to existing scripts except the one noted below
+- No new JSON schemas or intermediate formats
+- The skill remains fully usable outside fullsend via interactive or
+  headless invocation
+
+## One Existing Script Change
+
+`collect_recommendations.py` currently takes explicit IDs as arguments. The
+validation and post scripts need it to discover IDs from whatever review files
+exist. This requires adding a `--from-reviews` flag that globs
+`artifacts/rfe-reviews/*-review.md` and extracts IDs from filenames.
+
+## Future: Eval Integration
+
+Not in scope for the PoC. When ready, a second harness
+(`rfe-creator-eval.yaml`) can use `base: harnesses/rfe-creator.yaml` and
+override the pre/post scripts to assemble `batch.yaml` from the eval dataset
+and run the judge suite against the artifacts. The agent definition handles
+this naturally — if `batch.yaml` exists, the skill runs in batch mode.

--- a/eval.md
+++ b/eval.md
@@ -44,10 +44,10 @@ suggested_judges:
 
 ## Skill Analysis
 
-`rfe.speedrun` is a thin orchestrator that turns problem statements into reviewed, optionally split, and Jira-submitted RHAIRFE tickets via three phases: **create -> auto-fix -> submit**. It accepts input in three modes:
+`rfe.speedrun` is a thin orchestrator that turns problem statements into reviewed, optionally split, and Jira-submitted tickets via three phases: **create -> auto-fix -> submit**. It accepts input in three modes:
 
 - **Mode A — Batch YAML** (`--input <path>`): list of `{prompt, priority, labels}` entries. Used by the eval harness.
-- **Mode B — Existing Jira key**: a single `RHAIRFE-NNNN` to fetch, review, and resubmit.
+- **Mode B — Existing Jira key**: a single Jira key to fetch, review, and resubmit.
 - **Mode C — Single idea**: free-text problem statement.
 
 Every flag and ID list is persisted to `tmp/` (via `scripts/state.py`) so the pipeline survives context compression between phases.
@@ -69,7 +69,7 @@ Companion files the skill reads at runtime: `tmp/speedrun-config.yaml`, `tmp/spe
 
 The pipeline writes to 5 directories under `artifacts/`:
 
-1. **artifacts/rfe-tasks/** — One Markdown file per RFE. Naming `RFE-NNN.md` (newly-created, pre-submit) or `RHAIRFE-NNNN.md` (fetched/submitted). YAML frontmatter (validated by `scripts/frontmatter.py`): `rfe_id`, `title`, `priority` (enum), `size` (S/M/L/XL), `status` (Draft/Ready/Submitted/Archived), `parent_key` (split children), `original_labels`. Body sections: Summary, Problem Statement, Affected Customers, Business Justification, Acceptance Criteria, Success Criteria.
+1. **artifacts/rfe-tasks/** — One Markdown file per RFE. Naming `RFE-NNN.md` (newly-created, pre-submit) or `<PROJECT>-NNNN.md` (fetched/submitted). YAML frontmatter (validated by `scripts/frontmatter.py`): `rfe_id`, `title`, `priority` (enum), `size` (S/M/L/XL), `status` (Draft/Ready/Submitted/Archived), `parent_key` (split children), `original_labels`. Body sections: Summary, Problem Statement, Affected Customers, Business Justification, Acceptance Criteria, Success Criteria.
 
 2. **artifacts/rfe-reviews/** — Per-RFE review artifacts:
    - `{ID}-review.md` — frontmatter with `rfe_id`, `score` (0-10), `pass` (bool), `recommendation` (submit/revise/split/reject/autorevise_reject), `feasibility` (feasible/infeasible/indeterminate), `auto_revised` (bool), `needs_attention` (bool), `needs_attention_reason`, `scores.{what,why,open_to_how,not_a_task,right_sized}` (each 0-2), `before_score`, `before_scores`, `error` on failure. Body: Assessor Feedback table, Verdict, Feedback, Technical Feasibility, Strategy Considerations, Revision History.

--- a/eval.yaml
+++ b/eval.yaml
@@ -89,7 +89,7 @@ outputs:
     batch_pattern: "DRAFT-{n:03d}"
     schema: |
       RFE task files in Markdown with YAML frontmatter.
-      Naming: DRAFT-NNN.md (new, pre-submission) or RHAIRFE-NNNN.md (fetched).
+      Naming: DRAFT-NNN.md (new, pre-submission) or <PROJECT>-NNNN.md (fetched).
       Frontmatter fields (validated by scripts/frontmatter.py):
         rfe_id, title, priority (Blocker/Critical/Major/Normal/Minor),
         size (S/M/L/XL), status (Draft/Ready/Submitted/Archived),

--- a/eval.yaml
+++ b/eval.yaml
@@ -86,10 +86,10 @@ inputs:
 
 outputs:
   - path: artifacts/rfe-tasks
-    batch_pattern: "RFE-{n:03d}"
+    batch_pattern: "DRAFT-{n:03d}"
     schema: |
       RFE task files in Markdown with YAML frontmatter.
-      Naming: RFE-NNN.md (new, pre-submission) or RHAIRFE-NNNN.md (fetched).
+      Naming: DRAFT-NNN.md (new, pre-submission) or RHAIRFE-NNNN.md (fetched).
       Frontmatter fields (validated by scripts/frontmatter.py):
         rfe_id, title, priority (Blocker/Critical/Major/Normal/Minor),
         size (S/M/L/XL), status (Draft/Ready/Submitted/Archived),
@@ -98,7 +98,7 @@ outputs:
       Business Justification, Acceptance Criteria, Success Criteria.
 
   - path: artifacts/rfe-reviews
-    batch_pattern: "RFE-{n:03d}"
+    batch_pattern: "DRAFT-{n:03d}"
     schema: |
       Review and assessment files for each RFE.
       Files per RFE:
@@ -118,7 +118,7 @@ outputs:
       Revision History.
 
   - path: artifacts/rfe-originals
-    batch_pattern: "RFE-{n:03d}"
+    batch_pattern: "DRAFT-{n:03d}"
     schema: |
       Backup of original RFE content before revisions. One file per RFE:
       {ID}.md containing the original body (no frontmatter). Used for

--- a/eval/README.md
+++ b/eval/README.md
@@ -38,7 +38,7 @@ Each run produces:
 
 ## How it works
 
-The evaluation runs the `rfe.speedrun` skill headlessly against 20 test cases derived from real RHAIRFE Jira issues. Each test case provides a problem statement (prompt + clarifying context), and the pipeline creates, reviews, auto-fixes, and (dry-run) submits RFEs.
+The evaluation runs the `rfe.speedrun` skill headlessly against 20 test cases derived from real Jira issues. Each test case provides a problem statement (prompt + clarifying context), and the pipeline creates, reviews, auto-fixes, and (dry-run) submits RFEs.
 
 ### How it was generated
 

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -62,7 +62,7 @@ SCHEMAS = {
         "rfe_id": {
             "type": "string",
             "required": True,
-            "pattern": r"^(RFE-\d+|RHAIRFE-\d+)$",
+            "pattern": r"^(DRAFT-\d+|RHAIRFE-\d+)$",
         },
         "title": {
             "type": "string",
@@ -87,7 +87,7 @@ SCHEMAS = {
         "parent_key": {
             "type": "string",
             "required": False,
-            "pattern": r"^(RFE-\d+|RHAIRFE-\d+)$",
+            "pattern": r"^(DRAFT-\d+|RHAIRFE-\d+)$",
             "default": None,
         },
         "original_labels": {
@@ -100,7 +100,7 @@ SCHEMAS = {
         "rfe_id": {
             "type": "string",
             "required": True,
-            "pattern": r"^(RFE-\d+|RHAIRFE-\d+)$",
+            "pattern": r"^(DRAFT-\d+|RHAIRFE-\d+)$",
         },
         "score": {
             "type": "int",
@@ -468,7 +468,7 @@ def find_artifact_file(artifacts_dir, identifier):
     """Find the main artifact file for a given RFE ID or Jira key.
 
     Matches:
-    - RFE-NNN.md (local pre-submission)
+    - DRAFT-NNN.md (local pre-submission)
     - RHAIRFE-NNNN.md (Jira-keyed)
 
     Excludes companion files (-comments.md, -removed-context.md).
@@ -476,7 +476,7 @@ def find_artifact_file(artifacts_dir, identifier):
 
     Args:
         artifacts_dir: path to artifacts directory
-        identifier: RFE-NNN or RHAIRFE-NNNN
+        identifier: DRAFT-NNN or RHAIRFE-NNNN
 
     Returns:
         Full path to artifact file, or None if not found.
@@ -501,8 +501,8 @@ def find_artifact_file(artifacts_dir, identifier):
                     continue
                 return path
 
-        # Match by local RFE ID (exact: RFE-001.md, legacy: RFE-001-slug.md)
-        if identifier.startswith("RFE-"):
+        # Match by local draft ID (exact: DRAFT-001.md, legacy: DRAFT-001-slug.md)
+        if identifier.startswith("DRAFT-"):
             if filename == f"{identifier}.md" or filename.startswith(identifier + "-"):
                 path = os.path.join(tasks_dir, filename)
                 data, _ = read_frontmatter(path)
@@ -529,7 +529,7 @@ def find_artifact_file_including_archived(artifacts_dir, identifier):
             if filename == f"{identifier}.md":
                 return os.path.join(tasks_dir, filename)
 
-        if identifier.startswith("RFE-"):
+        if identifier.startswith("DRAFT-"):
             if filename == f"{identifier}.md" or filename.startswith(identifier + "-"):
                 return os.path.join(tasks_dir, filename)
 
@@ -550,7 +550,7 @@ def find_removed_context_yaml(artifacts_dir, identifier):
             if filename == f"{identifier}-removed-context.yaml":
                 return os.path.join(tasks_dir, filename)
 
-        if identifier.startswith("RFE-"):
+        if identifier.startswith("DRAFT-"):
             if filename == f"{identifier}-removed-context.yaml":
                 return os.path.join(tasks_dir, filename)
 
@@ -571,7 +571,7 @@ def find_removed_context_file(artifacts_dir, identifier):
             if filename == f"{identifier}-removed-context.md":
                 return os.path.join(tasks_dir, filename)
 
-        if identifier.startswith("RFE-"):
+        if identifier.startswith("DRAFT-"):
             if filename == f"{identifier}-removed-context.md":
                 return os.path.join(tasks_dir, filename)
 
@@ -595,7 +595,7 @@ def find_review_file(artifacts_dir, identifier):
             if filename == f"{identifier}-review.md":
                 return os.path.join(reviews_dir, filename)
 
-        if identifier.startswith("RFE-"):
+        if identifier.startswith("DRAFT-"):
             if filename == f"{identifier}-review.md":
                 return os.path.join(reviews_dir, filename)
 
@@ -660,14 +660,14 @@ def scan_review_files(artifacts_dir):
 
 
 def rename_to_jira_key(artifacts_dir, rfe_id, jira_key):
-    """Rename RFE-NNN.md files to RHAIRFE-NNNN.md after submission.
+    """Rename DRAFT-NNN.md files to their Jira key after submission.
 
     Renames the task file, companion files, and review file.
     Updates rfe_id in frontmatter to the new Jira key.
 
     Args:
         artifacts_dir: path to artifacts directory
-        rfe_id: e.g. "RFE-001"
+        rfe_id: e.g. "DRAFT-001"
         jira_key: e.g. "RHAIRFE-1600"
     """
     tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
@@ -800,7 +800,7 @@ def parse_child_artifact(path):
     if data.get("title"):
         title = data["title"]
     else:
-        title_match = re.match(r"^#\s+RFE-\d+:\s+(.+)$", content, re.MULTILINE)
+        title_match = re.match(r"^#\s+DRAFT-\d+:\s+(.+)$", content, re.MULTILINE)
         title = title_match.group(1).strip() if title_match else "Untitled"
 
     if data.get("priority"):

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -12,6 +12,18 @@ import sys
 
 import yaml
 
+_JIRA_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]+-\d+$")
+
+
+def is_jira_key(identifier):
+    """True if identifier looks like a Jira issue key (e.g., PROJ-1234).
+
+    Returns False for DRAFT-NNN identifiers (local pre-submission IDs).
+    """
+    if identifier.startswith("DRAFT-"):
+        return False
+    return bool(_JIRA_KEY_RE.match(identifier))
+
 
 def read_ids_file(path):
     """Read RFE IDs from a file (one per line), deduped, order-preserved.
@@ -62,7 +74,7 @@ SCHEMAS = {
         "rfe_id": {
             "type": "string",
             "required": True,
-            "pattern": r"^(DRAFT-\d+|RHAIRFE-\d+)$",
+            "pattern": r"^(DRAFT-\d+|[A-Z][A-Z0-9]+-\d+)$",
         },
         "title": {
             "type": "string",
@@ -87,7 +99,7 @@ SCHEMAS = {
         "parent_key": {
             "type": "string",
             "required": False,
-            "pattern": r"^(DRAFT-\d+|RHAIRFE-\d+)$",
+            "pattern": r"^(DRAFT-\d+|[A-Z][A-Z0-9]+-\d+)$",
             "default": None,
         },
         "original_labels": {
@@ -100,7 +112,7 @@ SCHEMAS = {
         "rfe_id": {
             "type": "string",
             "required": True,
-            "pattern": r"^(DRAFT-\d+|RHAIRFE-\d+)$",
+            "pattern": r"^(DRAFT-\d+|[A-Z][A-Z0-9]+-\d+)$",
         },
         "score": {
             "type": "int",

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -481,14 +481,14 @@ def find_artifact_file(artifacts_dir, identifier):
 
     Matches:
     - DRAFT-NNN.md (local pre-submission)
-    - RHAIRFE-NNNN.md (Jira-keyed)
+    - PROJ-NNNN.md (Jira-keyed, any project)
 
     Excludes companion files (-comments.md, -removed-context.md).
     Excludes archived artifacts (status: Archived in frontmatter).
 
     Args:
         artifacts_dir: path to artifacts directory
-        identifier: DRAFT-NNN or RHAIRFE-NNNN
+        identifier: DRAFT-NNN or PROJ-NNNN (any Jira key)
 
     Returns:
         Full path to artifact file, or None if not found.
@@ -503,8 +503,8 @@ def find_artifact_file(artifacts_dir, identifier):
         if _is_companion_file(filename):
             continue
 
-        # Match by Jira key (exact: RHAIRFE-1595.md)
-        if identifier.startswith("RHAIRFE-"):
+        # Match by Jira key (exact: PROJ-1595.md)
+        if is_jira_key(identifier):
             if filename == f"{identifier}.md":
                 path = os.path.join(tasks_dir, filename)
                 # Check if archived
@@ -537,7 +537,7 @@ def find_artifact_file_including_archived(artifacts_dir, identifier):
         if _is_companion_file(filename):
             continue
 
-        if identifier.startswith("RHAIRFE-"):
+        if is_jira_key(identifier):
             if filename == f"{identifier}.md":
                 return os.path.join(tasks_dir, filename)
 
@@ -558,7 +558,7 @@ def find_removed_context_yaml(artifacts_dir, identifier):
         if not filename.endswith("-removed-context.yaml"):
             continue
 
-        if identifier.startswith("RHAIRFE-"):
+        if is_jira_key(identifier):
             if filename == f"{identifier}-removed-context.yaml":
                 return os.path.join(tasks_dir, filename)
 
@@ -579,7 +579,7 @@ def find_removed_context_file(artifacts_dir, identifier):
         if not filename.endswith("-removed-context.md"):
             continue
 
-        if identifier.startswith("RHAIRFE-"):
+        if is_jira_key(identifier):
             if filename == f"{identifier}-removed-context.md":
                 return os.path.join(tasks_dir, filename)
 
@@ -603,7 +603,7 @@ def find_review_file(artifacts_dir, identifier):
         if not filename.endswith("-review.md"):
             continue
 
-        if identifier.startswith("RHAIRFE-"):
+        if is_jira_key(identifier):
             if filename == f"{identifier}-review.md":
                 return os.path.join(reviews_dir, filename)
 
@@ -680,7 +680,7 @@ def rename_to_jira_key(artifacts_dir, rfe_id, jira_key):
     Args:
         artifacts_dir: path to artifacts directory
         rfe_id: e.g. "DRAFT-001"
-        jira_key: e.g. "RHAIRFE-1600"
+        jira_key: e.g. "PROJ-1600"
     """
     tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
     reviews_dir = os.path.join(artifacts_dir, "rfe-reviews")

--- a/scripts/batch_summary.py
+++ b/scripts/batch_summary.py
@@ -14,7 +14,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Aggregate RFE review results for batch summaries."
     )
-    parser.add_argument("ids", nargs="*", help="RFE IDs (e.g. RHAIRFE-100)")
+    parser.add_argument("ids", nargs="*", help="RFE IDs (e.g. PROJ-100)")
     parser.add_argument(
         "--ids-file", help="Read RFE IDs from a file (one per line) instead of positional args"
     )

--- a/scripts/check_conflicts.py
+++ b/scripts/check_conflicts.py
@@ -32,7 +32,7 @@ import re
 import sys
 import unicodedata
 
-from artifact_utils import scan_task_files
+from artifact_utils import is_jira_key, scan_task_files
 from jira_utils import adf_to_markdown, get_issue, require_env
 
 
@@ -101,7 +101,7 @@ def main():
     jira_rfes = []
     for task_path, task_data in tasks:
         rfe_id = task_data["rfe_id"]
-        if not rfe_id.startswith("RHAIRFE-"):
+        if not is_jira_key(rfe_id):
             continue
         if task_data.get("status") == "Archived":
             continue

--- a/scripts/check_resume.py
+++ b/scripts/check_resume.py
@@ -19,7 +19,7 @@ Usage:
         --output-file tmp/autofix-process-ids.txt
 
     # Legacy positional args
-    python3 scripts/check_resume.py RHAIRFE-1234 RHAIRFE-5678
+    python3 scripts/check_resume.py PROJ-1234 PROJ-5678
 """
 
 import argparse

--- a/scripts/check_revised.py
+++ b/scripts/check_revised.py
@@ -11,7 +11,7 @@ Modes:
 Usage:
     python3 scripts/check_revised.py artifacts/rfe-originals/ID.md artifacts/rfe-tasks/ID.md
     python3 scripts/check_revised.py --batch
-    python3 scripts/check_revised.py --batch RHAIRFE-1504 RHAIRFE-1510
+    python3 scripts/check_revised.py --batch PROJ-1504 PROJ-1510
 """
 
 import os

--- a/scripts/cleanup_partial_split.py
+++ b/scripts/cleanup_partial_split.py
@@ -21,7 +21,7 @@ ARTIFACTS_DIR = os.path.join(os.getcwd(), "artifacts")
 
 def main():
     parser = argparse.ArgumentParser(description="Clean up orphan children from a failed split")
-    parser.add_argument("parent_id", help="Parent RFE ID (e.g. RHAIRFE-100)")
+    parser.add_argument("parent_id", help="Parent RFE ID (e.g. PROJ-100)")
     args = parser.parse_args()
 
     parent_id = args.parent_id

--- a/scripts/collect_children.py
+++ b/scripts/collect_children.py
@@ -12,9 +12,7 @@ from artifact_utils import resolve_ids, scan_task_files
 
 def main():
     parser = argparse.ArgumentParser(description="Find child RFEs by parent_key")
-    parser.add_argument(
-        "parent_ids", nargs="*", help="One or more parent RFE IDs (e.g. PROJ-100)"
-    )
+    parser.add_argument("parent_ids", nargs="*", help="One or more parent RFE IDs (e.g. PROJ-100)")
     parser.add_argument(
         "--ids-file",
         help="Read parent RFE IDs from a file (one per line) instead of positional args",

--- a/scripts/collect_children.py
+++ b/scripts/collect_children.py
@@ -13,7 +13,7 @@ from artifact_utils import resolve_ids, scan_task_files
 def main():
     parser = argparse.ArgumentParser(description="Find child RFEs by parent_key")
     parser.add_argument(
-        "parent_ids", nargs="*", help="One or more parent RFE IDs (e.g. RHAIRFE-100)"
+        "parent_ids", nargs="*", help="One or more parent RFE IDs (e.g. PROJ-100)"
     )
     parser.add_argument(
         "--ids-file",

--- a/scripts/collect_recommendations.py
+++ b/scripts/collect_recommendations.py
@@ -81,7 +81,7 @@ def discover_ids_from_reviews():
     for path in sorted(glob.glob(pattern)):
         basename = os.path.basename(path)
         # DRAFT-001-review.md -> DRAFT-001
-        # RHAIRFE-1234-review.md -> RHAIRFE-1234
+        # PROJ-1234-review.md -> PROJ-1234
         rfe_id = basename.rsplit("-review.md", 1)[0]
         ids.append(rfe_id)
     return ids

--- a/scripts/collect_recommendations.py
+++ b/scripts/collect_recommendations.py
@@ -2,6 +2,7 @@
 """Group RFE IDs by review recommendation or reassess status."""
 
 import argparse
+import glob
 import os
 import sys
 
@@ -72,6 +73,20 @@ def collect_errors(ids):
     print(f"ERRORS={','.join(error_ids)}")
 
 
+def discover_ids_from_reviews():
+    """Glob review files and extract IDs from filenames."""
+    review_dir = os.path.join(ARTIFACTS_DIR, "rfe-reviews")
+    pattern = os.path.join(review_dir, "*-review.md")
+    ids = []
+    for path in sorted(glob.glob(pattern)):
+        basename = os.path.basename(path)
+        # DRAFT-001-review.md -> DRAFT-001
+        # RHAIRFE-1234-review.md -> RHAIRFE-1234
+        rfe_id = basename.rsplit("-review.md", 1)[0]
+        ids.append(rfe_id)
+    return ids
+
+
 def main():
     parser = argparse.ArgumentParser(description="Group RFE IDs by review recommendation.")
     parser.add_argument("ids", nargs="*", help="RFE IDs to check")
@@ -79,14 +94,25 @@ def main():
         "--ids-file", help="Read RFE IDs from a file (one per line) instead of positional args"
     )
     parser.add_argument(
+        "--from-reviews",
+        action="store_true",
+        help="Discover IDs by globbing artifacts/rfe-reviews/*-review.md",
+    )
+    parser.add_argument(
         "--reassess", action="store_true", help="Collect re-assess candidates instead"
     )
     parser.add_argument("--errors", action="store_true", help="Collect IDs with error field set")
     args = parser.parse_args()
 
-    ids = resolve_ids(args.ids, args.ids_file)
-    if not ids:
-        parser.error("no RFE IDs provided (pass positionally or via --ids-file)")
+    if args.from_reviews:
+        ids = discover_ids_from_reviews()
+        if not ids:
+            print("ERROR: no review files found in artifacts/rfe-reviews/", file=sys.stderr)
+            sys.exit(1)
+    else:
+        ids = resolve_ids(args.ids, args.ids_file)
+        if not ids:
+            parser.error("no RFE IDs provided (pass positionally or via --ids-file)")
 
     if args.errors:
         collect_errors(ids)

--- a/scripts/fetch_issue.py
+++ b/scripts/fetch_issue.py
@@ -6,12 +6,12 @@ Atlassian MCP server is unavailable. Outputs JSON to stdout for the
 calling skill to parse.
 
 Usage:
-    python3 scripts/fetch_issue.py RHAIRFE-1234 \\
+    python3 scripts/fetch_issue.py PROJ-1234 \\
         [--fields summary,description,comment,priority,labels,status] \\
         [--markdown]
 
     # Fetch everything and write all artifact files at once
-    python3 scripts/fetch_issue.py RHAIRFE-1234 --fetch-all artifacts
+    python3 scripts/fetch_issue.py PROJ-1234 --fetch-all artifacts
 
 Environment variables:
     JIRA_SERVER  Jira server URL (e.g. https://mysite.atlassian.net)
@@ -145,7 +145,7 @@ def main():
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument("issue_key", help="Jira issue key (e.g. RHAIRFE-1234)")
+    parser.add_argument("issue_key", help="Jira issue key (e.g. PROJ-1234)")
 
     mode_group = parser.add_mutually_exclusive_group()
     mode_group.add_argument(

--- a/scripts/frontmatter.py
+++ b/scripts/frontmatter.py
@@ -10,19 +10,19 @@ Usage:
     python3 scripts/frontmatter.py schema rfe-review
 
     # Set/update frontmatter on a file (validates before writing)
-    python3 scripts/frontmatter.py set artifacts/rfe-tasks/RFE-001.md \\
-        --rfe_id RFE-001 --title "My RFE" --priority Major --size M \\
+    python3 scripts/frontmatter.py set artifacts/rfe-tasks/DRAFT-001.md \\
+        --rfe_id DRAFT-001 --title "My RFE" --priority Major --size M \\
         --status Draft
 
     # Set nested fields with dot notation
-    python3 scripts/frontmatter.py set artifacts/rfe-reviews/RFE-001-review.md \\
-        --rfe_id RFE-001 --score 9 --pass true --recommendation submit \\
+    python3 scripts/frontmatter.py set artifacts/rfe-reviews/DRAFT-001-review.md \\
+        --rfe_id DRAFT-001 --score 9 --pass true --recommendation submit \\
         --feasibility feasible --auto_revised false --needs_attention false \\
         --scores.what 2 --scores.why 1 --scores.open_to_how 2 \\
         --scores.not_a_task 2 --scores.right_sized 2
 
     # Read and validate frontmatter from a file
-    python3 scripts/frontmatter.py read artifacts/rfe-tasks/RFE-001.md
+    python3 scripts/frontmatter.py read artifacts/rfe-tasks/DRAFT-001.md
 
     # Rebuild the rfes.md index from all task and review files
     python3 scripts/frontmatter.py rebuild-index [--artifacts-dir artifacts]

--- a/scripts/generate_review_pdf.py
+++ b/scripts/generate_review_pdf.py
@@ -10,7 +10,7 @@ from collections import Counter
 import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from artifact_utils import find_artifact_file_including_archived, read_frontmatter
+from artifact_utils import find_artifact_file_including_archived, is_jira_key, read_frontmatter
 
 DEFAULT_ARTIFACTS = os.path.join(os.getcwd(), "artifacts")
 
@@ -1301,13 +1301,13 @@ def main():
 
     def jira_link(rfe_id):
         """Wrap an RFE ID in a Jira link if it's a real key and server is configured."""
-        if jira_server and rfe_id.startswith("RHAIRFE-"):
+        if jira_server and is_jira_key(rfe_id):
             return f'<a href="{jira_server}/browse/{html_escape(rfe_id)}" target="_blank" class="jira-link" title="Open in Jira">{html_escape(rfe_id)} &#x1F517;</a>'
         return html_escape(rfe_id)
 
     def jira_ext(rfe_id):
         """Small external link icon for Jira keys in summary table."""
-        if jira_server and rfe_id.startswith("RHAIRFE-"):
+        if jira_server and is_jira_key(rfe_id):
             return f' <a href="{jira_server}/browse/{html_escape(rfe_id)}" target="_blank" style="color:#0f3460;text-decoration:none;font-size:9pt;" title="Open in Jira">&#x1F517;</a>'
         return ""
 

--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -675,7 +675,7 @@ def strip_metadata(markdown):
 
     Strips content that should not be pushed to Jira:
     - YAML frontmatter (--- delimited block at start of file)
-    - Title headings (# RFE-NNN: / # RHAIRFE-NNN: / # STRAT-NNN: / # RHAISTRAT-NNN:)
+    - Title headings (# DRAFT-NNN: / # RHAIRFE-NNN: / # STRAT-NNN: / # RHAISTRAT-NNN:)
       — title is in frontmatter and Jira's summary field
     - Legacy inline metadata lines (now in frontmatter):
       **Jira Key**, **Size**, **Split from**, **Priority**, **Source RFE**
@@ -698,7 +698,7 @@ def strip_metadata(markdown):
 
     for line in lines:
         # Skip title heading — duplicates Summary
-        if re.match(r"^#\s+(RFE-\d+|RHAIRFE-\d+|STRAT-\d+|RHAISTRAT-\d+):", line):
+        if re.match(r"^#\s+(DRAFT-\d+|RHAIRFE-\d+|STRAT-\d+|RHAISTRAT-\d+):", line):
             continue
 
         # Skip metadata lines (legacy inline format, now in frontmatter)

--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -675,7 +675,7 @@ def strip_metadata(markdown):
 
     Strips content that should not be pushed to Jira:
     - YAML frontmatter (--- delimited block at start of file)
-    - Title headings (# DRAFT-NNN: / # RHAIRFE-NNN: / # STRAT-NNN: / # RHAISTRAT-NNN:)
+    - Title headings (# DRAFT-NNN: / # PROJ-NNN:)
       — title is in frontmatter and Jira's summary field
     - Legacy inline metadata lines (now in frontmatter):
       **Jira Key**, **Size**, **Split from**, **Priority**, **Source RFE**
@@ -698,7 +698,7 @@ def strip_metadata(markdown):
 
     for line in lines:
         # Skip title heading — duplicates Summary
-        if re.match(r"^#\s+(DRAFT-\d+|RHAIRFE-\d+|STRAT-\d+|RHAISTRAT-\d+):", line):
+        if re.match(r"^#\s+(DRAFT-\d+|[A-Z][A-Z0-9]+-\d+):", line):
             continue
 
         # Skip metadata lines (legacy inline format, now in frontmatter)

--- a/scripts/jql_query.py
+++ b/scripts/jql_query.py
@@ -2,12 +2,12 @@
 """Execute a JQL query against Jira and return paginated key list.
 
 Usage:
-    python3 scripts/jql_query.py "project = RHAIRFE AND status = New" [--limit N]
+    python3 scripts/jql_query.py "project = MYPROJ AND status = New" [--limit N]
 
 Output:
     TOTAL=<total_matching>
-    RHAIRFE-100
-    RHAIRFE-101
+    PROJ-100
+    PROJ-101
     ...
 """
 

--- a/scripts/next_rfe_id.py
+++ b/scripts/next_rfe_id.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-"""Allocate the next available RFE-NNN ID(s) atomically.
+"""Allocate the next available DRAFT-NNN ID(s) atomically.
 
 Uses a lock file to prevent concurrent split agents from picking
 the same IDs.
 
 Usage:
     python3 scripts/next_rfe_id.py 3
-    # RFE-012
-    # RFE-013
-    # RFE-014
+    # DRAFT-012
+    # DRAFT-013
+    # DRAFT-014
 
     python3 scripts/next_rfe_id.py --from-batch batch.yaml
     # allocates one ID per entry in the YAML batch file (avoids N=$(...) in skills)
@@ -25,11 +25,11 @@ LOCK_FILE = "artifacts/.rfe-id-lock"
 
 
 def get_highest_rfe_number():
-    """Scan artifacts/rfe-tasks/ for the highest RFE-NNN number."""
+    """Scan artifacts/rfe-tasks/ for the highest DRAFT-NNN number."""
     highest = 0
-    for path in glob.glob(os.path.join(TASKS_DIR, "RFE-*.md")):
+    for path in glob.glob(os.path.join(TASKS_DIR, "DRAFT-*.md")):
         basename = os.path.basename(path)
-        match = re.match(r"RFE-(\d+)", basename)
+        match = re.match(r"DRAFT-(\d+)", basename)
         if match:
             num = int(match.group(1))
             if num > highest:
@@ -72,7 +72,7 @@ def main():
         fcntl.flock(lock_fd, fcntl.LOCK_EX)
         highest = get_highest_rfe_number()
         for i in range(count):
-            rfe_id = f"RFE-{highest + 1 + i:03d}"
+            rfe_id = f"DRAFT-{highest + 1 + i:03d}"
             # Touch a placeholder so subsequent calls see it
             placeholder = os.path.join(TASKS_DIR, f"{rfe_id}.md")
             open(placeholder, "a").close()

--- a/scripts/prep_assess.py
+++ b/scripts/prep_assess.py
@@ -6,7 +6,7 @@ directory. This replaces the two-step process in rfe.review (prep_single + cp).
 
 Usage:
     python3 scripts/prep_assess.py RHAIRFE-1234
-    python3 scripts/prep_assess.py RFE-001
+    python3 scripts/prep_assess.py DRAFT-001
 
 Outputs:
     FILE=/tmp/rfe-assess/single/<ID>.md

--- a/scripts/prep_assess.py
+++ b/scripts/prep_assess.py
@@ -5,7 +5,7 @@ Combines prep_single (cleanup) + copy of the task file into the assessment
 directory. This replaces the two-step process in rfe.review (prep_single + cp).
 
 Usage:
-    python3 scripts/prep_assess.py RHAIRFE-1234
+    python3 scripts/prep_assess.py PROJ-1234
     python3 scripts/prep_assess.py DRAFT-001
 
 Outputs:

--- a/scripts/resolve_project.py
+++ b/scripts/resolve_project.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Resolve Jira project configuration from environment variables.
+
+Prints JIRA_PROJECT and JIRA_ISSUE_TYPE as KEY=VALUE lines.
+Exits non-zero if JIRA_PROJECT is not set.
+
+Usage:
+    python3 scripts/resolve_project.py
+"""
+
+import os
+import sys
+
+
+def main():
+    project = os.environ.get("JIRA_PROJECT")
+    issue_type = os.environ.get("JIRA_ISSUE_TYPE", "Feature Request")
+
+    if not project:
+        print(
+            "ERROR: JIRA_PROJECT is not set.\n"
+            "Set the Jira project key for this RFE workflow:\n"
+            "  export JIRA_PROJECT=RHAIRFE\n"
+            "Optionally set the issue type (default: Feature Request):\n"
+            "  export JIRA_ISSUE_TYPE='Feature Request'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"JIRA_PROJECT={project}")
+    print(f"JIRA_ISSUE_TYPE={issue_type}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/resolve_project.py
+++ b/scripts/resolve_project.py
@@ -20,7 +20,7 @@ def main():
         print(
             "ERROR: JIRA_PROJECT is not set.\n"
             "Set the Jira project key for this RFE workflow:\n"
-            "  export JIRA_PROJECT=RHAIRFE\n"
+            "  export JIRA_PROJECT=YOURPROJECT\n"
             "Optionally set the issue type (default: Feature Request):\n"
             "  export JIRA_ISSUE_TYPE='Feature Request'",
             file=sys.stderr,

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -438,7 +438,7 @@ def main():
 
     # Find leaf children: walk the tree recursively to collect all
     # non-archived descendants.  Intermediary nodes (archived local IDs
-    # like RFE-017) are stepping stones — their children belong to the
+    # like DRAFT-017) are stepping stones — their children belong to the
     # RHAIRFE parent for Jira linking purposes.
     tasks_by_parent = {}
     for path, data in tasks:

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -10,7 +10,7 @@ Identifies parent (status: Archived, rfe_id matches parent key) and children
 (parent_key matches parent's rfe_id) from frontmatter.
 
 Usage:
-    python scripts/split_submit.py RHAIRFE-XXXX [--dry-run] [--artifacts-dir DIR]
+    python scripts/split_submit.py PROJ-XXXX [--dry-run] [--artifacts-dir DIR]
 
 Environment variables:
     JIRA_SERVER  Jira server URL (e.g. https://mysite.atlassian.net)
@@ -238,8 +238,9 @@ def phase2_create_link(server, user, token, parent_key, children, state, artifac
         labels = state.parent_labels + labels
 
         if dry_run:
+            project = os.environ.get("JIRA_PROJECT", "UNKNOWN")
             print(
-                f"  Phase 2: Would create RHAIRFE ticket for child "
+                f"  Phase 2: Would create {project} ticket for child "
                 f"{idx}/{total}: {title} (priority: {priority})"
             )
             print(f"           Labels: {', '.join(labels)}")
@@ -252,7 +253,7 @@ def phase2_create_link(server, user, token, parent_key, children, state, artifac
             print(f"           Would link to {parent_key} via 'Issue split'")
             if attn_reason:
                 print("           Would post needs-attention comment")
-            state.phase2_done[idx] = "RHAIRFE-DRY"
+            state.phase2_done[idx] = f"{os.environ.get('JIRA_PROJECT', 'UNKNOWN')}-DRY"
             continue
 
         # 1. Create ticket with labels, inherited components, and parent
@@ -260,8 +261,8 @@ def phase2_create_link(server, user, token, parent_key, children, state, artifac
             server,
             user,
             token,
-            "RHAIRFE",
-            "Feature Request",
+            os.environ["JIRA_PROJECT"],
+            os.environ.get("JIRA_ISSUE_TYPE", "Feature Request"),
             title,
             description_adf,
             priority,
@@ -439,7 +440,7 @@ def main():
     # Find leaf children: walk the tree recursively to collect all
     # non-archived descendants.  Intermediary nodes (archived local IDs
     # like DRAFT-017) are stepping stones — their children belong to the
-    # RHAIRFE parent for Jira linking purposes.
+    # Jira parent for linking purposes.
     tasks_by_parent = {}
     for path, data in tasks:
         pk = data.get("parent_key")
@@ -553,7 +554,7 @@ def main():
     # Post-submit: update frontmatter and rename files
     for idx, (rfe_id, title, priority, artifact_path) in enumerate(children, 1):
         assigned_key = state.phase2_done.get(idx)
-        if not assigned_key or assigned_key == "RHAIRFE-DRY":
+        if not assigned_key or assigned_key.endswith("-DRY"):
             continue
 
         rename_to_jira_key(args.artifacts_dir, rfe_id, assigned_key)

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -203,7 +203,7 @@ def main():
 
     # Build parent ancestry map to identify descendants of Jira split
     # parents at any depth (handles re-splits where grandchildren point
-    # to local intermediary parents like RFE-017 → RHAIRFE-1234).
+    # to local intermediary parents like DRAFT-017 → RHAIRFE-1234).
     _parent_of = {}  # rfe_id -> parent_key
     for _, data in tasks:
         pk = data.get("parent_key")
@@ -354,8 +354,8 @@ def main():
     # Filter to non-archived, non-submitted RFEs.  Any descendant of a
     # Jira split parent (RHAIRFE-*) was already handled by split_submit.py
     # in Phase 1 — this includes grandchildren from re-splits whose
-    # immediate parent is a local ID (e.g. RFE-017 → RHAIRFE-1234).
-    # Children of purely local parents (RFE-NNN with no RHAIRFE ancestor)
+    # immediate parent is a local ID (e.g. DRAFT-017 → RHAIRFE-1234).
+    # Children of purely local parents (DRAFT-NNN with no RHAIRFE ancestor)
     # go through Phase 2 as regular creates.
     # Filtering Submitted makes replay safe: already-submitted entries are
     # skipped, preventing duplicate Jira creates.

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -2,7 +2,7 @@
 """Submit RFE artifacts to Jira — create new or update existing tickets.
 
 Handles both split and standard submissions in one pass. Split parents
-(RHAIRFE with status: Archived) are submitted via split_submit.py first,
+(Jira issues with status: Archived) are submitted via split_submit.py first,
 then regular RFEs are updated/created directly.
 
 Reads all structured metadata from YAML frontmatter on task and review files.
@@ -50,6 +50,7 @@ from artifact_utils import (  # noqa: E402
     ValidationError,
     find_removed_context_yaml,
     find_review_file,
+    is_jira_key,
     read_frontmatter_validated,
     rebuild_index,
     rename_to_jira_key,
@@ -190,20 +191,20 @@ def main():
         sys.exit(1)
 
     # --- Phase 1: Submit splits via split_submit.py ---
-    # Find RHAIRFE parents that were split (Archived + have children)
+    # Find Jira parents that were split (Archived + have children)
     child_parent_keys = {data.get("parent_key") for _, data in tasks if data.get("parent_key")}
     split_parent_data = {
         data["rfe_id"]: data
         for _, data in tasks
         if data.get("status") == "Archived"
-        and data["rfe_id"].startswith("RHAIRFE-")
+        and is_jira_key(data["rfe_id"])
         and data["rfe_id"] in child_parent_keys
     }
     split_parents = list(split_parent_data.keys())
 
     # Build parent ancestry map to identify descendants of Jira split
     # parents at any depth (handles re-splits where grandchildren point
-    # to local intermediary parents like DRAFT-017 → RHAIRFE-1234).
+    # to local intermediary parents like DRAFT-017 → PROJ-1234).
     _parent_of = {}  # rfe_id -> parent_key
     for _, data in tasks:
         pk = data.get("parent_key")
@@ -211,11 +212,11 @@ def main():
             _parent_of[data["rfe_id"]] = pk
 
     def _has_jira_ancestor(rfe_id):
-        """True if rfe_id descends from any RHAIRFE parent."""
+        """True if rfe_id descends from any Jira parent."""
         seen = set()
         pk = _parent_of.get(rfe_id)
         while pk and pk not in seen:
-            if pk.startswith("RHAIRFE-"):
+            if is_jira_key(pk):
                 return True
             seen.add(pk)
             pk = _parent_of.get(pk)
@@ -324,7 +325,7 @@ def main():
             for path, data in post_split_tasks:
                 if data.get("parent_key") and data.get("status") == "Submitted":
                     rfe_id = data.get("rfe_id", "")
-                    if rfe_id.startswith("RHAIRFE-"):
+                    if is_jira_key(rfe_id):
                         with open(path, encoding="utf-8") as f:
                             raw = f.read()
                         cleaned = strip_metadata(raw)
@@ -352,11 +353,11 @@ def main():
     tasks = scan_task_files(args.artifacts_dir)
 
     # Filter to non-archived, non-submitted RFEs.  Any descendant of a
-    # Jira split parent (RHAIRFE-*) was already handled by split_submit.py
-    # in Phase 1 — this includes grandchildren from re-splits whose
-    # immediate parent is a local ID (e.g. DRAFT-017 → RHAIRFE-1234).
-    # Children of purely local parents (DRAFT-NNN with no RHAIRFE ancestor)
-    # go through Phase 2 as regular creates.
+    # Jira split parent was already handled by split_submit.py in Phase 1
+    # — this includes grandchildren from re-splits whose immediate parent
+    # is a local ID (e.g. DRAFT-017 → PROJ-1234).  Children of purely
+    # local parents (DRAFT-NNN with no Jira ancestor) go through Phase 2
+    # as regular creates.
     # Filtering Submitted makes replay safe: already-submitted entries are
     # skipped, preventing duplicate Jira creates.
     submittable = [
@@ -387,7 +388,7 @@ def main():
     for task_path, task_data in submittable:
         rfe_id = task_data["rfe_id"]
         title = task_data["title"]
-        is_existing = rfe_id.startswith("RHAIRFE-")
+        is_existing = is_jira_key(rfe_id)
         priority = task_data["priority"]
         size = task_data.get("size", "M")
 
@@ -695,15 +696,16 @@ def main():
             else:
                 # Create new ticket
                 if args.dry_run:
-                    print(f"  {rfe_id}: Would create RHAIRFE ticket: {title}")
-                    results[rfe_id] = "RHAIRFE-DRY"
+                    project = os.environ.get("JIRA_PROJECT", "UNKNOWN")
+                    print(f"  {rfe_id}: Would create {project} ticket: {title}")
+                    results[rfe_id] = f"{project}-DRY"
                 else:
                     new_key = create_issue(
                         server,
                         user,
                         token,
-                        "RHAIRFE",
-                        "Feature Request",
+                        os.environ["JIRA_PROJECT"],
+                        os.environ.get("JIRA_ISSUE_TYPE", "Feature Request"),
                         title,
                         description_adf,
                         entry["priority"],
@@ -743,7 +745,7 @@ def main():
             # comment posting which looks up files by original rfe_id)
             if not entry["is_existing"] and not args.dry_run:
                 new_key = results.get(rfe_id)
-                if new_key and new_key != "RHAIRFE-DRY":
+                if new_key and not new_key.endswith("-DRY"):
                     rename_to_jira_key(args.artifacts_dir, rfe_id, new_key)
                     print(f"  {rfe_id}: Renamed to {new_key}")
 

--- a/tests/test_artifact_utils.py
+++ b/tests/test_artifact_utils.py
@@ -299,3 +299,49 @@ class TestUpdateFrontmatter:
         write_frontmatter("review.md", VALID_REVIEW_FM.copy(), "rfe-review")
         with pytest.raises(ValidationError):
             update_frontmatter("review.md", {"recommendation": "invalid"}, "rfe-review")
+
+
+# ── is_jira_key ──────────────────────────────────────────────────────────────
+
+
+class TestIsJiraKey:
+    def test_standard_jira_key(self):
+        from artifact_utils import is_jira_key
+
+        assert is_jira_key("RHAIRFE-1234") is True
+
+    def test_other_project_key(self):
+        from artifact_utils import is_jira_key
+
+        assert is_jira_key("MYPROJ-42") is True
+
+    def test_single_letter_project_not_valid(self):
+        from artifact_utils import is_jira_key
+
+        # Jira requires at least 2 characters for project keys
+        assert is_jira_key("X-1") is False
+
+    def test_draft_is_not_jira_key(self):
+        from artifact_utils import is_jira_key
+
+        assert is_jira_key("DRAFT-001") is False
+
+    def test_lowercase_is_not_jira_key(self):
+        from artifact_utils import is_jira_key
+
+        assert is_jira_key("rhairfe-1234") is False
+
+    def test_no_number_is_not_jira_key(self):
+        from artifact_utils import is_jira_key
+
+        assert is_jira_key("RHAIRFE-") is False
+
+    def test_empty_string(self):
+        from artifact_utils import is_jira_key
+
+        assert is_jira_key("") is False
+
+    def test_alphanumeric_project(self):
+        from artifact_utils import is_jira_key
+
+        assert is_jira_key("ABC123-456") is True

--- a/tests/test_artifact_utils.py
+++ b/tests/test_artifact_utils.py
@@ -345,3 +345,55 @@ class TestIsJiraKey:
         from artifact_utils import is_jira_key
 
         assert is_jira_key("ABC123-456") is True
+
+
+class TestFindArtifactFileGenericKey:
+    def test_finds_generic_jira_key(self, tmp_path):
+        from artifact_utils import find_artifact_file, write_frontmatter
+
+        tasks_dir = tmp_path / "rfe-tasks"
+        tasks_dir.mkdir()
+        task_path = tasks_dir / "MYPROJ-42.md"
+        write_frontmatter(
+            str(task_path),
+            {
+                "rfe_id": "MYPROJ-42",
+                "title": "Test",
+                "priority": "Normal",
+                "status": "Ready",
+            },
+            "rfe-task",
+        )
+        result = find_artifact_file(str(tmp_path), "MYPROJ-42")
+        assert result is not None
+        assert "MYPROJ-42.md" in result
+
+    def test_finds_generic_key_review(self, tmp_path):
+        from artifact_utils import find_review_file, write_frontmatter
+
+        reviews_dir = tmp_path / "rfe-reviews"
+        reviews_dir.mkdir()
+        review_path = reviews_dir / "MYPROJ-42-review.md"
+        write_frontmatter(
+            str(review_path),
+            {
+                "rfe_id": "MYPROJ-42",
+                "score": 8,
+                "pass": True,
+                "recommendation": "submit",
+                "feasibility": "feasible",
+                "auto_revised": False,
+                "needs_attention": False,
+                "scores": {
+                    "what": 2,
+                    "why": 2,
+                    "open_to_how": 2,
+                    "not_a_task": 1,
+                    "right_sized": 1,
+                },
+            },
+            "rfe-review",
+        )
+        result = find_review_file(str(tmp_path), "MYPROJ-42")
+        assert result is not None
+        assert "MYPROJ-42-review.md" in result

--- a/tests/test_check_review_progress.py
+++ b/tests/test_check_review_progress.py
@@ -561,7 +561,7 @@ class TestPollMode:
 
     def test_poll_max_wait_caps_id_list(self, tmp_path):
         """10+ pending IDs → message shows first 5 + '... and N more'."""
-        ids = [f"RFE-{i:03d}" for i in range(10)]
+        ids = [f"DRAFT-{i:03d}" for i in range(10)]
         with (
             patch.dict(
                 "check_review_progress.PHASE_CHECKS",
@@ -575,7 +575,7 @@ class TestPollMode:
         assert "... and 5 more" in out
         # First 5 sorted IDs should be present
         for i in range(5):
-            assert f"RFE-{i:03d}" in out
+            assert f"DRAFT-{i:03d}" in out
 
     def test_poll_max_wait_negative_rejected(self):
         """--max-wait -1 should error."""

--- a/tests/test_collect_recommendations.py
+++ b/tests/test_collect_recommendations.py
@@ -90,9 +90,9 @@ def art_dir(tmp_path):
 class TestCollectDefault:
     def test_groups_by_recommendation(self, art_dir):
         _write(
-            f"{art_dir}/artifacts/rfe-reviews/RFE-001-review.md",
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-001-review.md",
             REVIEW_TEMPLATE.format(
-                rfe_id="RFE-001",
+                rfe_id="DRAFT-001",
                 score=9,
                 pass_val="true",
                 recommendation="submit",
@@ -100,9 +100,9 @@ class TestCollectDefault:
             ),
         )
         _write(
-            f"{art_dir}/artifacts/rfe-reviews/RFE-002-review.md",
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-002-review.md",
             REVIEW_TEMPLATE.format(
-                rfe_id="RFE-002",
+                rfe_id="DRAFT-002",
                 score=3,
                 pass_val="false",
                 recommendation="reject",
@@ -110,102 +110,102 @@ class TestCollectDefault:
             ),
         )
         _write(
-            f"{art_dir}/artifacts/rfe-reviews/RFE-003-review.md",
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-003-review.md",
             REVIEW_TEMPLATE.format(
-                rfe_id="RFE-003",
+                rfe_id="DRAFT-003",
                 score=7,
                 pass_val="true",
                 recommendation="split",
                 auto_revised="false",
             ),
         )
-        out, _, rc = _run(["RFE-001", "RFE-002", "RFE-003"])
+        out, _, rc = _run(["DRAFT-001", "DRAFT-002", "DRAFT-003"])
         assert rc == 0
         groups = _parse_output(out)
-        assert "RFE-001" in groups["SUBMIT"]
-        assert "RFE-002" in groups["REJECT"]
-        assert "RFE-003" in groups["SPLIT"]
+        assert "DRAFT-001" in groups["SUBMIT"]
+        assert "DRAFT-002" in groups["REJECT"]
+        assert "DRAFT-003" in groups["SPLIT"]
 
     def test_autorevise_reject_maps_to_reject(self, art_dir):
         """autorevise_reject should be grouped as REJECT, not ERRORS."""
         _write(
-            f"{art_dir}/artifacts/rfe-reviews/RFE-001-review.md",
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-001-review.md",
             REVIEW_TEMPLATE.format(
-                rfe_id="RFE-001",
+                rfe_id="DRAFT-001",
                 score=4,
                 pass_val="false",
                 recommendation="autorevise_reject",
                 auto_revised="true",
             ),
         )
-        out, _, rc = _run(["RFE-001"])
+        out, _, rc = _run(["DRAFT-001"])
         assert rc == 0
         groups = _parse_output(out)
-        assert "RFE-001" in groups["REJECT"]
+        assert "DRAFT-001" in groups["REJECT"]
         assert groups["ERRORS"] == []
 
     def test_missing_review_file_goes_to_errors(self, art_dir):
-        out, _, rc = _run(["RFE-MISSING"])
+        out, _, rc = _run(["DRAFT-MISSING"])
         assert rc == 0
         groups = _parse_output(out)
-        assert "RFE-MISSING" in groups["ERRORS"]
+        assert "DRAFT-MISSING" in groups["ERRORS"]
 
     def test_error_field_goes_to_errors(self, art_dir):
         _write(
-            f"{art_dir}/artifacts/rfe-reviews/RFE-001-review.md",
-            ERROR_REVIEW.format(rfe_id="RFE-001", error="fetch_failed"),
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-001-review.md",
+            ERROR_REVIEW.format(rfe_id="DRAFT-001", error="fetch_failed"),
         )
-        out, _, rc = _run(["RFE-001"])
+        out, _, rc = _run(["DRAFT-001"])
         assert rc == 0
         groups = _parse_output(out)
-        assert "RFE-001" in groups["ERRORS"]
+        assert "DRAFT-001" in groups["ERRORS"]
 
 
 class TestCollectReassess:
     def test_revised_and_failing_needs_reassess(self, art_dir):
         _write(
-            f"{art_dir}/artifacts/rfe-reviews/RFE-001-review.md",
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-001-review.md",
             REVIEW_TEMPLATE.format(
-                rfe_id="RFE-001",
+                rfe_id="DRAFT-001",
                 score=5,
                 pass_val="false",
                 recommendation="revise",
                 auto_revised="true",
             ),
         )
-        out, _, rc = _run(["--reassess", "RFE-001"])
+        out, _, rc = _run(["--reassess", "DRAFT-001"])
         assert rc == 0
         groups = _parse_output(out)
-        assert "RFE-001" in groups["REASSESS"]
+        assert "DRAFT-001" in groups["REASSESS"]
 
     def test_passing_goes_to_done(self, art_dir):
         _write(
-            f"{art_dir}/artifacts/rfe-reviews/RFE-001-review.md",
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-001-review.md",
             REVIEW_TEMPLATE.format(
-                rfe_id="RFE-001",
+                rfe_id="DRAFT-001",
                 score=9,
                 pass_val="true",
                 recommendation="submit",
                 auto_revised="true",
             ),
         )
-        out, _, rc = _run(["--reassess", "RFE-001"])
+        out, _, rc = _run(["--reassess", "DRAFT-001"])
         assert rc == 0
         groups = _parse_output(out)
-        assert "RFE-001" in groups["DONE"]
+        assert "DRAFT-001" in groups["DONE"]
 
     def test_not_revised_goes_to_done(self, art_dir):
         _write(
-            f"{art_dir}/artifacts/rfe-reviews/RFE-001-review.md",
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-001-review.md",
             REVIEW_TEMPLATE.format(
-                rfe_id="RFE-001",
+                rfe_id="DRAFT-001",
                 score=5,
                 pass_val="false",
                 recommendation="revise",
                 auto_revised="false",
             ),
         )
-        out, _, rc = _run(["--reassess", "RFE-001"])
+        out, _, rc = _run(["--reassess", "DRAFT-001"])
         assert rc == 0
         groups = _parse_output(out)
-        assert "RFE-001" in groups["DONE"]
+        assert "DRAFT-001" in groups["DONE"]

--- a/tests/test_collect_recommendations.py
+++ b/tests/test_collect_recommendations.py
@@ -209,3 +209,52 @@ class TestCollectReassess:
         assert rc == 0
         groups = _parse_output(out)
         assert "DRAFT-001" in groups["DONE"]
+
+
+class TestFromReviews:
+    def test_discovers_ids_from_review_files(self, art_dir):
+        _write(
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_TEMPLATE.format(
+                rfe_id="DRAFT-001",
+                score=9,
+                pass_val="true",
+                recommendation="submit",
+                auto_revised="false",
+            ),
+        )
+        _write(
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-002-review.md",
+            REVIEW_TEMPLATE.format(
+                rfe_id="DRAFT-002",
+                score=3,
+                pass_val="false",
+                recommendation="reject",
+                auto_revised="false",
+            ),
+        )
+        out, _, rc = _run(["--from-reviews"])
+        assert rc == 0
+        groups = _parse_output(out)
+        assert "DRAFT-001" in groups["SUBMIT"]
+        assert "DRAFT-002" in groups["REJECT"]
+
+    def test_no_review_files_exits_nonzero(self, art_dir):
+        _, _, rc = _run(["--from-reviews"])
+        assert rc != 0
+
+    def test_from_reviews_with_reassess(self, art_dir):
+        _write(
+            f"{art_dir}/artifacts/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_TEMPLATE.format(
+                rfe_id="DRAFT-001",
+                score=5,
+                pass_val="false",
+                recommendation="revise",
+                auto_revised="true",
+            ),
+        )
+        out, _, rc = _run(["--from-reviews", "--reassess"])
+        assert rc == 0
+        groups = _parse_output(out)
+        assert "DRAFT-001" in groups["REASSESS"]

--- a/tests/test_draft_prefix.py
+++ b/tests/test_draft_prefix.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Tests for DRAFT-NNN local draft prefix.
+
+Local draft IDs must use the DRAFT-NNN prefix to avoid collision with
+real Jira project keys. The old RFE-NNN prefix is retired because RFE
+is itself a valid Jira project key.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from artifact_utils import validate
+
+
+class TestDraftPrefixInSchemas:
+    """Schema validation must accept DRAFT-NNN and reject bare RFE-NNN."""
+
+    def test_draft_prefix_accepted_in_task_schema(self):
+        data = {
+            "rfe_id": "DRAFT-001",
+            "title": "Test RFE",
+            "priority": "Normal",
+            "status": "Draft",
+        }
+        errors = validate(data, "rfe-task")
+        assert errors == [], f"DRAFT-001 should be valid: {errors}"
+
+    def test_draft_prefix_accepted_in_review_schema(self):
+        data = {
+            "rfe_id": "DRAFT-042",
+            "score": 8,
+            "pass": True,
+            "recommendation": "submit",
+            "feasibility": "feasible",
+            "auto_revised": False,
+            "needs_attention": False,
+            "scores": {
+                "what": 2,
+                "why": 2,
+                "open_to_how": 2,
+                "not_a_task": 2,
+                "right_sized": 0,
+            },
+        }
+        errors = validate(data, "rfe-review")
+        assert errors == [], f"DRAFT-042 should be valid: {errors}"
+
+    def test_rfe_prefix_rejected_in_task_schema(self):
+        data = {
+            "rfe_id": "RFE-001",
+            "title": "Test RFE",
+            "priority": "Normal",
+            "status": "Draft",
+        }
+        errors = validate(data, "rfe-task")
+        assert any("does not match" in e for e in errors), (
+            "RFE-001 should be rejected — RFE looks like a Jira project key"
+        )
+
+    def test_rfe_prefix_rejected_in_review_schema(self):
+        data = {
+            "rfe_id": "RFE-001",
+            "score": 8,
+            "pass": True,
+            "recommendation": "submit",
+            "feasibility": "feasible",
+            "auto_revised": False,
+            "needs_attention": False,
+            "scores": {
+                "what": 2,
+                "why": 2,
+                "open_to_how": 2,
+                "not_a_task": 2,
+                "right_sized": 0,
+            },
+        }
+        errors = validate(data, "rfe-review")
+        assert any("does not match" in e for e in errors), (
+            "RFE-001 should be rejected — RFE looks like a Jira project key"
+        )
+
+    def test_jira_key_still_accepted_in_task_schema(self):
+        data = {
+            "rfe_id": "RHAIRFE-1595",
+            "title": "Existing Jira issue",
+            "priority": "Major",
+            "status": "Ready",
+        }
+        errors = validate(data, "rfe-task")
+        assert errors == [], f"RHAIRFE-1595 should be valid: {errors}"
+
+    def test_draft_prefix_accepted_as_parent_key(self):
+        data = {
+            "rfe_id": "DRAFT-002",
+            "title": "Child RFE",
+            "priority": "Normal",
+            "status": "Draft",
+            "parent_key": "DRAFT-001",
+        }
+        errors = validate(data, "rfe-task")
+        assert errors == [], f"DRAFT-001 as parent_key should be valid: {errors}"

--- a/tests/test_draft_prefix.py
+++ b/tests/test_draft_prefix.py
@@ -9,8 +9,6 @@ is itself a valid Jira project key.
 import os
 import sys
 
-import pytest
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from artifact_utils import validate

--- a/tests/test_draft_prefix.py
+++ b/tests/test_draft_prefix.py
@@ -47,7 +47,8 @@ class TestDraftPrefixInSchemas:
         errors = validate(data, "rfe-review")
         assert errors == [], f"DRAFT-042 should be valid: {errors}"
 
-    def test_rfe_prefix_rejected_in_task_schema(self):
+    def test_rfe_prefix_accepted_as_jira_key_in_task_schema(self):
+        """RFE-001 is a valid Jira key format (RFE is a valid project key)."""
         data = {
             "rfe_id": "RFE-001",
             "title": "Test RFE",
@@ -55,11 +56,10 @@ class TestDraftPrefixInSchemas:
             "status": "Draft",
         }
         errors = validate(data, "rfe-task")
-        assert any("does not match" in e for e in errors), (
-            "RFE-001 should be rejected — RFE looks like a Jira project key"
-        )
+        assert errors == [], f"RFE-001 should be valid as a Jira key: {errors}"
 
-    def test_rfe_prefix_rejected_in_review_schema(self):
+    def test_rfe_prefix_accepted_as_jira_key_in_review_schema(self):
+        """RFE-001 is a valid Jira key format (RFE is a valid project key)."""
         data = {
             "rfe_id": "RFE-001",
             "score": 8,
@@ -77,9 +77,7 @@ class TestDraftPrefixInSchemas:
             },
         }
         errors = validate(data, "rfe-review")
-        assert any("does not match" in e for e in errors), (
-            "RFE-001 should be rejected — RFE looks like a Jira project key"
-        )
+        assert errors == [], f"RFE-001 should be valid as a Jira key: {errors}"
 
     def test_jira_key_still_accepted_in_task_schema(self):
         data = {

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -82,23 +82,23 @@ class TestSplitChildrenIncluded:
         )
         # Child tasks with parent_key
         _write(
-            f"{art_dir}/rfe-tasks/RFE-001.md",
-            TASK_TEMPLATE.format(rfe_id="RFE-001", extra="parent_key: RHAIRFE-1234"),
+            f"{art_dir}/rfe-tasks/DRAFT-001.md",
+            TASK_TEMPLATE.format(rfe_id="DRAFT-001", extra="parent_key: RHAIRFE-1234"),
         )
         _write(
-            f"{art_dir}/rfe-reviews/RFE-001-review.md",
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
             REVIEW_TEMPLATE.format(
-                rfe_id="RFE-001", score=9, pass_val="true", recommendation="submit", right_sized=2
+                rfe_id="DRAFT-001", score=9, pass_val="true", recommendation="submit", right_sized=2
             ),
         )
         _write(
-            f"{art_dir}/rfe-tasks/RFE-002.md",
-            TASK_TEMPLATE.format(rfe_id="RFE-002", extra="parent_key: RHAIRFE-1234"),
+            f"{art_dir}/rfe-tasks/DRAFT-002.md",
+            TASK_TEMPLATE.format(rfe_id="DRAFT-002", extra="parent_key: RHAIRFE-1234"),
         )
         _write(
-            f"{art_dir}/rfe-reviews/RFE-002-review.md",
+            f"{art_dir}/rfe-reviews/DRAFT-002-review.md",
             REVIEW_TEMPLATE.format(
-                rfe_id="RFE-002", score=8, pass_val="true", recommendation="submit", right_sized=1
+                rfe_id="DRAFT-002", score=8, pass_val="true", recommendation="submit", right_sized=1
             ),
         )
 
@@ -107,8 +107,8 @@ class TestSplitChildrenIncluded:
 
         ids_in_report = [e["id"] for e in report["per_rfe"]]
         assert "RHAIRFE-1234" in ids_in_report
-        assert "RFE-001" in ids_in_report
-        assert "RFE-002" in ids_in_report
+        assert "DRAFT-001" in ids_in_report
+        assert "DRAFT-002" in ids_in_report
         assert len(report["per_rfe"]) == 3
 
     def test_children_not_duplicated_if_already_passed(self, art_dir):
@@ -128,20 +128,20 @@ class TestSplitChildrenIncluded:
             ),
         )
         _write(
-            f"{art_dir}/rfe-tasks/RFE-001.md",
-            TASK_TEMPLATE.format(rfe_id="RFE-001", extra="parent_key: RHAIRFE-1234"),
+            f"{art_dir}/rfe-tasks/DRAFT-001.md",
+            TASK_TEMPLATE.format(rfe_id="DRAFT-001", extra="parent_key: RHAIRFE-1234"),
         )
         _write(
-            f"{art_dir}/rfe-reviews/RFE-001-review.md",
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
             REVIEW_TEMPLATE.format(
-                rfe_id="RFE-001", score=9, pass_val="true", recommendation="submit", right_sized=2
+                rfe_id="DRAFT-001", score=9, pass_val="true", recommendation="submit", right_sized=2
             ),
         )
 
-        report = build_report(["RHAIRFE-1234", "RFE-001"], "2026-04-01T22:50:53Z", 5, [], [])
+        report = build_report(["RHAIRFE-1234", "DRAFT-001"], "2026-04-01T22:50:53Z", 5, [], [])
 
         ids_in_report = [e["id"] for e in report["per_rfe"]]
-        assert ids_in_report.count("RFE-001") == 1
+        assert ids_in_report.count("DRAFT-001") == 1
         assert len(report["per_rfe"]) == 2
 
     def test_input_count_reflects_original_ids(self, art_dir):
@@ -161,13 +161,13 @@ class TestSplitChildrenIncluded:
             ),
         )
         _write(
-            f"{art_dir}/rfe-tasks/RFE-001.md",
-            TASK_TEMPLATE.format(rfe_id="RFE-001", extra="parent_key: RHAIRFE-1234"),
+            f"{art_dir}/rfe-tasks/DRAFT-001.md",
+            TASK_TEMPLATE.format(rfe_id="DRAFT-001", extra="parent_key: RHAIRFE-1234"),
         )
         _write(
-            f"{art_dir}/rfe-reviews/RFE-001-review.md",
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
             REVIEW_TEMPLATE.format(
-                rfe_id="RFE-001", score=9, pass_val="true", recommendation="submit", right_sized=2
+                rfe_id="DRAFT-001", score=9, pass_val="true", recommendation="submit", right_sized=2
             ),
         )
 

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -368,12 +368,12 @@ class TestReviewToRevise:
 
 class TestSplitPipeline:
     def test_split_review_filters_for_revision(self, tmp_dir, monkeypatch):
-        write_ids("tmp/pipeline-split-children-ids.txt", ["RFE-001", "RFE-002"])
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "RFE-001")
+        write_ids("tmp/pipeline-split-children-ids.txt", ["DRAFT-001", "DRAFT-002"])
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "DRAFT-001")
         state = make_state(phase="SPLIT_REVIEW")
         next_phase, _ = ps.advance(state)
         assert next_phase == "SPLIT_REVISE"
-        assert read_ids("tmp/pipeline-revise-ids.txt") == ["RFE-001"]
+        assert read_ids("tmp/pipeline-revise-ids.txt") == ["DRAFT-001"]
 
     def test_split_sequence_revise_to_reassess(self, tmp_dir):
         """SPLIT_FIXUP → SPLIT_SAVE → SPLIT_REASSESS → SPLIT_RE_REVIEW → SPLIT_RESTORE."""
@@ -399,12 +399,12 @@ class TestSplitFullCycle:
     def test_revised_children_are_re_reviewed(self, tmp_dir, monkeypatch):
         """Trace: SPLIT_REVIEW filters → SPLIT_REVISE → FIXUP → re-review."""
         # SPLIT_REVIEW: 1 of 3 children needs revision
-        write_ids("tmp/pipeline-split-children-ids.txt", ["RFE-001", "RFE-002", "RFE-003"])
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "RFE-002")
+        write_ids("tmp/pipeline-split-children-ids.txt", ["DRAFT-001", "DRAFT-002", "DRAFT-003"])
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "DRAFT-002")
         state = make_state(phase="SPLIT_REVIEW")
         next_phase, _ = ps.advance(state)
         assert next_phase == "SPLIT_REVISE"
-        assert read_ids("tmp/pipeline-revise-ids.txt") == ["RFE-002"]
+        assert read_ids("tmp/pipeline-revise-ids.txt") == ["DRAFT-002"]
 
         # Walk through the full post-revise sequence
         expected_phases = [
@@ -425,7 +425,7 @@ class TestSplitFullCycle:
 
     def test_no_revision_skips_reassess(self, tmp_dir, monkeypatch):
         """When no children need revision, re-review phases are no-ops."""
-        write_ids("tmp/pipeline-split-children-ids.txt", ["RFE-001"])
+        write_ids("tmp/pipeline-split-children-ids.txt", ["DRAFT-001"])
         monkeypatch.setattr(ps, "_run_script", lambda cmd: "")
         state = make_state(phase="SPLIT_REVIEW")
         next_phase, _ = ps.advance(state)
@@ -453,24 +453,24 @@ class TestSplitFullCycle:
 
 class TestSplitCorrectionCheck:
     def test_undersized_loops_back(self, tmp_dir, monkeypatch):
-        write_ids("tmp/pipeline-split-children-ids.txt", ["RFE-001", "RFE-002"])
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "RESPLIT=RFE-001")
+        write_ids("tmp/pipeline-split-children-ids.txt", ["DRAFT-001", "DRAFT-002"])
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "RESPLIT=DRAFT-001")
         state = make_state(phase="SPLIT_CORRECTION_CHECK", correction_cycle=0)
         next_phase, summary = ps.advance(state)
         assert next_phase == "SPLIT"
         assert state["correction_cycle"] == 1
-        assert read_ids("tmp/pipeline-split-ids.txt") == ["RFE-001"]
+        assert read_ids("tmp/pipeline-split-ids.txt") == ["DRAFT-001"]
 
     def test_no_undersized_goes_to_batch_done(self, tmp_dir, monkeypatch):
-        write_ids("tmp/pipeline-split-children-ids.txt", ["RFE-001"])
+        write_ids("tmp/pipeline-split-children-ids.txt", ["DRAFT-001"])
         monkeypatch.setattr(ps, "_run_script", lambda cmd: "RESPLIT=")
         state = make_state(phase="SPLIT_CORRECTION_CHECK", correction_cycle=0)
         next_phase, _ = ps.advance(state)
         assert next_phase == "BATCH_DONE"
 
     def test_max_correction_cycle_exits(self, tmp_dir, monkeypatch):
-        write_ids("tmp/pipeline-split-children-ids.txt", ["RFE-001"])
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "RESPLIT=RFE-001")
+        write_ids("tmp/pipeline-split-children-ids.txt", ["DRAFT-001"])
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "RESPLIT=DRAFT-001")
         state = make_state(phase="SPLIT_CORRECTION_CHECK", correction_cycle=1)
         next_phase, _ = ps.advance(state)
         assert next_phase == "BATCH_DONE"
@@ -506,7 +506,7 @@ class TestCollect:
 
 class TestSplitCollect:
     def test_children_exist(self, tmp_dir):
-        write_ids("tmp/pipeline-split-children-ids.txt", ["RFE-001"])
+        write_ids("tmp/pipeline-split-children-ids.txt", ["DRAFT-001"])
         state = make_state(phase="SPLIT_COLLECT")
         next_phase, _ = ps.advance(state)
         assert next_phase == "SPLIT_PIPELINE_START"
@@ -1272,7 +1272,7 @@ class TestDispatchLoopE2E:
         # SPLIT_COLLECT writes child IDs
         def subprocess_mock(cmd, **kw):
             if "split_collect.py" in cmd:
-                write_ids("tmp/pipeline-split-children-ids.txt", ["RFE-001", "RFE-002"])
+                write_ids("tmp/pipeline-split-children-ids.txt", ["DRAFT-001", "DRAFT-002"])
             return type("R", (), {"returncode": 0})()
 
         phases = self._run_loop(monkeypatch, subprocess_mock)
@@ -1363,7 +1363,7 @@ class TestDispatchLoopE2E:
             if "check_right_sized.py" in cmd:
                 correction_checks["count"] += 1
                 if correction_checks["count"] == 1:
-                    return "RESPLIT=RFE-001"  # undersized on first check
+                    return "RESPLIT=DRAFT-001"  # undersized on first check
                 return "RESPLIT="  # all pass on second check
             if "batch_summary.py" in cmd:
                 return "submit=0"
@@ -1377,9 +1377,9 @@ class TestDispatchLoopE2E:
             if "split_collect.py" in cmd:
                 split_collect_calls["count"] += 1
                 if split_collect_calls["count"] == 1:
-                    write_ids("tmp/pipeline-split-children-ids.txt", ["RFE-001", "RFE-002"])
+                    write_ids("tmp/pipeline-split-children-ids.txt", ["DRAFT-001", "DRAFT-002"])
                 else:
-                    write_ids("tmp/pipeline-split-children-ids.txt", ["RFE-003", "RFE-004"])
+                    write_ids("tmp/pipeline-split-children-ids.txt", ["DRAFT-003", "DRAFT-004"])
             return type("R", (), {"returncode": 0})()
 
         phases = self._run_loop(monkeypatch, subprocess_mock)

--- a/tests/test_resolve_project.py
+++ b/tests/test_resolve_project.py
@@ -1,0 +1,37 @@
+"""Tests for resolve_project.py."""
+
+import os
+import subprocess
+import sys
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "resolve_project.py")
+
+
+class TestResolveProject:
+    def test_both_set(self):
+        env = {k: v for k, v in os.environ.items()}
+        env["JIRA_PROJECT"] = "MYPROJ"
+        env["JIRA_ISSUE_TYPE"] = "Bug"
+        result = subprocess.run(
+            [sys.executable, SCRIPT],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "JIRA_PROJECT=MYPROJ" in result.stdout
+        assert "JIRA_ISSUE_TYPE=Bug" in result.stdout
+
+    def test_project_only_defaults_issue_type(self):
+        env = {k: v for k, v in os.environ.items() if k != "JIRA_ISSUE_TYPE"}
+        env["JIRA_PROJECT"] = "RHAIRFE"
+        result = subprocess.run([sys.executable, SCRIPT], capture_output=True, text=True, env=env)
+        assert result.returncode == 0
+        assert "JIRA_PROJECT=RHAIRFE" in result.stdout
+        assert "JIRA_ISSUE_TYPE=Feature Request" in result.stdout
+
+    def test_missing_project_exits_nonzero(self):
+        env = {k: v for k, v in os.environ.items() if k not in ("JIRA_PROJECT", "JIRA_ISSUE_TYPE")}
+        result = subprocess.run([sys.executable, SCRIPT], capture_output=True, text=True, env=env)
+        assert result.returncode == 1
+        assert "JIRA_PROJECT" in result.stderr

--- a/tests/test_split_submit.py
+++ b/tests/test_split_submit.py
@@ -34,7 +34,7 @@ Original parent content.
 
 CHILD_TASK = """\
 ---
-rfe_id: RFE-{num:03d}
+rfe_id: DRAFT-{num:03d}
 title: Child RFE {num}
 priority: Major
 status: Ready
@@ -79,7 +79,7 @@ class TestMaxLeafChildren:
         """More than MAX_LEAF_CHILDREN → exit code 2."""
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", PARENT_TASK)
         for i in range(1, 8):  # 7 children > 6 limit
-            _write(f"{art_dir}/rfe-tasks/RFE-{i:03d}.md", CHILD_TASK.format(num=i))
+            _write(f"{art_dir}/rfe-tasks/DRAFT-{i:03d}.md", CHILD_TASK.format(num=i))
 
         result = _run_split_submit(art_dir)
         assert result.returncode == 2
@@ -91,7 +91,7 @@ class TestMaxLeafChildren:
         """Exactly MAX_LEAF_CHILDREN → proceeds (no exit code 2)."""
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", PARENT_TASK)
         for i in range(1, 7):  # 6 children = limit
-            _write(f"{art_dir}/rfe-tasks/RFE-{i:03d}.md", CHILD_TASK.format(num=i))
+            _write(f"{art_dir}/rfe-tasks/DRAFT-{i:03d}.md", CHILD_TASK.format(num=i))
 
         result = _run_split_submit(art_dir)
         # Should not exit with code 2 (may fail for other reasons
@@ -103,7 +103,7 @@ class TestMaxLeafChildren:
         """Fewer than MAX_LEAF_CHILDREN → proceeds."""
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", PARENT_TASK)
         for i in range(1, 4):  # 3 children
-            _write(f"{art_dir}/rfe-tasks/RFE-{i:03d}.md", CHILD_TASK.format(num=i))
+            _write(f"{art_dir}/rfe-tasks/DRAFT-{i:03d}.md", CHILD_TASK.format(num=i))
 
         result = _run_split_submit(art_dir)
         assert result.returncode != 2
@@ -116,8 +116,8 @@ class TestSplitSummaryAdf:
         state = SubmissionState()
         state.phase2_done = {1: "RHAIRFE-100", 2: "RHAIRFE-101"}
         children = [
-            ("RFE-001", "First child", "Major", "/fake/path1"),
-            ("RFE-002", "Second child", "Major", "/fake/path2"),
+            ("DRAFT-001", "First child", "Major", "/fake/path1"),
+            ("DRAFT-002", "Second child", "Major", "/fake/path2"),
         ]
         adf = build_split_summary_adf("https://jira.example.com", children, state, 2)
 
@@ -143,7 +143,7 @@ class TestSplitSummaryAdf:
         """Trailing slash on server URL does not produce double slash."""
         state = SubmissionState()
         state.phase2_done = {1: "RHAIRFE-100"}
-        children = [("RFE-001", "Child", "Major", "/fake/path")]
+        children = [("DRAFT-001", "Child", "Major", "/fake/path")]
         adf = build_split_summary_adf("https://jira.example.com/", children, state, 1)
 
         item = adf["content"][1]["content"][0]

--- a/tests/test_split_submit.py
+++ b/tests/test_split_submit.py
@@ -54,6 +54,7 @@ def _run_split_submit(artifacts_dir, parent_key="RHAIRFE-1000"):
         "JIRA_SERVER": "",
         "JIRA_USER": "",
         "JIRA_TOKEN": "",
+        "JIRA_PROJECT": "RHAIRFE",
     }
     return subprocess.run(
         [sys.executable, SCRIPT, parent_key, "--dry-run", "--artifacts-dir", artifacts_dir],

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -160,10 +160,10 @@ class TestContentDiffGuard:
 
     def test_new_rfe_always_created(self, art_dir):
         """New RFE (RFE-NNN) → always create, no content-diff check."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
         _write(
-            f"{art_dir}/rfe-reviews/RFE-001-review.md",
-            REVIEW_FM.format(rfe_id="RFE-001", auto_revised="false"),
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_FM.format(rfe_id="DRAFT-001", auto_revised="false"),
         )
 
         stdout, _, rc = _run_submit(art_dir)
@@ -174,10 +174,10 @@ class TestContentDiffGuard:
 class TestSkipLogic:
     def test_rejected_rfe_skipped(self, art_dir):
         """RFE with recommendation=reject → SKIP rejected."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
         _write(
-            f"{art_dir}/rfe-reviews/RFE-001-review.md",
-            REVIEW_FM.format(rfe_id="RFE-001", auto_revised="false").replace(
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_FM.format(rfe_id="DRAFT-001", auto_revised="false").replace(
                 "recommendation: submit", "recommendation: reject"
             ),
         )
@@ -190,8 +190,8 @@ class TestSkipLogic:
     def test_archived_rfe_excluded(self, art_dir):
         """Archived RFE → not in plan at all."""
         _write(
-            f"{art_dir}/rfe-tasks/RFE-001.md",
-            TASK_FM.format(rfe_id="RFE-001").replace("status: Ready", "status: Archived"),
+            f"{art_dir}/rfe-tasks/DRAFT-001.md",
+            TASK_FM.format(rfe_id="DRAFT-001").replace("status: Ready", "status: Archived"),
         )
 
         stdout, stderr, rc = _run_submit(art_dir)
@@ -203,15 +203,15 @@ class TestSkipLogic:
         """Children of local RFE-NNN parent → included in Phase 2 as creates."""
         # Archived local parent
         _write(
-            f"{art_dir}/rfe-tasks/RFE-001.md",
-            TASK_FM.format(rfe_id="RFE-001").replace("status: Ready", "status: Archived"),
+            f"{art_dir}/rfe-tasks/DRAFT-001.md",
+            TASK_FM.format(rfe_id="DRAFT-001").replace("status: Ready", "status: Archived"),
         )
         # Children with local parent_key
-        for i, child_id in enumerate(["RFE-002", "RFE-003"], start=2):
+        for i, child_id in enumerate(["DRAFT-002", "DRAFT-003"], start=2):
             _write(
                 f"{art_dir}/rfe-tasks/{child_id}.md",
                 TASK_FM.format(rfe_id=child_id).replace(
-                    "status: Ready", "status: Ready\nparent_key: RFE-001"
+                    "status: Ready", "status: Ready\nparent_key: DRAFT-001"
                 ),
             )
             _write(
@@ -222,21 +222,21 @@ class TestSkipLogic:
         stdout, _, rc = _run_submit(art_dir)
         assert rc == 0
         assert "Would create" in stdout
-        assert "RFE-002" in stdout
-        assert "RFE-003" in stdout
+        assert "DRAFT-002" in stdout
+        assert "DRAFT-003" in stdout
 
     def test_children_of_jira_parent_excluded(self, art_dir):
         """Children of RHAIRFE parent → excluded from Phase 2 (Phase 1 handles)."""
         # Child with Jira parent_key
         _write(
-            f"{art_dir}/rfe-tasks/RFE-002.md",
-            TASK_FM.format(rfe_id="RFE-002").replace(
+            f"{art_dir}/rfe-tasks/DRAFT-002.md",
+            TASK_FM.format(rfe_id="DRAFT-002").replace(
                 "status: Ready", "status: Ready\nparent_key: RHAIRFE-1234"
             ),
         )
         _write(
-            f"{art_dir}/rfe-reviews/RFE-002-review.md",
-            REVIEW_FM.format(rfe_id="RFE-002", auto_revised="false"),
+            f"{art_dir}/rfe-reviews/DRAFT-002-review.md",
+            REVIEW_FM.format(rfe_id="DRAFT-002", auto_revised="false"),
         )
 
         stdout, stderr, rc = _run_submit(art_dir)
@@ -248,23 +248,23 @@ class TestSkipLogic:
 
         Tests Phase 2 filtering only: the RHAIRFE parent task file is
         omitted so Phase 1 has no split parents to run.  The ancestor
-        chain in frontmatter (RFE-011 → RFE-010 → RHAIRFE-1234) is
+        chain in frontmatter (DRAFT-011 → DRAFT-010 → RHAIRFE-1234) is
         enough for _has_jira_ancestor to exclude the grandchildren.
-        A standalone RFE-020 is included so Phase 2 has work to do.
+        A standalone DRAFT-020 is included so Phase 2 has work to do.
         """
         # Archived local intermediary whose parent_key traces to Jira
         _write(
-            f"{art_dir}/rfe-tasks/RFE-010.md",
-            TASK_FM.format(rfe_id="RFE-010").replace(
+            f"{art_dir}/rfe-tasks/DRAFT-010.md",
+            TASK_FM.format(rfe_id="DRAFT-010").replace(
                 "status: Ready", "status: Archived\nparent_key: RHAIRFE-1234"
             ),
         )
         # Grandchildren — parent_key points to local intermediary
-        for child_id in ["RFE-011", "RFE-012"]:
+        for child_id in ["DRAFT-011", "DRAFT-012"]:
             _write(
                 f"{art_dir}/rfe-tasks/{child_id}.md",
                 TASK_FM.format(rfe_id=child_id).replace(
-                    "status: Ready", "status: Ready\nparent_key: RFE-010"
+                    "status: Ready", "status: Ready\nparent_key: DRAFT-010"
                 ),
             )
             _write(
@@ -272,29 +272,29 @@ class TestSkipLogic:
                 REVIEW_FM.format(rfe_id=child_id, auto_revised="false"),
             )
         # Standalone RFE so Phase 2 runs (rc == 0)
-        _write(f"{art_dir}/rfe-tasks/RFE-020.md", TASK_FM.format(rfe_id="RFE-020"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-020.md", TASK_FM.format(rfe_id="DRAFT-020"))
         _write(
-            f"{art_dir}/rfe-reviews/RFE-020-review.md",
-            REVIEW_FM.format(rfe_id="RFE-020", auto_revised="false"),
+            f"{art_dir}/rfe-reviews/DRAFT-020-review.md",
+            REVIEW_FM.format(rfe_id="DRAFT-020", auto_revised="false"),
         )
 
         stdout, _, rc = _run_submit(art_dir)
         assert rc == 0
         # Standalone RFE submitted normally
-        assert "RFE-020" in stdout and "Would create" in stdout
+        assert "DRAFT-020" in stdout and "Would create" in stdout
         # Grandchildren excluded from Phase 2 plan
         plan_section = stdout.split("Submission plan:")[1]
-        assert "RFE-011" not in plan_section
-        assert "RFE-012" not in plan_section
+        assert "DRAFT-011" not in plan_section
+        assert "DRAFT-012" not in plan_section
 
 
 class TestAutoRevisedLabel:
     def test_auto_revised_label_applied(self, art_dir):
         """auto_revised=true → rfe-creator-auto-revised label."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
         _write(
-            f"{art_dir}/rfe-reviews/RFE-001-review.md",
-            REVIEW_FM.format(rfe_id="RFE-001", auto_revised="true"),
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_FM.format(rfe_id="DRAFT-001", auto_revised="true"),
         )
 
         stdout, _, rc = _run_submit(art_dir)
@@ -303,10 +303,10 @@ class TestAutoRevisedLabel:
 
     def test_no_label_when_not_revised(self, art_dir):
         """auto_revised=false → no auto-revised label."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
         _write(
-            f"{art_dir}/rfe-reviews/RFE-001-review.md",
-            REVIEW_FM.format(rfe_id="RFE-001", auto_revised="false"),
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_FM.format(rfe_id="DRAFT-001", auto_revised="false"),
         )
 
         stdout, _, rc = _run_submit(art_dir)
@@ -360,9 +360,9 @@ class TestRemoveLabels:
 
     def test_rejected_new_rfe_skips(self, art_dir):
         """Rejected new RFE (RFE-NNN) → SKIP, no label removal."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
         _write(
-            f"{art_dir}/rfe-reviews/RFE-001-review.md", REJECT_REVIEW_FM.format(rfe_id="RFE-001")
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md", REJECT_REVIEW_FM.format(rfe_id="DRAFT-001")
         )
 
         stdout, _, rc = _run_submit(art_dir)
@@ -513,8 +513,8 @@ class TestFeasibilityLabelOnSubmit:
     )
     def test_feasibility_label_on_create(self, art_dir, verdict, label):
         """Each verdict applies the matching label on a new RFE."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", self._task("RFE-001"))
-        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md", _feas_review("RFE-001", verdict))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", self._task("DRAFT-001"))
+        _write(f"{art_dir}/rfe-reviews/DRAFT-001-review.md", _feas_review("DRAFT-001", verdict))
         stdout, _, rc = _run_submit(art_dir)
         assert rc == 0
         assert label in stdout
@@ -575,7 +575,7 @@ class TestFeasibilityLabelOnSubmit:
 
     def test_no_review_skips_feasibility_op(self, art_dir):
         """Missing review file → no feasibility label, but submit still runs."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", self._task("RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", self._task("DRAFT-001"))
         # No review file written
         stdout, _, rc = _run_submit(art_dir)
         assert rc == 0
@@ -594,7 +594,7 @@ class TestSplitRefusal:
     )
 
     CHILD_TASK_TPL = (
-        "---\nrfe_id: RFE-{num:03d}\ntitle: Child RFE {num}\n"
+        "---\nrfe_id: DRAFT-{num:03d}\ntitle: Child RFE {num}\n"
         "priority: Major\nstatus: Ready\n"
         "parent_key: RHAIRFE-1000\n---\n\nChild {num} content.\n"
     )
@@ -612,7 +612,7 @@ class TestSplitRefusal:
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
         _write(f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md", self.REVIEW)
         for i in range(1, num_children + 1):
-            _write(f"{art_dir}/rfe-tasks/RFE-{i:03d}.md", self.CHILD_TASK_TPL.format(num=i))
+            _write(f"{art_dir}/rfe-tasks/DRAFT-{i:03d}.md", self.CHILD_TASK_TPL.format(num=i))
 
     def test_refusal_sets_frontmatter_fields(self, art_dir):
         """Exit code 2 → needs_attention + reason + error in review."""
@@ -648,16 +648,16 @@ class TestSplitRefusal:
         self._setup_oversized_split(art_dir)
 
         # Add a regular (non-split) RFE that should still be processed
-        _write(f"{art_dir}/rfe-tasks/RFE-099.md", TASK_FM.format(rfe_id="RFE-099"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-099.md", TASK_FM.format(rfe_id="DRAFT-099"))
         _write(
-            f"{art_dir}/rfe-reviews/RFE-099-review.md",
-            REVIEW_FM.format(rfe_id="RFE-099", auto_revised="false"),
+            f"{art_dir}/rfe-reviews/DRAFT-099-review.md",
+            REVIEW_FM.format(rfe_id="DRAFT-099", auto_revised="false"),
         )
 
         stdout, stderr, rc = _run_submit(art_dir)
         assert rc == 0
         assert "Split refused" in stdout
-        assert "Would create" in stdout  # RFE-099 still processed
+        assert "Would create" in stdout  # DRAFT-099 still processed
 
 
 class TestSnapshotUpdate:
@@ -665,10 +665,10 @@ class TestSnapshotUpdate:
 
     def test_dry_run_does_not_update_snapshot(self, art_dir):
         """Dry-run does not update snapshot."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
         _write(
-            f"{art_dir}/rfe-reviews/RFE-001-review.md",
-            REVIEW_FM.format(rfe_id="RFE-001", auto_revised="false"),
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_FM.format(rfe_id="DRAFT-001", auto_revised="false"),
         )
 
         stdout, _, rc = _run_submit(art_dir)
@@ -700,10 +700,10 @@ class TestGenerateReportFlag:
 
     def test_generate_report_with_timestamp_accepted(self, art_dir):
         """--generate-report with --report-timestamp → no validation error."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
         _write(
-            f"{art_dir}/rfe-reviews/RFE-001-review.md",
-            REVIEW_FM.format(rfe_id="RFE-001", auto_revised="false"),
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_FM.format(rfe_id="DRAFT-001", auto_revised="false"),
         )
 
         env = {
@@ -770,10 +770,10 @@ class TestApprovedTransition:
 
     def test_new_rfe_prints_would_transition(self, art_dir):
         """--auto-approve + new RFE with passing review → would-transition."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
         _write(
-            f"{art_dir}/rfe-reviews/RFE-001-review.md",
-            REVIEW_FM.format(rfe_id="RFE-001", auto_revised="false"),
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_FM.format(rfe_id="DRAFT-001", auto_revised="false"),
         )
 
         stdout, stderr, rc = _run_submit(art_dir, ["--auto-approve"])

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -798,3 +798,41 @@ class TestApprovedTransition:
         stdout, stderr, rc = _run_submit(art_dir)
         assert rc == 0, stderr
         assert "Would transition to Approved" not in stdout
+
+
+class TestProjectEnvVar:
+    """submit.py reads JIRA_PROJECT from env for create operations."""
+
+    def test_dry_run_uses_jira_project(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JIRA_PROJECT", "TESTPROJ")
+        art_dir = str(tmp_path)
+        for d in ["rfe-tasks", "rfe-reviews"]:
+            os.makedirs(os.path.join(art_dir, d), exist_ok=True)
+        _write(
+            f"{art_dir}/rfe-tasks/DRAFT-001.md",
+            "---\nrfe_id: DRAFT-001\ntitle: Test\npriority: Normal\nstatus: Draft\n---\n\nBody.\n",
+        )
+        _write(
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_FM.format(rfe_id="DRAFT-001", auto_revised="false"),
+        )
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert "Would create TESTPROJ ticket" in stdout
+
+    def test_dry_run_without_jira_project_shows_unknown(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("JIRA_PROJECT", raising=False)
+        art_dir = str(tmp_path)
+        for d in ["rfe-tasks", "rfe-reviews"]:
+            os.makedirs(os.path.join(art_dir, d), exist_ok=True)
+        _write(
+            f"{art_dir}/rfe-tasks/DRAFT-001.md",
+            "---\nrfe_id: DRAFT-001\ntitle: Test\npriority: Normal\nstatus: Draft\n---\n\nBody.\n",
+        )
+        _write(
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
+            REVIEW_FM.format(rfe_id="DRAFT-001", auto_revised="false"),
+        )
+        stdout, _, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert "Would create UNKNOWN ticket" in stdout

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -362,7 +362,8 @@ class TestRemoveLabels:
         """Rejected new RFE (RFE-NNN) → SKIP, no label removal."""
         _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
         _write(
-            f"{art_dir}/rfe-reviews/DRAFT-001-review.md", REJECT_REVIEW_FM.format(rfe_id="DRAFT-001")
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
+            REJECT_REVIEW_FM.format(rfe_id="DRAFT-001"),
         )
 
         stdout, _, rc = _run_submit(art_dir)

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -137,8 +137,8 @@ def _review(rfe_id, auto_revised="false", needs_attention="false", extra_fields=
 class TestCreateNewRFE:
     def test_posts_correct_fields(self, art_dir, jira):
         """New RFE → issue created in Jira with correct fields."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
-        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md", _review("RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
+        _write(f"{art_dir}/rfe-reviews/DRAFT-001-review.md", _review("DRAFT-001"))
 
         r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
@@ -153,8 +153,8 @@ class TestCreateNewRFE:
 
     def test_includes_labels(self, art_dir, jira):
         """New RFE → labels include auto-created and rubric-pass."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
-        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md", _review("RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
+        _write(f"{art_dir}/rfe-reviews/DRAFT-001-review.md", _review("DRAFT-001"))
 
         r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
@@ -166,15 +166,15 @@ class TestCreateNewRFE:
         assert "rfe-creator-autofix-rubric-pass" in labels
 
     def test_renames_files(self, art_dir, jira):
-        """New RFE → RFE-001.md renamed to RHAIRFE-N.md."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
-        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md", _review("RFE-001"))
+        """New RFE → DRAFT-001.md renamed to RHAIRFE-N.md."""
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
+        _write(f"{art_dir}/rfe-reviews/DRAFT-001-review.md", _review("DRAFT-001"))
 
         r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
 
-        # RFE-001.md should be renamed to the Jira key
-        assert not os.path.exists(f"{art_dir}/rfe-tasks/RFE-001.md")
+        # DRAFT-001.md should be renamed to the Jira key
+        assert not os.path.exists(f"{art_dir}/rfe-tasks/DRAFT-001.md")
         issues = jira.search("project = RHAIRFE")
         key = issues[0]["key"]
         assert os.path.exists(f"{art_dir}/rfe-tasks/{key}.md")
@@ -493,8 +493,8 @@ class TestConflictDetection:
 class TestCommentPosting:
     def test_removed_context_comment(self, art_dir, jira):
         """RFE with removed-context YAML → comment posted."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
-        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md", _review("RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
+        _write(f"{art_dir}/rfe-reviews/DRAFT-001-review.md", _review("DRAFT-001"))
         rc_yaml = {
             "blocks": [
                 {
@@ -504,7 +504,7 @@ class TestCommentPosting:
                 }
             ]
         }
-        _write(f"{art_dir}/rfe-tasks/RFE-001-removed-context.yaml", yaml.dump(rc_yaml))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001-removed-context.yaml", yaml.dump(rc_yaml))
 
         r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
@@ -518,11 +518,11 @@ class TestCommentPosting:
 
     def test_needs_attention_comment(self, art_dir, jira):
         """RFE with needs_attention → comment posted."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
         _write(
-            f"{art_dir}/rfe-reviews/RFE-001-review.md",
+            f"{art_dir}/rfe-reviews/DRAFT-001-review.md",
             _review(
-                "RFE-001",
+                "DRAFT-001",
                 needs_attention="true",
                 extra_fields="needs_attention_reason: Unclear scope\n",
             ),
@@ -556,8 +556,8 @@ class TestSnapshotUpdate:
     def test_snapshot_updated_on_create(self, art_dir, jira):
         """Create → snapshot updated with new issue hash."""
         snap_path = self._seed_snapshot(art_dir, {"RHAIRFE-9000": "existing"})
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
-        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md", _review("RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
+        _write(f"{art_dir}/rfe-reviews/DRAFT-001-review.md", _review("DRAFT-001"))
 
         r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
@@ -690,7 +690,7 @@ class TestSplitConflictDetection:
         "priority: Major\nstatus: Archived\n---\n\nOriginal content.\n"
     )
     CHILD_TASK = (
-        "---\nrfe_id: RFE-001\ntitle: Child RFE\n"
+        "---\nrfe_id: DRAFT-001\ntitle: Child RFE\n"
         "priority: Major\nstatus: Ready\n"
         "parent_key: RHAIRFE-1000\n---\n\nChild content.\n"
     )
@@ -701,7 +701,7 @@ class TestSplitConflictDetection:
         jira.create("RHAIRFE-1000", "Parent RFE", "Edited by someone.")
         _write(f"{art_dir}/rfe-originals/RHAIRFE-1000.md", "Original content.")
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", self.CHILD_TASK)
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", self.CHILD_TASK)
 
         env = {
             **os.environ,
@@ -724,7 +724,7 @@ class TestSplitConflictDetection:
         jira.create("RHAIRFE-1000", "Parent RFE", body)
         _write(f"{art_dir}/rfe-originals/RHAIRFE-1000.md", body)
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", self.CHILD_TASK)
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", self.CHILD_TASK)
 
         env = {
             **os.environ,
@@ -746,7 +746,7 @@ class TestSplitConflictDetection:
         jira.create("RHAIRFE-1000", "Parent RFE", "Edited by someone.")
         _write(f"{art_dir}/rfe-originals/RHAIRFE-1000.md", "Original content.")
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", self.CHILD_TASK)
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", self.CHILD_TASK)
         _write(f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md", _review("RHAIRFE-1000"))
 
         r = _run_submit(art_dir, jira.url)
@@ -774,7 +774,7 @@ class TestSplitFieldInheritance:
         "priority: Major\nstatus: Archived\n---\n\nParent content.\n"
     )
     CHILD_TASK_TPL = (
-        "---\nrfe_id: RFE-{num:03d}\ntitle: Child RFE {num}\n"
+        "---\nrfe_id: DRAFT-{num:03d}\ntitle: Child RFE {num}\n"
         "priority: Major\nstatus: Ready\n"
         "parent_key: RHAIRFE-1000\n---\n\nChild {num} content.\n"
     )
@@ -790,8 +790,8 @@ class TestSplitFieldInheritance:
         )
         _write(f"{art_dir}/rfe-originals/RHAIRFE-1000.md", "Parent content.")
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", self.CHILD_TASK_TPL.format(num=1))
-        _write(f"{art_dir}/rfe-tasks/RFE-002.md", self.CHILD_TASK_TPL.format(num=2))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", self.CHILD_TASK_TPL.format(num=1))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-002.md", self.CHILD_TASK_TPL.format(num=2))
 
         env = {
             **os.environ,
@@ -861,14 +861,14 @@ class TestSplitFieldInheritance:
             "priority: Major\nstatus: Archived\n---\n\nParent content.\n",
         )
         _write(
-            f"{art_dir}/rfe-tasks/RFE-001.md",
-            "---\nrfe_id: RFE-001\ntitle: Child RFE 1\n"
+            f"{art_dir}/rfe-tasks/DRAFT-001.md",
+            "---\nrfe_id: DRAFT-001\ntitle: Child RFE 1\n"
             "priority: Major\nstatus: Ready\n"
             "parent_key: RHAIRFE-2000\n---\n\nChild 1 content.\n",
         )
         _write(
-            f"{art_dir}/rfe-tasks/RFE-002.md",
-            "---\nrfe_id: RFE-002\ntitle: Child RFE 2\n"
+            f"{art_dir}/rfe-tasks/DRAFT-002.md",
+            "---\nrfe_id: DRAFT-002\ntitle: Child RFE 2\n"
             "priority: Major\nstatus: Ready\n"
             "parent_key: RHAIRFE-2000\n---\n\nChild 2 content.\n",
         )
@@ -908,8 +908,8 @@ class TestSplitFieldInheritance:
             "priority: Major\nstatus: Archived\n---\n\nContent.\n",
         )
         _write(
-            f"{art_dir}/rfe-tasks/RFE-001.md",
-            "---\nrfe_id: RFE-001\ntitle: Child RFE 1\n"
+            f"{art_dir}/rfe-tasks/DRAFT-001.md",
+            "---\nrfe_id: DRAFT-001\ntitle: Child RFE 1\n"
             "priority: Major\nstatus: Ready\n"
             "parent_key: RHAIRFE-3000\n---\n\nChild content.\n",
         )
@@ -942,8 +942,8 @@ class TestReplayIdempotency:
 
     def test_replay_new_rfe_no_duplicate(self, art_dir, jira):
         """Create RFE, replay → no duplicate issue in Jira."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
-        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md", _review("RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
+        _write(f"{art_dir}/rfe-reviews/DRAFT-001-review.md", _review("DRAFT-001"))
 
         # First run: creates the issue + renames file
         r1 = _run_submit(art_dir, jira.url)
@@ -956,7 +956,7 @@ class TestReplayIdempotency:
 
         # File should be renamed and marked Submitted
         assert os.path.exists(f"{art_dir}/rfe-tasks/{key}.md")
-        assert not os.path.exists(f"{art_dir}/rfe-tasks/RFE-001.md")
+        assert not os.path.exists(f"{art_dir}/rfe-tasks/DRAFT-001.md")
         fm = _read_frontmatter(f"{art_dir}/rfe-tasks/{key}.md")
         assert fm["status"] == "Submitted"
 
@@ -998,13 +998,13 @@ class TestReplayIdempotency:
 
     def test_replay_after_partial_failure(self, art_dir, jira):
         """First RFE succeeds, second fails → replay only submits second."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
-        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md", _review("RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
+        _write(f"{art_dir}/rfe-reviews/DRAFT-001-review.md", _review("DRAFT-001"))
         _write(
-            f"{art_dir}/rfe-tasks/RFE-002.md",
-            TASK_FM.format(rfe_id="RFE-002").replace("title: Test RFE", "title: Second RFE"),
+            f"{art_dir}/rfe-tasks/DRAFT-002.md",
+            TASK_FM.format(rfe_id="DRAFT-002").replace("title: Test RFE", "title: Second RFE"),
         )
-        _write(f"{art_dir}/rfe-reviews/RFE-002-review.md", _review("RFE-002"))
+        _write(f"{art_dir}/rfe-reviews/DRAFT-002-review.md", _review("DRAFT-002"))
 
         # First run: both succeed
         r1 = _run_submit(art_dir, jira.url)
@@ -1014,8 +1014,8 @@ class TestReplayIdempotency:
         assert len(issues) == 2
 
         # Both renamed and marked Submitted
-        assert not os.path.exists(f"{art_dir}/rfe-tasks/RFE-001.md")
-        assert not os.path.exists(f"{art_dir}/rfe-tasks/RFE-002.md")
+        assert not os.path.exists(f"{art_dir}/rfe-tasks/DRAFT-001.md")
+        assert not os.path.exists(f"{art_dir}/rfe-tasks/DRAFT-002.md")
 
         # Replay: nothing to do
         r2 = _run_submit(art_dir, jira.url)
@@ -1061,7 +1061,7 @@ class TestSplitChildSnapshot:
         "priority: Major\nstatus: Archived\n---\n\nParent content.\n"
     )
     CHILD_TASK_TPL = (
-        "---\nrfe_id: RFE-{num:03d}\ntitle: Child RFE {num}\n"
+        "---\nrfe_id: DRAFT-{num:03d}\ntitle: Child RFE {num}\n"
         "priority: Major\nstatus: Ready\n"
         "parent_key: RHAIRFE-1000\n---\n\nChild {num} content.\n"
     )
@@ -1085,7 +1085,7 @@ class TestSplitChildSnapshot:
         _write(f"{art_dir}/rfe-originals/RHAIRFE-1000.md", "Parent content.")
         _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
         for i in range(1, num_children + 1):
-            _write(f"{art_dir}/rfe-tasks/RFE-{i:03d}.md", self.CHILD_TASK_TPL.format(num=i))
+            _write(f"{art_dir}/rfe-tasks/DRAFT-{i:03d}.md", self.CHILD_TASK_TPL.format(num=i))
         return self._seed_snapshot(art_dir, {"RHAIRFE-1000": "parent-hash"})
 
     def test_split_child_hashes_in_snapshot(self, art_dir, jira):
@@ -1093,8 +1093,8 @@ class TestSplitChildSnapshot:
         snap_path = self._setup_split(art_dir, jira)
 
         # Add a regular RFE so Phase 2 also runs
-        _write(f"{art_dir}/rfe-tasks/RFE-099.md", TASK_FM.format(rfe_id="RFE-099"))
-        _write(f"{art_dir}/rfe-reviews/RFE-099-review.md", _review("RFE-099"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-099.md", TASK_FM.format(rfe_id="DRAFT-099"))
+        _write(f"{art_dir}/rfe-reviews/DRAFT-099-review.md", _review("DRAFT-099"))
 
         r = _run_submit(art_dir, jira.url)
         assert r.returncode == 0, r.stderr
@@ -1193,8 +1193,8 @@ class TestApprovedTransition:
 
     def test_new_rfe_transitions_to_approved(self, art_dir, jira):
         """--auto-approve + new RFE with passing review → Approved."""
-        _write(f"{art_dir}/rfe-tasks/RFE-001.md", TASK_FM.format(rfe_id="RFE-001"))
-        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md", _review("RFE-001"))
+        _write(f"{art_dir}/rfe-tasks/DRAFT-001.md", TASK_FM.format(rfe_id="DRAFT-001"))
+        _write(f"{art_dir}/rfe-reviews/DRAFT-001-review.md", _review("DRAFT-001"))
 
         r = _run_submit(art_dir, jira.url, ["--auto-approve"])
         assert r.returncode == 0, r.stderr


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
The RFE- prefix for local drafts looks like a real Jira project key and would collide if the tool is used against a project whose key happens to be "RFE". Rename the local convention to DRAFT-NNN so it is unambiguously a local-only identifier.

All RHAIRFE- references (the actual Jira project key) are unchanged, but I plan to come back and make that configurable in a followup PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

A new test_draft_prefix.py validates that DRAFT- is accepted and RFE- is now rejected in the schema.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft items now use `DRAFT-###` identifiers end-to-end across creation, speedrun pre-allocation, splitting, review, and submission flows.
  * Added configurable Jira project support via `JIRA_PROJECT` (and optional `JIRA_ISSUE_TYPE`), including an interactive project-resolution step when missing.
  * Added an end-to-end “RFE Creator Agent” harness and enhanced recommendation ID collection from existing review artifacts.

* **Bug Fixes**
  * Validation, artifact discovery, and Jira heading/metadata handling now consistently recognize `DRAFT-###` as local pre-submission IDs.

* **Documentation**
  * Updated guides and examples (including editing-between-steps globs) to use `DRAFT-###` and `PROJ-*`-style Jira keys.

* **Tests**
  * Updated fixtures/assertions to `DRAFT-*` and broadened Jira-key/draft-ID validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->