### PR TITLE
Fix SPLIT_COLLECT run-phase failure caused by ids_file argument mismatch

### DIFF
--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -227,7 +227,6 @@ PHASE_CONFIG = {
     "SPLIT_COLLECT": {
         "type": "script",
         "command": "python3 scripts/split_collect.py",
-        "ids_file": "tmp/pipeline-split-ids.txt",
     },
     "SPLIT_PIPELINE_START": {"type": "noop"},
     "SPLIT_ASSESS": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The run-phase handler generically appends IDs from the configured ids_file to any script command. For SPLIT_COLLECT, this produced:

  python3 scripts/split_collect.py RFE-005

But split_collect.py only defines --type via argparse — no positional arguments. argparse rejects the extra args and exits with code 2, causing run-phase to fail. The script reads tmp/pipeline-split-ids.txt internally and does not need IDs passed on the command line.

In CI eval runs, the agent had to work around this by manually running split_collect.py without the extra args and then advancing the phase with set-phase. Each workaround cost extra turns and wall-clock time, contributing to eventual timeouts.

The ids_file guard (skip if empty) is also unnecessary here: the pipeline can only reach SPLIT_COLLECT after the COLLECT phase wrote at least one ID to the file and the SPLIT agents ran on them.

Fix: remove ids_file from the SPLIT_COLLECT phase config so run-phase executes the command as-is.

## How Has This Been Tested?
Tested with an eval

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
