### PR TITLE
Remove deprecated Write() permission rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,9 +51,7 @@
       "Bash(python3 scripts/submit.py *)",
       "Bash(python3 scripts/split_submit.py *)",
       "Edit(artifacts/**)",
-      "Edit(/tmp/rfe-assess/**)",
-      "Write(artifacts/**)",
-      "Write(/tmp/rfe-assess/**)"
+      "Edit(/tmp/rfe-assess/**)"
     ],
     "additionalDirectories": [
       "/tmp/rfe-assess",

--- a/design-proposals/plan-a-thin-dispatcher.md
+++ b/design-proposals/plan-a-thin-dispatcher.md
@@ -538,12 +538,26 @@ def advance(current_phase, state):
     # seq[:-1] to reach explicit decision handlers below. REVIEW, REASSESS_RESTORE,
     # and SPLIT_REVIEW are also in these sequences but are intercepted above.
     MAIN_SEQUENCE = ["FETCH", "SETUP", "ASSESS", "REVIEW", "REVISE", "FIXUP"]
-    REASSESS_SEQUENCE = ["REASSESS_SAVE", "REASSESS_ASSESS", "REASSESS_REVIEW",
-                         "REASSESS_RESTORE", "REASSESS_REVISE", "REASSESS_FIXUP"]
-    SPLIT_SEQUENCE = ["SPLIT_PIPELINE_START", "SPLIT_ASSESS",
-                      "SPLIT_REVIEW", "SPLIT_REVISE", "SPLIT_FIXUP",
-                      "SPLIT_SAVE", "SPLIT_REASSESS", "SPLIT_RE_REVIEW",
-                      "SPLIT_RESTORE", "SPLIT_CORRECTION_CHECK"]
+    REASSESS_SEQUENCE = [
+        "REASSESS_SAVE",
+        "REASSESS_ASSESS",
+        "REASSESS_REVIEW",
+        "REASSESS_RESTORE",
+        "REASSESS_REVISE",
+        "REASSESS_FIXUP",
+    ]
+    SPLIT_SEQUENCE = [
+        "SPLIT_PIPELINE_START",
+        "SPLIT_ASSESS",
+        "SPLIT_REVIEW",
+        "SPLIT_REVISE",
+        "SPLIT_FIXUP",
+        "SPLIT_SAVE",
+        "SPLIT_REASSESS",
+        "SPLIT_RE_REVIEW",
+        "SPLIT_RESTORE",
+        "SPLIT_CORRECTION_CHECK",
+    ]
 
     for seq in [MAIN_SEQUENCE, REASSESS_SEQUENCE, SPLIT_SEQUENCE]:
         if current_phase in seq[:-1]:
@@ -918,7 +932,9 @@ if phase == "revise":
     if data.get("auto_revised"):
         return "completed"
     if data.get("recommendation") == "split":
-        return "completed"  # revise agent can't fix right-sizing; completion expected without changes
+        return (
+            "completed"  # revise agent can't fix right-sizing; completion expected without changes
+        )
     return "pending"
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The Write() permission rules in .claude/settings.json allowed Claude Code to write to artifacts/** and /tmp/rfe-assess/** without prompting. Claude Code recently changed how it matches file permission rules — it now only recognizes Edit(path) rules, which cover all file-editing tools (both Edit and Write). The old Write(path) syntax is no longer matched by permission checks, so those rules silently do nothing and produce warnings in the CI log:


```
Permission allow rule (.claude/settings.json): Write(artifacts/**) is not matched
by file permission checks — only Edit(path) rules are. Use Edit(artifacts/**) instead
```

The settings file already had both Edit() and Write() rules for the same paths, so the Write() rules were redundant. This commit removes them. No behavior change — the Edit() rules were already granting the same permissions.

As for exactly when Claude Code made this change — the deprecation appeared in a recent Claude Code update. The specific version isn't documented in the warning, but it's part of the shift to unify file-editing permissions under Edit() rather than having separate Write() and Edit() matchers.

Note: The ruff commit is to fix a preexisting issue in the repo.

## How Has This Been Tested?
I reran my tests with the patch

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration permissions.
  * Retained editing access for the designated temporary workspace while removing unrelated write permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->