### PR TITLE
Fix SSL certificate verification and review metadata on submit errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+certifi
 pyyaml

--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -12,11 +12,20 @@ import base64
 import json
 import os
 import re
+import ssl
 import sys
 import time
 import unicodedata
 import urllib.error
 import urllib.request
+
+ssl_ctx = ssl.create_default_context()
+try:
+    import certifi
+
+    ssl_ctx.load_verify_locations(certifi.where())
+except (ImportError, OSError):
+    pass
 
 # ─── HTTP Layer ───────────────────────────────────────────────────────────────
 
@@ -33,7 +42,7 @@ def make_request(url, user, token, body=None, method=None):
         headers["Content-Type"] = "application/json"
         data = json.dumps(body).encode()
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(req, timeout=60) as resp:
+    with urllib.request.urlopen(req, timeout=60, context=ssl_ctx) as resp:
         if resp.status == 204:
             return None
         resp_body = resp.read()

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -760,8 +760,6 @@ def main():
                     update_frontmatter(
                         review_path,
                         {
-                            "needs_attention": True,
-                            "needs_attention_reason": f"Submit failed: {msg}",
                             "error": f"submit_failed: {msg}",
                         },
                         "rfe-review",


### PR DESCRIPTION
## Description

**SSL certificate verification** — Add `certifi`-backed SSL context to `jira_utils.py`, matching the fix already shipped in [strat-creator](https://github.com/opendatahub-io/strat-creator/blob/main/scripts/jira_utils.py) to address [RHOAIENG-62016](https://redhat.atlassian.net/browse/RHOAIENG-62016). Without this, `urlopen()` fails with `SSL: CERTIFICATE_VERIFY_FAILED` on macOS python.org installs (empty default cert store). Falls back gracefully if certifi isn't installed.

**Submit error metadata leak** — The submit error handler was overwriting `needs_attention` and `needs_attention_reason` with the transient error. On successful retry, the stale error got posted as a Jira comment (see https://redhat.atlassian.net/browse/RHAIRFE-2687?focusedCommentId=17627173). Fix: only set the `error` field, leave the review agent's attention fields untouched.

## How Has This Been Tested?

- All 48 existing tests pass (`pytest tests/test_submit.py tests/test_jira_utils_labels.py`)
- `ruff check` clean
- Manually hit the SSL failure during an `/rfe.submit` run on macOS with python.org Python 3.11, confirmed the certifi fix resolves it
- The metadata leak was observed during the same session (stale SSL error posted as a Jira comment after successful retry) — the code path is straightforward but was not re-tested after the fix

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved HTTPS connection security by enabling explicit certificate validation using trusted CA certificates.
  - Added more reliable handling when trusted certificate information is unavailable.

- **Bug Fixes**
  - Submission failures are now recorded consistently as errors in review status information, making failed submissions easier to identify without interrupting the overall process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-62016]: https://redhat.atlassian.net/browse/RHOAIENG-62016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ