### PR TITLE
Fix rubric PROMPT_PATH to match assess-rfe repo layout

### DIFF
--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -127,7 +127,7 @@ PHASE_CONFIG = {
         "vars": {
             "DATA_FILE": "/tmp/rfe-assess/single/{ID}.md",
             "RUN_DIR": "/tmp/rfe-assess/single",
-            "PROMPT_PATH": ".context/assess-rfe/scripts/agent_prompt.md",
+            "PROMPT_PATH": ".context/assess-rfe/skills/assess-rfe/scripts/agent_prompt.md",
         },
     },
     "REVIEW": {
@@ -176,7 +176,7 @@ PHASE_CONFIG = {
         "vars": {
             "DATA_FILE": "/tmp/rfe-assess/single/{ID}.md",
             "RUN_DIR": "/tmp/rfe-assess/single",
-            "PROMPT_PATH": ".context/assess-rfe/scripts/agent_prompt.md",
+            "PROMPT_PATH": ".context/assess-rfe/skills/assess-rfe/scripts/agent_prompt.md",
         },
     },
     "REASSESS_REVIEW": {
@@ -249,7 +249,7 @@ PHASE_CONFIG = {
         "vars": {
             "DATA_FILE": "/tmp/rfe-assess/single/{ID}.md",
             "RUN_DIR": "/tmp/rfe-assess/single",
-            "PROMPT_PATH": ".context/assess-rfe/scripts/agent_prompt.md",
+            "PROMPT_PATH": ".context/assess-rfe/skills/assess-rfe/scripts/agent_prompt.md",
         },
     },
     "SPLIT_REVIEW": {
@@ -295,7 +295,7 @@ PHASE_CONFIG = {
         "vars": {
             "DATA_FILE": "/tmp/rfe-assess/single/{ID}.md",
             "RUN_DIR": "/tmp/rfe-assess/single",
-            "PROMPT_PATH": ".context/assess-rfe/scripts/agent_prompt.md",
+            "PROMPT_PATH": ".context/assess-rfe/skills/assess-rfe/scripts/agent_prompt.md",
         },
     },
     "SPLIT_RE_REVIEW": {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
assess-rfe PR #5 (move-scripts-to-skill-dirs) moved the scorer rubric from scripts/agent_prompt.md to skills/assess-rfe/scripts/agent_prompt.md. The pipeline config was never updated, so PROMPT_PATH pointed to a path that no longer exists after bootstrap.

The scorer still worked because bootstrap copies the skill into .claude/skills/assess-rfe/scripts/ and the LLM found the rubric there, but this was a fragile fallback rather than the intended behavior.

Updated all four assess phases (ASSESS, REASSESS_ASSESS, SPLIT_ASSESS, SPLIT_REASSESS) to use the correct post-refactor path.

## How Has This Been Tested?
Tested with eval

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
