### PR TITLE
Add missing KEY variable to assess agent vars

### DIFF
--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -125,6 +125,7 @@ PHASE_CONFIG = {
         "post_verify": "python3 scripts/verify_phase.py --phase assess"
         " --ids-file tmp/pipeline-active-ids.txt",
         "vars": {
+            "KEY": "{ID}",
             "DATA_FILE": "/tmp/rfe-assess/single/{ID}.md",
             "RUN_DIR": "/tmp/rfe-assess/single",
             "PROMPT_PATH": ".context/assess-rfe/scripts/agent_prompt.md",
@@ -174,6 +175,7 @@ PHASE_CONFIG = {
         "post_verify": "python3 scripts/verify_phase.py --phase assess"
         " --ids-file tmp/pipeline-reassess-ids.txt",
         "vars": {
+            "KEY": "{ID}",
             "DATA_FILE": "/tmp/rfe-assess/single/{ID}.md",
             "RUN_DIR": "/tmp/rfe-assess/single",
             "PROMPT_PATH": ".context/assess-rfe/scripts/agent_prompt.md",
@@ -247,6 +249,7 @@ PHASE_CONFIG = {
         "post_verify": "python3 scripts/verify_phase.py --phase assess"
         " --ids-file tmp/pipeline-split-children-ids.txt",
         "vars": {
+            "KEY": "{ID}",
             "DATA_FILE": "/tmp/rfe-assess/single/{ID}.md",
             "RUN_DIR": "/tmp/rfe-assess/single",
             "PROMPT_PATH": ".context/assess-rfe/scripts/agent_prompt.md",
@@ -293,6 +296,7 @@ PHASE_CONFIG = {
         "post_verify": "python3 scripts/verify_phase.py --phase assess"
         " --ids-file tmp/pipeline-revise-ids.txt",
         "vars": {
+            "KEY": "{ID}",
             "DATA_FILE": "/tmp/rfe-assess/single/{ID}.md",
             "RUN_DIR": "/tmp/rfe-assess/single",
             "PROMPT_PATH": ".context/assess-rfe/scripts/agent_prompt.md",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The assess-agent.md prompt template uses {KEY} for the issue key, but the pipeline's assess vars never provided it. The scorer agent needs KEY to name its output file ({RUN_DIR}/{KEY}.result.md). Without it, the scorer had to infer the key from context (e.g. parsing the DATA_FILE path), which worked most of the time but failed intermittently — particularly for split children INIT-018 and INIT-019 in CI eval job 15520629945.

When the scorer fails to write the result file, verify_phase.py treats it as an agent failure and creates a review file with score=0 and recommendation=revise, short-circuiting the entire downstream review pipeline for that ID. This is why INIT-018/019 scored 0 while their sibling INIT-017 scored 9.

The interactive skill (initiative.review/SKILL.md) already passes KEY explicitly in its agent launch instructions. This aligns the pipeline config with that behavior.

Added KEY={ID} to all four assess phases: ASSESS, REASSESS_ASSESS, SPLIT_ASSESS, and SPLIT_REASSESS.

## How Has This Been Tested?
Tested with eval

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Assessment workflows now include each agent’s identifier in the launch configuration.
  * Updated assessment and reassessment phases, including split workflows, to provide consistent agent context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->