### PR TITLE
switch issue split type to work item split

### DIFF
--- a/docs/state-machine/pipeline-correctness-reference.md
+++ b/docs/state-machine/pipeline-correctness-reference.md
@@ -867,22 +867,33 @@ assessment persists until a fresh `/rfe.review` invocation.
 
 ### 5.5 split_submit.py Partial Failure Recovery
 
-`discover_state()` recovers Phase 2 progress via two mechanisms: confirmation
-comments (`[RFE Creator] Created as X, linked to parent`) and existing "Work
-item split" outward links (`split_submit.py:108-141`). Both are written AFTER
-`create_issue_link()`, so recovery works when the crash occurs after the link
-step (e.g., during the comment post or a later child iteration).
+`discover_state()` recovers Phase 2 progress via two independent mechanisms
+(`split_submit.py:108-141`):
 
-**Known gap:** if `split_submit.py` crashes between `create_issue()` and
-`create_issue_link()` -- i.e., the child ticket exists but has no link and no
-confirmation comment -- `discover_state()` cannot detect the orphan. On rerun,
-a duplicate child ticket is created. This is the exact failure mode triggered
-by the Jul 2026 "Issue split" to "Work item split" link type rename: every
-crash left an orphaned child (e.g., RHAIRFE-2781) that reruns could not
-recover from. A robust fix would require a stable marker (e.g., a label or
-comment on the child) written immediately after `create_issue()` and before
-`create_issue_link()`, so that `discover_state()` can match orphans by marker
-on subsequent runs.
+1. **Confirmation comments** (lines 114-121): matches `[RFE Creator] Created
+   as X, linked to parent` on the parent issue.  Posted AFTER
+   `create_issue_link()` (line 286).
+2. **Issue links** (lines 131-141): scans "Work item split" outward links on
+   the parent.  These exist as soon as `create_issue_link()` succeeds
+   (line 279).
+
+Because the link is written by `create_issue_link()` itself, a crash after
+the link call but before the confirmation comment still leaves a recoverable
+marker -- `discover_state()` picks it up via mechanism 2.  A crash during a
+later child iteration is also safe: earlier children already have their links
+and/or comments.
+
+**Known gap:** if `split_submit.py` crashes between `create_issue()` (line
+260) and `create_issue_link()` (line 279) -- i.e., the child ticket exists
+but has no link and no confirmation comment -- `discover_state()` cannot
+detect the orphan.  On rerun, a duplicate child ticket is created.  This is
+the exact failure mode triggered by the Jul 2026 "Issue split" to "Work item
+split" link type rename: every crash left an orphaned child (e.g.,
+RHAIRFE-2781) that reruns could not recover from.  A robust fix would require
+a stable marker (e.g., a label on the child) written immediately after
+`create_issue()` and before `create_issue_link()`, so that `discover_state()`
+can match orphans by marker on subsequent runs.  See
+`TestSplitRecoveryGap` in `tests/test_submit_integration.py`.
 
 ### 5.6 Speedrun `--headless` and Double-Announce
 

--- a/docs/state-machine/pipeline-correctness-reference.md
+++ b/docs/state-machine/pipeline-correctness-reference.md
@@ -867,11 +867,22 @@ assessment persists until a fresh `/rfe.review` invocation.
 
 ### 5.5 split_submit.py Partial Failure Recovery
 
-If `split_submit.py` crashes after creating a child ticket but before creating
-the "Work item split" link, `discover_state()` Phase 2 recovery detects the orphan
-via both confirmation comments AND existing links (`split_submit.py:108-131`).
-The window for permanent inconsistency is narrow (crash between `create_issue`
-and `create_link` within a single loop iteration).
+`discover_state()` recovers Phase 2 progress via two mechanisms: confirmation
+comments (`[RFE Creator] Created as X, linked to parent`) and existing "Work
+item split" outward links (`split_submit.py:108-141`). Both are written AFTER
+`create_issue_link()`, so recovery works when the crash occurs after the link
+step (e.g., during the comment post or a later child iteration).
+
+**Known gap:** if `split_submit.py` crashes between `create_issue()` and
+`create_issue_link()` -- i.e., the child ticket exists but has no link and no
+confirmation comment -- `discover_state()` cannot detect the orphan. On rerun,
+a duplicate child ticket is created. This is the exact failure mode triggered
+by the Jul 2026 "Issue split" to "Work item split" link type rename: every
+crash left an orphaned child (e.g., RHAIRFE-2781) that reruns could not
+recover from. A robust fix would require a stable marker (e.g., a label or
+comment on the child) written immediately after `create_issue()` and before
+`create_issue_link()`, so that `discover_state()` can match orphans by marker
+on subsequent runs.
 
 ### 5.6 Speedrun `--headless` and Double-Announce
 

--- a/docs/state-machine/pipeline-correctness-reference.md
+++ b/docs/state-machine/pipeline-correctness-reference.md
@@ -147,7 +147,7 @@ exclusion, and split parent detection. The `rfe_id` pattern constraint causes
 |---|---|---|
 | `SS_DISCOVER` | `discover_state()` scans Jira for recovery markers (idempotent); fallback: link-based recovery if no confirmation comment | `split_submit.py:90-148` |
 | `SS_PHASE1_PERSIST` | Post archival comments on parent with child content; Phase 2 refuses if incomplete | `split_submit.py:153-174` |
-| `SS_PHASE2_CREATE_LINK` | Create child Jira tickets + "Issue split" links + post confirmation | `split_submit.py:176-262` |
+| `SS_PHASE2_CREATE_LINK` | Create child Jira tickets + "Work item split" links + post confirmation | `split_submit.py:176-262` |
 | `SS_PHASE3_CLOSE` | Label parent with split-original, transition to Closed (resolution: Obsolete); skips gracefully if no Closed transition | `split_submit.py:295-347` |
 | `SS_RENAME` | Post-submit: rename RFE-NNN.md -> RHAIRFE-NNNN.md, update frontmatter | `split_submit.py:507-518` |
 
@@ -656,7 +656,7 @@ stateDiagram-v2
             SS_Discover --> SS_Persist : discover_state()\nidempotent recovery
             SS_Persist --> SS_Create : Phase 1: archival comments posted
             SS_Create --> SS_Link : Phase 2: child tickets created
-            SS_Link --> SS_Close : Issue split links created
+            SS_Link --> SS_Close : Work item split links created
             SS_Close --> SS_Rename : Phase 3: parent labeled +\ntransitioned to Closed
             SS_Rename --> SS_Done : rename RFE-NNN.md →\nRHAIRFE-NNNN.md
         }
@@ -868,7 +868,7 @@ assessment persists until a fresh `/rfe.review` invocation.
 ### 5.5 split_submit.py Partial Failure Recovery
 
 If `split_submit.py` crashes after creating a child ticket but before creating
-the "Issue split" link, `discover_state()` Phase 2 recovery detects the orphan
+the "Work item split" link, `discover_state()` Phase 2 recovery detects the orphan
 via both confirmation comments AND existing links (`split_submit.py:108-131`).
 The window for permanent inconsistency is narrow (crash between `create_issue`
 and `create_link` within a single loop iteration).

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -129,7 +129,7 @@ def discover_state(server, user, token, parent_key, expected_children):
         ["issuelinks", "status", "components", "labels", "parent", "reporter"],
     )
     for link in issue.get("fields", {}).get("issuelinks", []):
-        if link.get("type", {}).get("name") != "Issue split":
+        if link.get("type", {}).get("name") != "Work item split":
             continue
         outward = link.get("outwardIssue")
         if not outward:
@@ -249,7 +249,7 @@ def phase2_create_link(server, user, token, parent_key, children, state, artifac
                 print(f"           Parent: {state.parent_parent_key}")
             if state.parent_reporter_id:
                 print(f"           Reporter: {state.parent_reporter_id}")
-            print(f"           Would link to {parent_key} via 'Issue split'")
+            print(f"           Would link to {parent_key} via 'Work item split'")
             if attn_reason:
                 print("           Would post needs-attention comment")
             state.phase2_done[idx] = "RHAIRFE-DRY"
@@ -276,7 +276,7 @@ def phase2_create_link(server, user, token, parent_key, children, state, artifac
             print(f"           Parent: {state.parent_parent_key}")
 
         # 2. Link to parent
-        create_issue_link(server, user, token, "Issue split", parent_key, child_key)
+        create_issue_link(server, user, token, "Work item split", parent_key, child_key)
         print(f"           Linked {child_key} to {parent_key}")
 
         # 3. Post confirmation comment

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,7 @@ def jira(jira_emu):
 
     _extra_link_types = [
         {
-            "name": "Issue split",
+            "name": "Work item split",
             "inward_description": "is split from",
             "outward_description": "split to",
         },


### PR DESCRIPTION
# Summary

The autofix-rfe CI pipeline has been failing since Jul 16 because split_submit.py references a Jira issue link type name that no longer exists. The link type (ID 10120) was renamed by a Jira admin from "Issue split" to "Work item split" between Jul 10–16, causing every  create_issue_link() call to return HTTP 404.

This is a one-line functional fix (plus two cosmetic updates to the name check and dry-run log message).

#  Impact

The broken link type name has two cascading effects:

  1. Split submissions crash -- child tickets are created but never linked to their parent, leaving orphaned issues in Jira (e.g., RHAIRFE-2781).
  2. Auto-approve is blocked -- submit.py processes splits before non-split submissions, so a single split failure aborts the entire run. All auto-approve candidates in the batch are skipped. This has blocked auto-approvals in 8 of the last 10 pipeline runs (Jul 16–22).         

# Changes

scripts/split_submit.py — replaced "Issue split" with "Work item split" in three locations:

  - Line 132: existing-link name check (recovery/idempotency logic)
  - Line 252: dry-run print message
  - Line 279: create_issue_link() call (the actual API call that fails)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated split-submission linking and recovery behavior to use the **“Work item split”** link type consistently.
  * Aligned Phase 2 dry-run output and actual link creation with the new link type for consistent reruns.
* **Tests**
  * Updated the Jira test fixture to seed **“Work item split”** link types for integration testing.
* **Documentation**
  * Refreshed the pipeline correctness reference to consistently use **“Work item split”** terminology, including Phase 2 recovery details and a documented unrecoverable orphan-detection gap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->