### PR TITLE
Give speedrun Phase 1 a real blocking barrier

### DIFF
--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -79,16 +79,30 @@ Count entries and pre-allocate all IDs upfront:
 python3 scripts/next_rfe_id.py --from-batch <input_file>   # input_file = the --input path; prints one RFE ID per entry
 ```
 
+Persist the pre-allocated IDs before launching any agents — the Phase 1 barrier below reads this file:
+
+```bash
+python3 scripts/state.py write-ids tmp/speedrun-all-ids.txt <all_IDs>
+```
+
 For each entry, launch an Agent to invoke `/rfe.create`. Pass the pre-assigned ID so each Agent knows which ID to use:
 
 ```
-Agent for entry 1:  /rfe.create --headless --rfe-id RFE-001 [--priority <priority>] <prompt>
-Agent for entry 2:  /rfe.create --headless --rfe-id RFE-002 [--priority <priority>] <prompt>
+Agent(prompt: "/rfe.create --headless --rfe-id RFE-001 [--priority <priority>] <prompt>")
+Agent(prompt: "/rfe.create --headless --rfe-id RFE-002 [--priority <priority>] <prompt>")
 ...
-Agent for entry N:  /rfe.create --headless --rfe-id RFE-<N> [--priority <priority>] <prompt>
+Agent(prompt: "/rfe.create --headless --rfe-id RFE-<N> [--priority <priority>] <prompt>")
 ```
 
-Each entry is a single business need — `/rfe.create` must produce exactly one RFE per invocation. Wait for all N agents to complete. You must have exactly N RFE IDs — if fewer were created, retry the missing entries. **Never delete or re-create task files during Phase 1** — quality issues are addressed in Phase 2 (Auto-fix).
+Each entry is a single business need — `/rfe.create` must produce exactly one RFE per invocation. Launch all N Agents in a single message so they run concurrently. Your next Bash call after that message MUST be the Phase 1 barrier — a blocking check that reads the task files on disk:
+
+```bash
+python3 scripts/check_review_progress.py --wait --phase create --id-file tmp/speedrun-all-ids.txt
+```
+
+Call it immediately, before any agent has reported. Do not count agent-completion notifications and do not track how many agents have finished — the barrier is the only completion signal for Phase 1.
+
+Exit 0 means all N task files exist with valid frontmatter — Phase 1 is done. Exit 3 is a timeout, not a failure; it prints the still-pending IDs. Re-run the command as long as that pending list keeps shrinking. If the same IDs stay pending across 3 consecutive exit-3 results, those agents are dead and re-running will never clear them — launch a replacement Agent for each still-pending ID, then resume the barrier. You must have exactly N RFE IDs before moving on. **Never delete or re-create task files during Phase 1** — quality issues are addressed in Phase 2 (Auto-fix).
 
 **Mode B (Existing RFE)**: Skip Phase 1. The Jira key(s) from arguments become the processing list.
 

--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -137,7 +137,7 @@ Skill(skill: "rfe.auto-fix", args: "--headless --announce-complete --batch-size 
 
 Pass `--headless` and `--announce-complete` through if set in the config. **Always** pass `--batch-size <batch_size>` using the value from `tmp/speedrun-config.yaml` — never omit it, never let auto-fix's own default take over. The speedrun default (5) was already pinned in Step 0; relying on it here is what makes runs reproducible.
 
-Auto-fix handles: assessment, feasibility checks, review, auto-revision, re-assessment, splitting oversized RFEs, retry queue, and report generation. The Skill call blocks until auto-fix completes — this is correct. **Do NOT stop, summarize, or skip remaining batches early** — the pipeline must process every ID through all phases. Never emit a text-only response (no tool call) during pipeline execution — this terminates the CI process.
+Auto-fix handles: assessment, feasibility checks, review, auto-revision, re-assessment, splitting oversized RFEs, retry queue, and report generation. The Skill call blocks until auto-fix completes — this is correct. **Do NOT stop, summarize, or skip remaining batches early** — the pipeline must process every ID through all phases. Never end a turn with a text-only response (no tool call) in order to wait for something — that hands control back, and you only run again if an agent-completion notification wakes you.
 
 **Bash discipline:** Issue exactly one operation per Bash call. Never use command substitution `$(...)` or chain commands with `;`, `&&`, or `||` — they trigger an approval prompt and are denied in headless mode. Instead, pass a value between commands by writing it to a `tmp/` file with `scripts/state.py` and reading it back in a separate call.
 

--- a/.claude/skills/rfe.speedrun/SKILL.md
+++ b/.claude/skills/rfe.speedrun/SKILL.md
@@ -102,7 +102,7 @@ python3 scripts/check_review_progress.py --wait --phase create --id-file tmp/spe
 
 Call it immediately, before any agent has reported. Do not count agent-completion notifications and do not track how many agents have finished — the barrier is the only completion signal for Phase 1.
 
-Exit 0 means all N task files exist with valid frontmatter — Phase 1 is done. Exit 3 is a timeout, not a failure; it prints the still-pending IDs. Re-run the command as long as that pending list keeps shrinking. If the same IDs stay pending across 3 consecutive exit-3 results, those agents are dead and re-running will never clear them — launch a replacement Agent for each still-pending ID, then resume the barrier. You must have exactly N RFE IDs before moving on. **Never delete or re-create task files during Phase 1** — quality issues are addressed in Phase 2 (Auto-fix).
+Exit 0 means all N task files exist, each with parseable frontmatter carrying its own `rfe_id` — Phase 1 is done. Exit 3 is a timeout, not a failure; it prints the still-pending IDs. A file that is half-written, unparseable, or holding the wrong `rfe_id` counts as pending, so it times out rather than releasing the barrier. Re-run the command as long as that pending list keeps shrinking. If the same IDs stay pending across 3 consecutive exit-3 results, those agents are dead and re-running will never clear them — launch a replacement Agent for each still-pending ID, then resume the barrier. You must have exactly N RFE IDs before moving on. **Never delete or re-create task files during Phase 1** — quality issues are addressed in Phase 2 (Auto-fix).
 
 **Mode B (Existing RFE)**: Skip Phase 1. The Jira key(s) from arguments become the processing list.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,10 @@ Before modifying `scripts/snapshot_fetch.py`, `scripts/bootstrap_snapshot.py`, o
 
 When `tmp/pipeline-state.yaml` exists and the phase is not DONE:
 
-1. A text-only response (no tool call) during pipeline execution terminates the CI process.
+1. A text-only response (no tool call) ends your turn and hands control back.
+   You will only run again if an agent-completion notification wakes you, so
+   if the work you are waiting on cannot produce one, the run is over. Never
+   end a turn to "wait" — block on the barrier in rule 2 instead.
 2. After launching each wave of agents, your next Bash call MUST be
    `python3 scripts/pipeline_state.py wait-for-wave`. This is a blocking
    synchronization barrier that reads artifact files on disk. On exit 3,

--- a/scripts/check_review_progress.py
+++ b/scripts/check_review_progress.py
@@ -42,13 +42,20 @@ def check_id(phase, rfe_id):
     if not os.path.exists(path):
         return "pending"
     if phase == "create":
+        # Every not-yet-good state is "pending", never "error". The --wait loop
+        # exits on pending == 0 and never consults the error count, so an
+        # "error" here would release the barrier on the very file it rejected.
+        # Timing out into the relaunch path in rfe.speedrun is the recovery.
         try:
             data, _ = read_frontmatter(path)
         except Exception:
-            return "error"
+            return "pending"
         # read_frontmatter returns {} for a file with no frontmatter block yet,
-        # which is a half-written file, not a finished one.
-        if not data or not data.get("rfe_id"):
+        # which is a half-written file, not a finished one. The id has to be
+        # the one asked about: a task file carrying a different rfe_id is not
+        # this ID's create output, and accepting it would break the
+        # one-RFE-per-preallocated-ID contract the barrier exists to enforce.
+        if not data or data.get("rfe_id") != rfe_id:
             return "pending"
         return "completed"
     if phase in ("review", "initiative-review"):

--- a/scripts/check_review_progress.py
+++ b/scripts/check_review_progress.py
@@ -17,6 +17,10 @@ from artifact_utils import read_frontmatter
 
 PHASE_CHECKS = {
     "fetch": lambda id: f"artifacts/rfe-tasks/{id}.md",
+    # Same path as "fetch", but a stricter check — see check_id(). Create agents
+    # write the task file first and set frontmatter in a later tool call, so
+    # existence alone would release the barrier mid-write.
+    "create": lambda id: f"artifacts/rfe-tasks/{id}.md",
     "assess": lambda id: f"tmp/rfe-assess/single/{id}.result.md",
     "feasibility": lambda id: f"artifacts/rfe-reviews/{id}-feasibility.md",
     "review": lambda id: f"artifacts/rfe-reviews/{id}-review.md",
@@ -37,6 +41,16 @@ def check_id(phase, rfe_id):
     path = PHASE_CHECKS[phase](rfe_id)
     if not os.path.exists(path):
         return "pending"
+    if phase == "create":
+        try:
+            data, _ = read_frontmatter(path)
+        except Exception:
+            return "error"
+        # read_frontmatter returns {} for a file with no frontmatter block yet,
+        # which is a half-written file, not a finished one.
+        if not data or not data.get("rfe_id"):
+            return "pending"
+        return "completed"
     if phase in ("review", "initiative-review"):
         try:
             data, _ = read_frontmatter(path)

--- a/tests/test_check_review_progress.py
+++ b/tests/test_check_review_progress.py
@@ -151,6 +151,69 @@ class TestCheckId:
             assert check_id("revise", "RHAIRFE-1") == "error"
 
 
+class TestCreatePhase:
+    """The create phase is the Phase 1 barrier in /rfe.speedrun.
+
+    Create agents write the task file first and set frontmatter in a later tool
+    call, so this phase deliberately checks more than existence — releasing the
+    barrier mid-write is what leaves the pipeline with unusable task files.
+    """
+
+    def test_missing_file_is_pending(self, tmp_path):
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"create": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            assert check_id("create", "RFE-001") == "pending"
+
+    def test_valid_frontmatter_is_completed(self, tmp_path):
+        f = tmp_path / "RFE-001.md"
+        f.write_text("---\nrfe_id: RFE-001\ntitle: A need\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"create": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            assert check_id("create", "RFE-001") == "completed"
+
+    def test_file_without_frontmatter_is_pending(self, tmp_path):
+        """The agent wrote the file but has not run frontmatter.py set yet."""
+        f = tmp_path / "RFE-001.md"
+        f.write_text("# A need\n\nSome body text.\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"create": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            assert check_id("create", "RFE-001") == "pending"
+
+    def test_frontmatter_without_rfe_id_is_pending(self, tmp_path):
+        f = tmp_path / "RFE-001.md"
+        f.write_text("---\ntitle: A need\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"create": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            assert check_id("create", "RFE-001") == "pending"
+
+    def test_empty_frontmatter_is_pending(self, tmp_path):
+        f = tmp_path / "RFE-001.md"
+        f.write_text("---\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"create": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            assert check_id("create", "RFE-001") == "pending"
+
+    def test_unparseable_frontmatter_is_error(self, tmp_path):
+        """An error is surfaced rather than waited on — retrying won't fix it."""
+        f = tmp_path / "RFE-001.md"
+        f.write_text("---\n: bad yaml [[\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"create": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            assert check_id("create", "RFE-001") == "error"
+
+
 # ── _check_phase ──
 
 

--- a/tests/test_check_review_progress.py
+++ b/tests/test_check_review_progress.py
@@ -203,15 +203,45 @@ class TestCreatePhase:
         ):
             assert check_id("create", "RFE-001") == "pending"
 
-    def test_unparseable_frontmatter_is_error(self, tmp_path):
-        """An error is surfaced rather than waited on — retrying won't fix it."""
+    def test_unparseable_frontmatter_is_pending(self, tmp_path):
+        """Not "error": the --wait loop stops on pending == 0 and ignores errors.
+
+        Returning "error" would release the barrier on exactly the file it
+        just rejected. Pending times out into the relaunch path instead.
+        """
         f = tmp_path / "RFE-001.md"
         f.write_text("---\n: bad yaml [[\n---\nBody\n")
         with patch.dict(
             "check_review_progress.PHASE_CHECKS",
             {"create": lambda id: str(tmp_path / f"{id}.md")},
         ):
-            assert check_id("create", "RFE-001") == "error"
+            assert check_id("create", "RFE-001") == "pending"
+
+    def test_mismatched_rfe_id_is_pending(self, tmp_path):
+        """A task file holding someone else's ID is not this ID's create output."""
+        f = tmp_path / "RFE-001.md"
+        f.write_text("---\nrfe_id: RFE-002\ntitle: A need\n---\nBody\n")
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"create": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            assert check_id("create", "RFE-001") == "pending"
+
+    def test_create_never_reports_error(self, tmp_path):
+        """No create input may return "error" — the barrier would leak past it."""
+        cases = [
+            "---\n: bad yaml [[\n---\nBody\n",
+            "---\n---\nBody\n",
+            "---\nrfe_id: RFE-002\n---\nBody\n",
+            "# No frontmatter\n",
+        ]
+        with patch.dict(
+            "check_review_progress.PHASE_CHECKS",
+            {"create": lambda id: str(tmp_path / f"{id}.md")},
+        ):
+            for content in cases:
+                (tmp_path / "RFE-001.md").write_text(content)
+                assert check_id("create", "RFE-001") != "error", content
 
 
 # ── _check_phase ──


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Problem:

Phase 1 of `rfe.speedrun` fans out N Agents to create RFEs, then instructed the
orchestrator to "wait for all N agents to complete."

There is no way to do that. Ending a turn hands control back, and the session only
resumes if an agent-completion notification arrives. So the orchestrator was left
counting notifications as a proxy for completion — which isn't one. It drifts the
moment a single agent dies, and there's no bound on how long it waits.

Every other phase already solved this. `rfe.auto-fix` blocks on
`pipeline_state.py wait-for-wave`, a command that reads artifact files on disk.
Phase 1 was the one fan-out with no barrier.

What this does:

Gives Phase 1 the same kind of barrier.

**`scripts/check_review_progress.py`** gains a `create` phase keyed on
`artifacts/rfe-tasks/<id>.md`. Existence alone is not sufficient:
`next_rfe_id.py` pre-creates a 0-byte placeholder for every allocated ID, so an
existence check would release the barrier immediately, before any agent has
written anything. Create agents also write the file first and set frontmatter in a
later tool call. The check therefore requires parseable frontmatter carrying
`rfe_id` — a half-written file reads as `pending`, not `completed`.

**`.claude/skills/rfe.speedrun/SKILL.md`** replaces the un-followable instruction
with the barrier call:

```bash
python3 scripts/check_review_progress.py --wait --phase create --id-file tmp/speedrun-all-ids.txt
```

- `write-ids` moves ahead of the launch so the barrier has an `--id-file` to read.
  The post-Phase-1 `write-ids` stays, since Modes B and C don't take the batch path.
- Documents exit 0 / exit 3 semantics, and adds an escape hatch: if the same IDs
  stay pending across 3 consecutive timeouts, those agents are dead and re-running
  the barrier will never clear them — relaunch instead.
- The launch block is now literal `Agent(prompt: "...")` calls. The old
  `Agent for entry 1:` pseudo-code had to be rendered into a tool call by the
  orchestrator, which leaves the choice of tool open.

Second commit: a factual correction

`AGENTS.md` and `rfe.speedrun` both claimed a text-only response during pipeline
execution *terminates the CI process*. That's wrong in two directions — completed
runs routinely contain many text-only turns, and the pipeline doesn't necessarily
run under CI at all.

The true statement is narrower and more useful: ending a turn hands control back,
and you only resume if a notification wakes you. So ending a turn to "wait" for
work that can't produce a notification is what kills a run.


## How Has This Been Tested?
Tested with eval

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved creation workflow progress tracking with clearer pending, completed, and failed task states.
  * Creation tasks can now run concurrently, with better completion, timeout, and replacement handling.
  * Automated workflows remain active while processing and auto-fixes finish.

* **Reliability**
  * Added validation for task metadata to identify incomplete or invalid creation requests.
  * Improved handling of missing, empty, or malformed task information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->