### PR TITLE
Bootstrap agent definitions before the create phase

### DIFF
--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -32,6 +32,19 @@ Determine pipeline mode:
 
 If no arguments provided, stop with usage instructions.
 
+## Step 0.5: Bootstrap Dependencies
+
+Run bootstrap early so agent definitions (e.g. `rfe-scorer`) are installed
+in `.claude/agents/` before they're needed in Phase 2. The CREATE phase gives
+the background agent rescan time to register them.
+
+```bash
+bash scripts/bootstrap-assess-rfe.sh
+```
+
+If bootstrap fails, retry once. If the retry also fails, continue — auto-fix
+will attempt bootstrap again in its own setup step.
+
 ## Defaults
 
 When the user doesn't specify, use these defaults:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`rfe.speedrun` bootstrapped assess-rfe from inside auto-fix's SETUP phase, which copies the `rfe-scorer` definition into `.claude/agents/` moments before ASSESS tries to launch it. The agent registry is rescanned in the background, so the first wave of the run raced it:

    Agent type 'rfe-scorer' not found. Available agents: claude, Explore,
    general-purpose, Plan, statusline-setup

Models that pass `subagent_type` through literally eat that error and have to improvise a fallback; in the 2026-07-30 eval run it cost a wasted agent launch and left the dispatch loop confused enough that 18 of 20 RFEs were never assessed. Runs on the same harness hit it repeatedly — 22 times in one case.

Move bootstrap to Step 0.5, before Phase 1. The create phase then runs for several minutes between installing the definitions and needing them, which is ample rescan time. Bootstrap is idempotent and auto-fix still runs it in SETUP, so a failure here is not fatal — retry once, then continue.

## How Has This Been Tested?
Tested with eval

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated bootstrap assessment before the pipeline begins.
  * Failed bootstrap attempts are retried once, with processing continuing if the retry fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->