### PR TITLE
Fix ruff format check in jira_utils.py

### DIFF
--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -156,8 +156,7 @@ def create_issue(
     except urllib.error.HTTPError as e:
         if e.code in (400, 403) and "reporter" in body["fields"]:
             print(
-                f"  WARNING: Could not set reporter ({e.code}) — "
-                f"retrying without reporter field.",
+                f"  WARNING: Could not set reporter ({e.code}) — retrying without reporter field.",
                 file=sys.stderr,
             )
             del body["fields"]["reporter"]


### PR DESCRIPTION
## Problem

The `lint` job on `main` is failing (`ruff format --check --diff .`):

```
1 file would be reformatted, 53 files already formatted
--- scripts/jira_utils.py
```

The reporter-warning message added in #111 was split across two `f-string` lines that `ruff format` collapses onto one. It wasn't run through `ruff format`, so it broke the lint job at `9728c13`.

See failing run: https://github.com/opendatahub-io/rfe-creator/actions/runs/28599233809/job/84802699937

## Fix

Merge the split f-string onto a single line so `ruff format --check` passes. No behavior change — the warning text is identical.

Verified locally:

```
$ ruff format --check --diff scripts/jira_utils.py
1 file already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * No user-facing behavior changed. A warning message was reformatted internally with no impact on output or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->