### PR TITLE
RHAIFIRST-313: Replace diff binary with difflib in report generation

### DIFF
--- a/scripts/generate_review_pdf.py
+++ b/scripts/generate_review_pdf.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Generate an HTML review report from RFE review artifacts."""
 
+import difflib
 import os
 import re
-import subprocess
 import sys
 from collections import Counter
 
@@ -61,24 +61,19 @@ def generate_diff(rfe_id, tasks_dir, originals_dir):
     if not os.path.exists(orig) or not os.path.exists(revised):
         return None
 
+    with open(orig) as f:
+        orig_lines = f.readlines()
+
     with open(revised) as f:
         revised_content = f.read()
     if revised_content.startswith("---"):
         parts = revised_content.split("---", 2)
         if len(parts) >= 3:
             revised_content = parts[2].lstrip("\n")
+    revised_lines = revised_content.splitlines(keepends=True)
 
-    import tempfile
-
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as tmp:
-        tmp.write(revised_content)
-        tmp_path = tmp.name
-
-    try:
-        result = subprocess.run(["diff", "-u", orig, tmp_path], capture_output=True, text=True)
-        return result.stdout
-    finally:
-        os.unlink(tmp_path)
+    diff = difflib.unified_diff(orig_lines, revised_lines, fromfile=orig, tofile=revised)
+    return "".join(diff)
 
 
 def html_escape(text):


### PR DESCRIPTION
## Summary

- Replace `subprocess.run(["diff", ...])` with Python's built-in `difflib.unified_diff()` in `generate_review_pdf.py`
- Eliminates external `diffutils` dependency that is missing in the openshell CI container
- The `autofix-rfe` pipeline's HTML report generation was silently failing because `submit.py` treats the report as optional

## Context

The `autofix-rfe` CI job runs `submit.py --generate-report` after the OpenShell sandbox is destroyed. At that point, the script executes in the outer openshell container, which does not have `diffutils` installed. The `generate_diff()` function was shelling out to the `diff` binary, causing a `FileNotFoundError`.

The standalone `submit-rfe` jobs already work around this by installing `diffutils` via `microdnf`, but using Python's stdlib `difflib` is a cleaner fix that works everywhere.

Jira: https://redhat.atlassian.net/browse/RHAIFIRST-313

## Test plan

- [x] All 51 existing tests pass (`test_generate_run_report.py` + `test_submit.py`)
- [x] Verified `generate_diff()` produces correct unified diff output consumed by `diff_to_html()`
- [ ] Verify HTML report is produced in next `autofix-rfe` pipeline run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review PDF generation by producing file differences directly within the application.
  * Increased consistency and reliability across environments by removing reliance on an external system diff utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->