### PR TITLE
Fix scorer subagent perms by moving single-mode path into working directory

### DIFF
--- a/.claude/skills/rfe.auto-fix/SKILL.md
+++ b/.claude/skills/rfe.auto-fix/SKILL.md
@@ -122,8 +122,8 @@ agents:
   - subagent_type: rfe-scorer
     prompt_file: .claude/skills/rfe.review/prompts/assess-agent.md
     vars: |
-      DATA_FILE=/tmp/rfe-assess/single/RHAIRFE-1234.md
-      RUN_DIR=/tmp/rfe-assess/single
+      DATA_FILE=tmp/rfe-assess/single/RHAIRFE-1234.md
+      RUN_DIR=tmp/rfe-assess/single
       PROMPT_PATH=.context/assess-rfe/scripts/agent_prompt.md
   - prompt_file: .claude/skills/rfe-feasibility-review/SKILL.md
     vars: |

--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -82,7 +82,7 @@ python3 scripts/prep_assess.py <ID>
 **Launch assess agent** (model: opus, run_in_background: true, subagent_type: rfe-scorer):
 
 ```
-Read .claude/skills/rfe.review/prompts/assess-agent.md and follow all instructions. Substitute: {KEY}=<ID>, {DATA_FILE}=/tmp/rfe-assess/single/<ID>.md, {RUN_DIR}=/tmp/rfe-assess/single, {PROMPT_PATH}=.context/assess-rfe/scripts/agent_prompt.md
+Read .claude/skills/rfe.review/prompts/assess-agent.md and follow all instructions. Substitute: {KEY}=<ID>, {DATA_FILE}=tmp/rfe-assess/single/<ID>.md, {RUN_DIR}=tmp/rfe-assess/single, {PROMPT_PATH}=.context/assess-rfe/scripts/agent_prompt.md
 ```
 
 **Launch feasibility agent** (model: opus, run_in_background: true) — one per ID:
@@ -105,7 +105,7 @@ python3 scripts/check_review_progress.py --phase feasibility --id-file tmp/rfe-p
 Sleep for the `NEXT_POLL` seconds reported by the script before polling again. Only output status when COMPLETED count changes. Wait for all to complete.
 
 After completion, check prerequisites for each ID via Glob:
-- If assess result (`/tmp/rfe-assess/single/<ID>.result.md`) is missing → write error: `assess_failed`
+- If assess result (`tmp/rfe-assess/single/<ID>.result.md`) is missing → write error: `assess_failed`
 - If feasibility file (`artifacts/rfe-reviews/<ID>-feasibility.md`) is missing → write error: `feasibility_failed`
 - If either is missing for an ID, write the error to review frontmatter and remove from processing list
 
@@ -114,7 +114,7 @@ After completion, check prerequisites for each ID via Glob:
 For each remaining ID, launch a **review agent** (model: opus, run_in_background: true):
 
 ```
-Read .claude/skills/rfe.review/prompts/review-agent.md and follow all instructions. Substitute: {ID}=<ID>, {ASSESS_PATH}=/tmp/rfe-assess/single/<ID>.result.md, {FEASIBILITY_PATH}=artifacts/rfe-reviews/<ID>-feasibility.md, {FIRST_PASS}=true
+Read .claude/skills/rfe.review/prompts/review-agent.md and follow all instructions. Substitute: {ID}=<ID>, {ASSESS_PATH}=tmp/rfe-assess/single/<ID>.result.md, {FEASIBILITY_PATH}=artifacts/rfe-reviews/<ID>-feasibility.md, {FIRST_PASS}=true
 ```
 
 Launch all review agents in parallel.
@@ -212,7 +212,7 @@ python3 scripts/state.py write-ids tmp/review-reassess-ids.txt <all_reassess_IDs
 ```bash
 python3 scripts/preserve_review_state.py save <all_reassess_IDs>
 rm artifacts/rfe-reviews/<ID>-review.md  # for each reassess ID
-rm /tmp/rfe-assess/single/<ID>.result.md  # for each reassess ID
+rm tmp/rfe-assess/single/<ID>.result.md  # for each reassess ID
 ```
 
 **4b. Re-run assessment.** For each reassess ID, prepare and launch an assess agent — this is the same process as Review Step 2:
@@ -224,7 +224,7 @@ python3 scripts/prep_assess.py <ID>
 Launch an **assess agent** (model: opus, run_in_background: true, subagent_type: rfe-scorer) for each reassess ID:
 
 ```
-Read .claude/skills/rfe.review/prompts/assess-agent.md and follow all instructions. Substitute: {KEY}=<ID>, {DATA_FILE}=/tmp/rfe-assess/single/<ID>.md, {RUN_DIR}=/tmp/rfe-assess/single, {PROMPT_PATH}=.context/assess-rfe/scripts/agent_prompt.md
+Read .claude/skills/rfe.review/prompts/assess-agent.md and follow all instructions. Substitute: {KEY}=<ID>, {DATA_FILE}=tmp/rfe-assess/single/<ID>.md, {RUN_DIR}=tmp/rfe-assess/single, {PROMPT_PATH}=.context/assess-rfe/scripts/agent_prompt.md
 ```
 
 Launch all assess agents in parallel.
@@ -247,7 +247,7 @@ python3 scripts/state.py read-ids tmp/review-reassess-ids.txt
 For each reassess ID, launch a **review agent** (model: opus, run_in_background: true):
 
 ```
-Read .claude/skills/rfe.review/prompts/review-agent.md and follow all instructions. Substitute: {ID}=<ID>, {ASSESS_PATH}=/tmp/rfe-assess/single/<ID>.result.md, {FEASIBILITY_PATH}=artifacts/rfe-reviews/<ID>-feasibility.md, {FIRST_PASS}=false
+Read .claude/skills/rfe.review/prompts/review-agent.md and follow all instructions. Substitute: {ID}=<ID>, {ASSESS_PATH}=tmp/rfe-assess/single/<ID>.result.md, {FEASIBILITY_PATH}=artifacts/rfe-reviews/<ID>-feasibility.md, {FIRST_PASS}=false
 ```
 
 Launch all review agents in parallel.

--- a/scripts/check_review_progress.py
+++ b/scripts/check_review_progress.py
@@ -17,7 +17,7 @@ from artifact_utils import read_frontmatter
 
 PHASE_CHECKS = {
     "fetch": lambda id: f"artifacts/rfe-tasks/{id}.md",
-    "assess": lambda id: f"/tmp/rfe-assess/single/{id}.result.md",
+    "assess": lambda id: f"tmp/rfe-assess/single/{id}.result.md",
     "feasibility": lambda id: f"artifacts/rfe-reviews/{id}-feasibility.md",
     "review": lambda id: f"artifacts/rfe-reviews/{id}-review.md",
     "revise": lambda id: f"artifacts/rfe-reviews/{id}-review.md",

--- a/scripts/cleanup_partial_split.py
+++ b/scripts/cleanup_partial_split.py
@@ -55,8 +55,8 @@ def main():
 
         # Delete assessment files
         for assess_file in [
-            f"/tmp/rfe-assess/single/{child_id}.md",
-            f"/tmp/rfe-assess/single/{child_id}.result.md",
+            f"tmp/rfe-assess/single/{child_id}.md",
+            f"tmp/rfe-assess/single/{child_id}.result.md",
         ]:
             if os.path.exists(assess_file):
                 os.remove(assess_file)

--- a/scripts/error_collect.py
+++ b/scripts/error_collect.py
@@ -126,8 +126,8 @@ def main():
         for path in [
             f"artifacts/rfe-reviews/{rfe_id}-review.md",
             f"artifacts/rfe-reviews/{rfe_id}-feasibility.md",
-            f"/tmp/rfe-assess/single/{rfe_id}.md",
-            f"/tmp/rfe-assess/single/{rfe_id}.result.md",
+            f"tmp/rfe-assess/single/{rfe_id}.md",
+            f"tmp/rfe-assess/single/{rfe_id}.result.md",
         ]:
             if os.path.exists(path):
                 os.remove(path)
@@ -152,7 +152,7 @@ def main():
     warnings = []
     for rfe_id in error_ids:
         for path in [
-            f"/tmp/rfe-assess/single/{rfe_id}.result.md",
+            f"tmp/rfe-assess/single/{rfe_id}.result.md",
             f"artifacts/rfe-reviews/{rfe_id}-review.md",
             f"artifacts/rfe-reviews/{rfe_id}-feasibility.md",
         ]:

--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -126,8 +126,8 @@ PHASE_CONFIG = {
         " --ids-file tmp/pipeline-active-ids.txt",
         "vars": {
             "KEY": "{ID}",
-            "DATA_FILE": "/tmp/rfe-assess/single/{ID}.md",
-            "RUN_DIR": "/tmp/rfe-assess/single",
+            "DATA_FILE": "tmp/rfe-assess/single/{ID}.md",
+            "RUN_DIR": "tmp/rfe-assess/single",
             "PROMPT_PATH": ".context/assess-rfe/skills/assess-rfe/scripts/agent_prompt.md",
         },
     },
@@ -141,7 +141,7 @@ PHASE_CONFIG = {
         "vars": {
             "FIRST_PASS": "true",
             "ID": "{ID}",
-            "ASSESS_PATH": "/tmp/rfe-assess/single/{ID}.result.md",
+            "ASSESS_PATH": "tmp/rfe-assess/single/{ID}.result.md",
             "FEASIBILITY_PATH": "artifacts/rfe-reviews/{ID}-feasibility.md",
         },
     },
@@ -175,8 +175,8 @@ PHASE_CONFIG = {
         " --ids-file tmp/pipeline-reassess-ids.txt",
         "vars": {
             "KEY": "{ID}",
-            "DATA_FILE": "/tmp/rfe-assess/single/{ID}.md",
-            "RUN_DIR": "/tmp/rfe-assess/single",
+            "DATA_FILE": "tmp/rfe-assess/single/{ID}.md",
+            "RUN_DIR": "tmp/rfe-assess/single",
             "PROMPT_PATH": ".context/assess-rfe/skills/assess-rfe/scripts/agent_prompt.md",
         },
     },
@@ -190,7 +190,7 @@ PHASE_CONFIG = {
         "vars": {
             "FIRST_PASS": "false",
             "ID": "{ID}",
-            "ASSESS_PATH": "/tmp/rfe-assess/single/{ID}.result.md",
+            "ASSESS_PATH": "tmp/rfe-assess/single/{ID}.result.md",
             "FEASIBILITY_PATH": "artifacts/rfe-reviews/{ID}-feasibility.md",
         },
     },
@@ -249,8 +249,8 @@ PHASE_CONFIG = {
         " --ids-file tmp/pipeline-split-children-ids.txt",
         "vars": {
             "KEY": "{ID}",
-            "DATA_FILE": "/tmp/rfe-assess/single/{ID}.md",
-            "RUN_DIR": "/tmp/rfe-assess/single",
+            "DATA_FILE": "tmp/rfe-assess/single/{ID}.md",
+            "RUN_DIR": "tmp/rfe-assess/single",
             "PROMPT_PATH": ".context/assess-rfe/skills/assess-rfe/scripts/agent_prompt.md",
         },
     },
@@ -264,7 +264,7 @@ PHASE_CONFIG = {
         "vars": {
             "FIRST_PASS": "true",
             "ID": "{ID}",
-            "ASSESS_PATH": "/tmp/rfe-assess/single/{ID}.result.md",
+            "ASSESS_PATH": "tmp/rfe-assess/single/{ID}.result.md",
             "FEASIBILITY_PATH": "artifacts/rfe-reviews/{ID}-feasibility.md",
         },
     },
@@ -296,8 +296,8 @@ PHASE_CONFIG = {
         " --ids-file tmp/pipeline-revise-ids.txt",
         "vars": {
             "KEY": "{ID}",
-            "DATA_FILE": "/tmp/rfe-assess/single/{ID}.md",
-            "RUN_DIR": "/tmp/rfe-assess/single",
+            "DATA_FILE": "tmp/rfe-assess/single/{ID}.md",
+            "RUN_DIR": "tmp/rfe-assess/single",
             "PROMPT_PATH": ".context/assess-rfe/skills/assess-rfe/scripts/agent_prompt.md",
         },
     },
@@ -311,7 +311,7 @@ PHASE_CONFIG = {
         "vars": {
             "FIRST_PASS": "false",
             "ID": "{ID}",
-            "ASSESS_PATH": "/tmp/rfe-assess/single/{ID}.result.md",
+            "ASSESS_PATH": "tmp/rfe-assess/single/{ID}.result.md",
             "FEASIBILITY_PATH": "artifacts/rfe-reviews/{ID}-feasibility.md",
         },
     },

--- a/scripts/prep_assess.py
+++ b/scripts/prep_assess.py
@@ -9,13 +9,13 @@ Usage:
     python3 scripts/prep_assess.py RFE-001
 
 Outputs:
-    FILE=/tmp/rfe-assess/single/<ID>.md
+    FILE=tmp/rfe-assess/single/<ID>.md
 """
 
 import os
 import sys
 
-SINGLE_DIR = "/tmp/rfe-assess/single"
+SINGLE_DIR = "tmp/rfe-assess/single"
 TASK_DIR = os.path.join("artifacts", "rfe-tasks")
 
 

--- a/scripts/reassess_save.py
+++ b/scripts/reassess_save.py
@@ -38,7 +38,7 @@ def main():
     for rfe_id in ids:
         for path in [
             f"artifacts/rfe-reviews/{rfe_id}-review.md",
-            f"/tmp/rfe-assess/single/{rfe_id}.result.md",
+            f"tmp/rfe-assess/single/{rfe_id}.result.md",
         ]:
             if os.path.exists(path):
                 os.remove(path)

--- a/scripts/verify_phase.py
+++ b/scripts/verify_phase.py
@@ -19,7 +19,7 @@ from artifact_utils import read_frontmatter
 
 PHASE_OUTPUT = {
     "fetch": lambda id: f"artifacts/rfe-tasks/{id}.md",
-    "assess": lambda id: f"/tmp/rfe-assess/single/{id}.result.md",
+    "assess": lambda id: f"tmp/rfe-assess/single/{id}.result.md",
     "feasibility": lambda id: f"artifacts/rfe-reviews/{id}-feasibility.md",
     "review": lambda id: f"artifacts/rfe-reviews/{id}-review.md",
     "split": lambda id: f"artifacts/rfe-reviews/{id}-split-status.yaml",

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -856,8 +856,8 @@ class TestAgentPhaseGuard:
         ps._save_state(make_state(phase="ASSESS"))
         write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1001"])
         # Assess file exists but feasibility file missing
-        os.makedirs("/tmp/rfe-assess/single", exist_ok=True)
-        with open("/tmp/rfe-assess/single/RHAIRFE-1001.result.md", "w") as f:
+        os.makedirs("tmp/rfe-assess/single", exist_ok=True)
+        with open("tmp/rfe-assess/single/RHAIRFE-1001.result.md", "w") as f:
             f.write("assessed")
         # No feasibility file → pending on parallel phase
         with pytest.raises(SystemExit) as exc_info:
@@ -868,8 +868,8 @@ class TestAgentPhaseGuard:
         """advance proceeds when both main and parallel phases are complete."""
         ps._save_state(make_state(phase="ASSESS"))
         write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1001"])
-        os.makedirs("/tmp/rfe-assess/single", exist_ok=True)
-        with open("/tmp/rfe-assess/single/RHAIRFE-1001.result.md", "w") as f:
+        os.makedirs("tmp/rfe-assess/single", exist_ok=True)
+        with open("tmp/rfe-assess/single/RHAIRFE-1001.result.md", "w") as f:
             f.write("assessed")
         with open("artifacts/rfe-reviews/RHAIRFE-1001-feasibility.md", "w") as f:
             f.write("feasibility done")
@@ -1838,8 +1838,8 @@ class TestNextActionAgent:
         ps._save_state(make_state(phase="ASSESS", batch=1))
 
         # RHAIRFE-1001: assess complete, feasibility missing → still pending
-        os.makedirs("/tmp/rfe-assess/single", exist_ok=True)
-        with open("/tmp/rfe-assess/single/RHAIRFE-1001.result.md", "w") as f:
+        os.makedirs("tmp/rfe-assess/single", exist_ok=True)
+        with open("tmp/rfe-assess/single/RHAIRFE-1001.result.md", "w") as f:
             f.write("assessed")
         # RHAIRFE-1002: both missing → pending
 


### PR DESCRIPTION
Related to: https://github.com/opendatahub-io/assess-rfe/pull/9

<!--- Provide a general summary of your changes in the Title above -->

## Description
The rfe-scorer subagent has permissionMode: acceptEdits, which only auto-approves file operations within the working directory. Single-mode assessment used /tmp/rfe-assess/single/ (absolute path outside the working directory) for both input and output, so the scorer couldn't read/write there.

This previously worked only because the scorer agent type failed to load, causing fallback to a general-purpose agent with unrestricted tool access. Once assess-rfe loaded correctly, the restricted scorer was used and permissions broke.

Fix: replace the absolute path /tmp/rfe-assess/single with the relative path tmp/rfe-assess/single (relative to working directory). tmp/ is already gitignored.

## How Has This Been Tested?
I have ran an eval with the fix

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized assessment and review artifacts to use the workspace’s relative `tmp/` directory.
  - Improved consistency when creating, locating, validating, cleaning up, and reassessing review files.
  - Prevented mismatches between generated artifact paths and progress or phase verification checks.

- **Documentation**
  - Updated skill guidance and examples to reflect the relative artifact locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->