### PR TITLE
Add preflight validator for rfe.speedrun batch input

### DIFF
--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -52,10 +52,10 @@ When the user doesn't specify, use these defaults:
   priority: Major
 ```
 
-Validate the batch file before spending any agent budget on it:
+Validate the batch file before spending any agent budget on it. Use `--strict` so unknown fields and duplicate prompts (typically typos or copy-paste mistakes) block the run too, not just hard errors:
 
 ```bash
-python3 scripts/validate_batch_input.py <input_file>
+python3 scripts/validate_batch_input.py <input_file> --strict
 ```
 
 If this exits nonzero, stop and report the printed `ERROR:`/`WARNING:` lines to the user instead of proceeding — do not fan out agents against a batch that's already known to be malformed.

--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -52,6 +52,14 @@ When the user doesn't specify, use these defaults:
   priority: Major
 ```
 
+Validate the batch file before spending any agent budget on it:
+
+```bash
+python3 scripts/validate_batch_input.py <input_file>
+```
+
+If this exits nonzero, stop and report the printed `ERROR:`/`WARNING:` lines to the user instead of proceeding — do not fan out agents against a batch that's already known to be malformed.
+
 Count entries and pre-allocate all IDs upfront:
 
 ```bash

--- a/scripts/validate_batch_input.py
+++ b/scripts/validate_batch_input.py
@@ -36,6 +36,9 @@ KNOWN_FIELDS = {"prompt", "priority", "labels", "clarifying_context"}
 
 def validate_entries(entries):
     """Validate a list of batch entries. Returns (errors, warnings) lists of strings."""
+    if not entries:
+        return ["batch input must contain at least one entry"], []
+
     errors = []
     warnings = []
     seen_prompts = {}
@@ -57,8 +60,15 @@ def validate_entries(entries):
                 f"entry {i}: 'priority' {entry['priority']!r} is not one of {ALLOWED_PRIORITIES}"
             )
 
-        if "labels" in entry and not isinstance(entry["labels"], list):
-            errors.append(f"entry {i}: 'labels' must be a list")
+        if "labels" in entry:
+            labels = entry["labels"]
+            if not isinstance(labels, list):
+                errors.append(f"entry {i}: 'labels' must be a list")
+            elif any(not isinstance(label, str) or not label.strip() for label in labels):
+                errors.append(f"entry {i}: 'labels' entries must be non-empty strings")
+
+        if "clarifying_context" in entry and not isinstance(entry["clarifying_context"], str):
+            errors.append(f"entry {i}: 'clarifying_context' must be a string")
 
         unknown = set(entry) - KNOWN_FIELDS
         for field in sorted(unknown):
@@ -83,18 +93,21 @@ def main():
     args = parser.parse_args()
 
     if not os.path.exists(args.path):
-        print(f"Error: file not found: {args.path}", file=sys.stderr)
+        print(f"ERROR: file not found: {args.path}", file=sys.stderr)
         sys.exit(2)
 
     try:
         with open(args.path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
+    except OSError as e:
+        print(f"ERROR: could not read file: {e}", file=sys.stderr)
+        sys.exit(2)
     except yaml.YAMLError as e:
-        print(f"Error: invalid YAML: {e}", file=sys.stderr)
+        print(f"ERROR: invalid YAML: {e}", file=sys.stderr)
         sys.exit(2)
 
     if not isinstance(data, list):
-        print(f"Error: batch input root must be a list, got {type(data).__name__}", file=sys.stderr)
+        print(f"ERROR: batch input root must be a list, got {type(data).__name__}", file=sys.stderr)
         sys.exit(2)
 
     errors, warnings = validate_entries(data)

--- a/scripts/validate_batch_input.py
+++ b/scripts/validate_batch_input.py
@@ -31,6 +31,11 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from artifact_utils import SCHEMAS
 
 ALLOWED_PRIORITIES = SCHEMAS["rfe-task"]["priority"]["enum"]
+
+# Keep in sync with the batch YAML format documented in
+# .claude/skills/rfe.speedrun/SKILL.md (Mode A). Since the skill runs this
+# validator with --strict, a field missing here becomes a blocking warning
+# for anyone who adds a new batch field without updating both places.
 KNOWN_FIELDS = {"prompt", "priority", "labels", "clarifying_context"}
 
 

--- a/scripts/validate_batch_input.py
+++ b/scripts/validate_batch_input.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Validate a batch YAML input file before /rfe.speedrun starts processing it.
+
+Catches malformed entries (missing prompt, bad priority, wrong types,
+duplicate prompts, unknown fields) before the expensive multi-agent
+create/auto-fix/submit pipeline runs.
+
+Usage:
+    python3 scripts/validate_batch_input.py <path> [--strict]
+
+Exit codes:
+    0  Valid (no errors; warnings allowed unless --strict)
+    1  Invalid — errors found, or warnings found with --strict
+    2  Usage/file error (file missing, not valid YAML, root not a list)
+
+Output:
+    ERROR_COUNT=N
+    WARNING_COUNT=N
+    ERROR: entry <i>: <message>       (one per error)
+    WARNING: entry <i>: <message>     (one per warning)
+    VALID=true|false
+"""
+
+import argparse
+import os
+import sys
+
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from artifact_utils import SCHEMAS
+
+ALLOWED_PRIORITIES = SCHEMAS["rfe-task"]["priority"]["enum"]
+KNOWN_FIELDS = {"prompt", "priority", "labels", "clarifying_context"}
+
+
+def validate_entries(entries):
+    """Validate a list of batch entries. Returns (errors, warnings) lists of strings."""
+    errors = []
+    warnings = []
+    seen_prompts = {}
+
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            errors.append(f"entry {i}: must be a mapping, got {type(entry).__name__}")
+            continue
+
+        prompt = entry.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            errors.append(f"entry {i}: 'prompt' is required and must be a non-empty string")
+        else:
+            key = prompt.strip().lower()
+            seen_prompts.setdefault(key, []).append(i)
+
+        if "priority" in entry and entry["priority"] not in ALLOWED_PRIORITIES:
+            errors.append(
+                f"entry {i}: 'priority' {entry['priority']!r} is not one of {ALLOWED_PRIORITIES}"
+            )
+
+        if "labels" in entry and not isinstance(entry["labels"], list):
+            errors.append(f"entry {i}: 'labels' must be a list")
+
+        unknown = set(entry) - KNOWN_FIELDS
+        for field in sorted(unknown):
+            warnings.append(f"entry {i}: unknown field '{field}'")
+
+    for key, indices in seen_prompts.items():
+        if len(indices) > 1:
+            warnings.append(f"entries {indices}: duplicate prompt {key!r}")
+
+    return errors, warnings
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("path", help="Path to the batch YAML input file")
+    parser.add_argument(
+        "--strict", action="store_true", help="Treat warnings as errors (nonzero exit)"
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(args.path):
+        print(f"Error: file not found: {args.path}", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        with open(args.path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        print(f"Error: invalid YAML: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    if not isinstance(data, list):
+        print(f"Error: batch input root must be a list, got {type(data).__name__}", file=sys.stderr)
+        sys.exit(2)
+
+    errors, warnings = validate_entries(data)
+
+    print(f"ERROR_COUNT={len(errors)}")
+    print(f"WARNING_COUNT={len(warnings)}")
+    for message in errors:
+        print(f"ERROR: {message}")
+    for message in warnings:
+        print(f"WARNING: {message}")
+
+    valid = not errors and not (args.strict and warnings)
+    print(f"VALID={'true' if valid else 'false'}")
+    sys.exit(0 if valid else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_validate_batch_input.py
+++ b/tests/test_validate_batch_input.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Tests for scripts/validate_batch_input.py — batch YAML preflight validation."""
+
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "validate_batch_input.py")
+
+from validate_batch_input import validate_entries  # noqa: E402
+
+
+def _write(path, content):
+    with open(path, "w") as f:
+        f.write(content)
+
+
+class TestValidateEntriesFunction:
+    def test_minimal_valid_entry(self):
+        errors, warnings = validate_entries([{"prompt": "Users need X"}])
+        assert errors == []
+        assert warnings == []
+
+    def test_missing_prompt(self):
+        errors, warnings = validate_entries([{"priority": "Major"}])
+        assert len(errors) == 1
+        assert "prompt" in errors[0]
+
+    def test_blank_prompt(self):
+        errors, warnings = validate_entries([{"prompt": "   "}])
+        assert len(errors) == 1
+        assert "prompt" in errors[0]
+
+    def test_non_dict_entry(self):
+        errors, warnings = validate_entries(["just a string"])
+        assert len(errors) == 1
+        assert "mapping" in errors[0]
+
+    def test_all_valid_priorities_accepted(self):
+        for priority in ["Blocker", "Critical", "Major", "Normal", "Minor", "Undefined"]:
+            errors, warnings = validate_entries([{"prompt": "x", "priority": priority}])
+            assert errors == [], f"{priority} should be valid"
+
+    def test_invalid_priority(self):
+        errors, warnings = validate_entries([{"prompt": "x", "priority": "High"}])
+        assert len(errors) == 1
+        assert "priority" in errors[0]
+
+    def test_labels_not_a_list(self):
+        errors, warnings = validate_entries([{"prompt": "x", "labels": "candidate-3.5"}])
+        assert len(errors) == 1
+        assert "labels" in errors[0]
+
+    def test_labels_list_is_valid(self):
+        errors, warnings = validate_entries([{"prompt": "x", "labels": ["candidate-3.5"]}])
+        assert errors == []
+
+    def test_unknown_field_is_warning_not_error(self):
+        errors, warnings = validate_entries([{"prompt": "x", "team": "aipcc"}])
+        assert errors == []
+        assert len(warnings) == 1
+        assert "team" in warnings[0]
+
+    def test_duplicate_prompts_exact(self):
+        errors, warnings = validate_entries([{"prompt": "same thing"}, {"prompt": "same thing"}])
+        assert errors == []
+        assert len(warnings) == 1
+        assert "duplicate" in warnings[0]
+
+    def test_duplicate_prompts_case_and_whitespace_insensitive(self):
+        errors, warnings = validate_entries(
+            [{"prompt": "Same Thing"}, {"prompt": "  same thing  "}]
+        )
+        assert len(warnings) == 1
+        assert "duplicate" in warnings[0]
+
+    def test_no_duplicate_warning_for_unique_prompts(self):
+        errors, warnings = validate_entries([{"prompt": "a"}, {"prompt": "b"}])
+        assert warnings == []
+
+    def test_empty_list_is_valid(self):
+        errors, warnings = validate_entries([])
+        assert errors == []
+        assert warnings == []
+
+
+class TestCLI:
+    def test_valid_file_exits_zero(self, tmp_path):
+        path = str(tmp_path / "batch.yaml")
+        _write(path, "- prompt: Users need X\n  priority: Major\n")
+        result = subprocess.run(["python3", SCRIPT, path], capture_output=True, text=True)
+        assert result.returncode == 0
+        assert "ERROR_COUNT=0" in result.stdout
+        assert "VALID=true" in result.stdout
+
+    def test_invalid_priority_exits_one(self, tmp_path):
+        path = str(tmp_path / "batch.yaml")
+        _write(path, "- prompt: Users need X\n  priority: High\n")
+        result = subprocess.run(["python3", SCRIPT, path], capture_output=True, text=True)
+        assert result.returncode == 1
+        assert "ERROR_COUNT=1" in result.stdout
+        assert "VALID=false" in result.stdout
+
+    def test_warnings_alone_exit_zero_without_strict(self, tmp_path):
+        path = str(tmp_path / "batch.yaml")
+        _write(path, "- prompt: Users need X\n  team: aipcc\n")
+        result = subprocess.run(["python3", SCRIPT, path], capture_output=True, text=True)
+        assert result.returncode == 0
+        assert "WARNING_COUNT=1" in result.stdout
+        assert "VALID=true" in result.stdout
+
+    def test_strict_fails_on_warnings(self, tmp_path):
+        path = str(tmp_path / "batch.yaml")
+        _write(path, "- prompt: Users need X\n  team: aipcc\n")
+        result = subprocess.run(
+            ["python3", SCRIPT, path, "--strict"], capture_output=True, text=True
+        )
+        assert result.returncode == 1
+        assert "VALID=false" in result.stdout
+
+    def test_missing_file_exits_two(self, tmp_path):
+        path = str(tmp_path / "does-not-exist.yaml")
+        result = subprocess.run(["python3", SCRIPT, path], capture_output=True, text=True)
+        assert result.returncode == 2
+
+    def test_malformed_yaml_exits_two(self, tmp_path):
+        path = str(tmp_path / "batch.yaml")
+        _write(path, "- prompt: [unterminated\n")
+        result = subprocess.run(["python3", SCRIPT, path], capture_output=True, text=True)
+        assert result.returncode == 2
+
+    def test_root_not_a_list_exits_two(self, tmp_path):
+        path = str(tmp_path / "batch.yaml")
+        _write(path, "prompt: Users need X\n")
+        result = subprocess.run(["python3", SCRIPT, path], capture_output=True, text=True)
+        assert result.returncode == 2

--- a/tests/test_validate_batch_input.py
+++ b/tests/test_validate_batch_input.py
@@ -57,6 +57,27 @@ class TestValidateEntriesFunction:
         errors, warnings = validate_entries([{"prompt": "x", "labels": ["candidate-3.5"]}])
         assert errors == []
 
+    def test_labels_with_non_string_entry(self):
+        errors, warnings = validate_entries([{"prompt": "x", "labels": [123, "ok"]}])
+        assert len(errors) == 1
+        assert "labels" in errors[0]
+
+    def test_labels_with_blank_string_entry(self):
+        errors, warnings = validate_entries([{"prompt": "x", "labels": ["   "]}])
+        assert len(errors) == 1
+        assert "labels" in errors[0]
+
+    def test_clarifying_context_wrong_type(self):
+        errors, warnings = validate_entries(
+            [{"prompt": "x", "clarifying_context": ["not", "a", "string"]}]
+        )
+        assert len(errors) == 1
+        assert "clarifying_context" in errors[0]
+
+    def test_clarifying_context_string_is_valid(self):
+        errors, warnings = validate_entries([{"prompt": "x", "clarifying_context": "some context"}])
+        assert errors == []
+
     def test_unknown_field_is_warning_not_error(self):
         errors, warnings = validate_entries([{"prompt": "x", "team": "aipcc"}])
         assert errors == []
@@ -80,10 +101,10 @@ class TestValidateEntriesFunction:
         errors, warnings = validate_entries([{"prompt": "a"}, {"prompt": "b"}])
         assert warnings == []
 
-    def test_empty_list_is_valid(self):
+    def test_empty_list_is_invalid(self):
         errors, warnings = validate_entries([])
-        assert errors == []
-        assert warnings == []
+        assert len(errors) == 1
+        assert "at least one" in errors[0]
 
 
 class TestCLI:
@@ -136,3 +157,16 @@ class TestCLI:
         _write(path, "prompt: Users need X\n")
         result = subprocess.run(["python3", SCRIPT, path], capture_output=True, text=True)
         assert result.returncode == 2
+
+    def test_empty_batch_exits_one(self, tmp_path):
+        path = str(tmp_path / "batch.yaml")
+        _write(path, "[]\n")
+        result = subprocess.run(["python3", SCRIPT, path], capture_output=True, text=True)
+        assert result.returncode == 1
+        assert "ERROR_COUNT=1" in result.stdout
+
+    def test_unreadable_path_exits_two(self, tmp_path):
+        # A directory is not a valid file to open — should be caught as an OSError, not crash.
+        result = subprocess.run(["python3", SCRIPT, str(tmp_path)], capture_output=True, text=True)
+        assert result.returncode == 2
+        assert "ERROR:" in result.stderr


### PR DESCRIPTION
Adds a preflight validator for `/rfe.speedrun --input` batch YAML files.

This catches malformed batch entries before the expensive create/review/auto-fix pipeline starts. It validates required prompts, allowed priorities, labels shape/content, `clarifying_context` type, duplicate prompts, unknown fields, empty batches, malformed YAML, and file-read errors.

The speedrun skill now runs the validator with `--strict` before pre-allocating RFE IDs, so warnings such as duplicate prompts and unknown fields block the run instead of wasting agent budget.

Tests are included for the validator function and CLI exit-code behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-validation step for batch YAML inputs before any agent work begins.
  * Introduced a validation command that reports `ERROR:`/`WARNING:` messages with summary counts and a clear validity status.
* **Bug Fixes**
  * Pipelines now stop immediately when validation fails, instead of proceeding with invalid inputs.
  * Strict mode now fails on warnings to prevent continuing with potentially problematic data.
* **Documentation**
  * Updated the Phase 1 speedrun documentation to reflect the new validation gate.
* **Tests**
  * Added tests covering validation rules, duplicates, warning behavior, and CLI exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->