### PR TITLE
Fix REASSESS_SAVE run-phase crash from unexpected positional args

### DIFF
--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -161,7 +161,6 @@ PHASE_CONFIG = {
     "REASSESS_SAVE": {
         "type": "script",
         "command": "python3 scripts/reassess_save.py",
-        "ids_file": "tmp/pipeline-reassess-ids.txt",
     },
     "REASSESS_ASSESS": {
         "type": "agent",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
REASSESS_SAVE config had ids_file set, which causes cmd_run_phase to append IDs as positional arguments to reassess_save.py. But reassess_save.py uses argparse (only --type) and reads IDs internally from the hardcoded file path — the extra positional args cause argparse to fail with "unrecognized arguments". Remove ids_file from the config since the script manages its own ID loading.

## How Has This Been Tested?
Tested with eval

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
