### PR TITLE
Pipeline design proposal matthewchiccino

### DIFF
--- a/design-proposals/remove-feasibility.md
+++ b/design-proposals/remove-feasibility.md
@@ -4,9 +4,9 @@
 
 The feasibility step in `rfe-creator` has a 0% `feasibility-fail` rate in production. The opus call is the most expensive stage of the pipeline, 50,000–80,000 token context read fires on every single RFE, and almost always returns "feasible".
 
-RFEs describe WHAT and WHY — they purposefully leave the HOW to engineering. The infeasibility bar is "the platform's architecture conflicts with this need." At that level of abstraction, before anyone has proposed an implementation, nothing qualifies. The check is structurally set up to pass.
+RFEs describe WHAT and WHY — they purposefully leave the HOW to engineering. Since nobody has proposed a solution, the abstraction makes the bar at this level too high. The check is set up to pass.
 
-Feasibility is really important at the strategy stage, where there's a HOW to judge. `strat-creator`'s `strategy-feasibility-review` asks whether a specific implementation approach works, whether the effort estimate is credible, whether component choices hold up, and whether cross-team dependencies are accounted for. Those are questions an engineering plan can really fail on. That check is the same as this one, already exists, runs on opus, and reads the same architecture context.
+Feasibility is really important at the strategy stage, where there's a HOW to judge. `strat-creator`'s `strategy-feasibility-review` asks whether a specific implementation works, whether the effort estimate is credible, whether component choices hold up, and whether cross-team dependencies are accounted for. Those are questions an engineering plan can really fail on. That check is the same as the RFE one. It already exists, runs on opus, and reads the same architecture context.
 
 ## Cost
 

--- a/design-proposals/remove-feasibility.md
+++ b/design-proposals/remove-feasibility.md
@@ -1,22 +1,37 @@
 # Proposal: Remove Feasibility from rfe-creator
 
-## The Core Argument
+## Argument
 
 The feasibility step in `rfe-creator` has a 0% `feasibility-fail` rate in production. The opus call is the most expensive stage of the pipeline, 50,000–80,000 token context read fires on every single RFE, and almost always returns "feasible".
 
 RFEs describe WHAT and WHY — they purposefully leave the HOW to engineering. Since nobody has proposed a solution, the abstraction makes the bar at this level too high. The check is set up to pass.
 
+The intent behind the check is right: catching infeasible ideas early prevents backtracking later. But the check's own definition makes that nearly impossible at the RFE stage. According to the prompts, something is only "infeasible" if the platform's architecture fundamentally conflicts with the need — not if it's ambitious, vague, or hard to build. Since RFEs don't propose an implementation, there's almost nothing concrete enough to rule out. The gate is important later stage where there's an actual plan to evaluate.
+
 Feasibility is really important at the strategy stage, where there's a HOW to judge. `strat-creator`'s `strategy-feasibility-review` asks whether a specific implementation works, whether the effort estimate is credible, whether component choices hold up, and whether cross-team dependencies are accounted for. Those are questions an engineering plan can really fail on. That check is the same as the RFE one. It already exists, runs on opus, and reads the same architecture context.
 
 ## Cost
 
-The feasibility step is the single most expensive operation in the pipeline:
+The feasibility step is the single most expensive operation in the rfe pipeline:
 
 - `model: opus` on every RFE (most expensive model)
 - 50,000–80,000 tokens of architecture context reads per call
 - Fires in parallel with assess on every RFE — including rough drafts that are about to fail rubric scoring and get revised anyway
 - For a batch of 20 RFEs: 1–1.6 million tokens to produce a `feasibility-pass` label ~100% of the time
 
-## The Recommendation
+At current opus pricing ($5.00/MTok input, $25.00/MTok output), the cost per RFE is roughly:
 
-Remove feasibility from `rfe-creator`. It's the most expensive step in the pipeline and the least useful. The signal it produces is redundant with `strat-creator`'s feasibility check, which runs later, on a concrete plan, where the question actually means something.
+```
+cost_per_rfe ≈ (80,000 × $5 + 750 × $25) / 1,000,000 ≈ $0.42
+total_feasibility_cost = $0.42 × N
+```
+
+For 100 RFEs — tests, drafts, or real ones — that's ~$42.00 to produce "feasible" every time, including on rough drafts that haven't passed rubric scoring yet.
+
+## Speed
+
+Assess and feasibility run in parallel, but the review agents in Step 3 are blocked until both complete. Removing feasibility means review agents start as soon as assess finishes, cutting the extra wait.
+
+## Recommendation
+
+Remove feasibility from `rfe-creator`. It's the most expensive step in the pipeline and the least useful. The signal it produces is redundant with `strat-creator`'s feasibility check, which runs later, on a concrete plan, where the question matters more.

--- a/design-proposals/remove-feasibility.md
+++ b/design-proposals/remove-feasibility.md
@@ -1,0 +1,22 @@
+# Proposal: Remove Feasibility from rfe-creator
+
+## The Core Argument
+
+The feasibility step in `rfe-creator` has a 0% `feasibility-fail` rate in production. The opus call is the most expensive stage of the pipeline, 50,000–80,000 token context read fires on every single RFE, and almost always returns "feasible".
+
+RFEs describe WHAT and WHY — they purposefully leave the HOW to engineering. The infeasibility bar is "the platform's architecture conflicts with this need." At that level of abstraction, before anyone has proposed an implementation, nothing qualifies. The check is structurally set up to pass.
+
+Feasibility is really important at the strategy stage, where there's a HOW to judge. `strat-creator`'s `strategy-feasibility-review` asks whether a specific implementation approach works, whether the effort estimate is credible, whether component choices hold up, and whether cross-team dependencies are accounted for. Those are questions an engineering plan can really fail on. That check is the same as this one, already exists, runs on opus, and reads the same architecture context.
+
+## Cost
+
+The feasibility step is the single most expensive operation in the pipeline:
+
+- `model: opus` on every RFE (most expensive model)
+- 50,000–80,000 tokens of architecture context reads per call
+- Fires in parallel with assess on every RFE — including rough drafts that are about to fail rubric scoring and get revised anyway
+- For a batch of 20 RFEs: 1–1.6 million tokens to produce a `feasibility-pass` label ~100% of the time
+
+## The Recommendation
+
+Remove feasibility from `rfe-creator`. It's the most expensive step in the pipeline and the least useful. The signal it produces is redundant with `strat-creator`'s feasibility check, which runs later, on a concrete plan, where the question actually means something.


### PR DESCRIPTION
Proposes removing the feasibility check from rfe-creator. It has a 0% flag rate in production, and the check that actually matters already runs in strat-creator where there's an actual plan to evaluate. Removing this expensive step will optimize cost and speed for the pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new design proposal recommending removal of the feasibility step from the `rfe-creator` workflow.
  * The proposal notes this could reduce latency and cost by avoiding an extra review pass, while keeping the relevant feasibility check later in the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->