### PR TITLE
Make review frontmatter parse and repair correctly

### DIFF
--- a/.claude/skills/initiative-review/prompts/review-agent.md
+++ b/.claude/skills/initiative-review/prompts/review-agent.md
@@ -23,9 +23,10 @@ python3 scripts/frontmatter.py schema initiative-review
 ## Step 3: Write Review File
 
 Write `artifacts/initiative-reviews/{ID}-review.md` with the body structure below — just
-the body, no `---` frontmatter block. Step 4 creates the frontmatter. A hand-written
-block breaks the moment a value contains a colon, and `frontmatter.py` cannot then
-read the file to repair it.
+the body, no `---` frontmatter block. Step 4 creates the frontmatter. Writing the
+body only avoids corruption entirely: a hand-written block breaks the moment a
+value contains a colon. (`frontmatter.py set` can recover a corrupted block, but
+don't rely on it.)
 
    ## Assessor Feedback
    <Full rubric feedback verbatim from assessment result>

--- a/.claude/skills/initiative-review/prompts/review-agent.md
+++ b/.claude/skills/initiative-review/prompts/review-agent.md
@@ -22,7 +22,10 @@ python3 scripts/frontmatter.py schema initiative-review
 
 ## Step 3: Write Review File
 
-Write `artifacts/initiative-reviews/{ID}-review.md` with this body structure:
+Write `artifacts/initiative-reviews/{ID}-review.md` with the body structure below — just
+the body, no `---` frontmatter block. Step 4 creates the frontmatter. A hand-written
+block breaks the moment a value contains a colon, and `frontmatter.py` cannot then
+read the file to repair it.
 
    ## Assessor Feedback
    <Full rubric feedback verbatim from assessment result>

--- a/.claude/skills/rfe.review/prompts/review-agent.md
+++ b/.claude/skills/rfe.review/prompts/review-agent.md
@@ -20,9 +20,10 @@ python3 scripts/frontmatter.py schema rfe-review
 ## Step 3: Write Review File
 
 Write `artifacts/rfe-reviews/{ID}-review.md` with the body structure below — just
-the body, no `---` frontmatter block. Step 4 creates the frontmatter. A hand-written
-block breaks the moment a value contains a colon, and `frontmatter.py` cannot then
-read the file to repair it.
+the body, no `---` frontmatter block. Step 4 creates the frontmatter. Writing the
+body only avoids corruption entirely: a hand-written block breaks the moment a
+value contains a colon. (`frontmatter.py set` can recover a corrupted block, but
+don't rely on it.)
 
    ## Assessor Feedback
    <Full rubric feedback verbatim from assessment result>

--- a/.claude/skills/rfe.review/prompts/review-agent.md
+++ b/.claude/skills/rfe.review/prompts/review-agent.md
@@ -19,7 +19,10 @@ python3 scripts/frontmatter.py schema rfe-review
 
 ## Step 3: Write Review File
 
-Write `artifacts/rfe-reviews/{ID}-review.md` with this body structure:
+Write `artifacts/rfe-reviews/{ID}-review.md` with the body structure below — just
+the body, no `---` frontmatter block. Step 4 creates the frontmatter. A hand-written
+block breaks the moment a value contains a colon, and `frontmatter.py` cannot then
+read the file to repair it.
 
    ## Assessor Feedback
    <Full rubric feedback verbatim from assessment result>

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -429,12 +429,50 @@ def get_schema_yaml(schema_type):
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?\n)---\s*\n", re.DOTALL)
 
 
+def _yaml_error_message(path, yaml_str, exc):
+    """Describe a frontmatter parse failure in one actionable line.
+
+    PyYAML's own traceback is unreadable in agent logs. Lead with the file and
+    the offending line so the message survives log truncation, and say how to
+    avoid it — the usual cause is a hand-written block whose free-text value
+    contains an unquoted ':'.
+    """
+    problem = getattr(exc, "problem", None) or str(exc)
+    mark = getattr(exc, "problem_mark", None)
+    if mark is None:
+        return f"Invalid YAML frontmatter in {path}: {problem}"
+
+    lines = yaml_str.splitlines()
+    source = lines[mark.line].strip() if 0 <= mark.line < len(lines) else ""
+    near = f" near {source!r}" if source else ""
+    return (
+        f"Invalid YAML frontmatter in {path}, line {mark.line + 1}{near} — {problem}. "
+        f"Set frontmatter with scripts/frontmatter.py rather than by hand; "
+        f"values containing ':' must be quoted."
+    )
+
+
+def _body_without_frontmatter(path):
+    """Return the markdown body, ignoring the contents of the frontmatter block.
+
+    The delimiters are matched by regex, so the body is recoverable even when
+    the YAML between them does not parse.
+    """
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+    match = _FRONTMATTER_RE.match(content)
+    return content[match.end() :] if match else content
+
+
 def read_frontmatter(path):
     """Read and parse YAML frontmatter from a markdown file.
 
     Returns:
         (data_dict, body_string) — frontmatter as dict, remainder as string.
         Returns ({}, full_content) if no frontmatter found.
+
+    Raises:
+        ValidationError: if the frontmatter block is present but unparseable.
     """
     with open(path, encoding="utf-8") as f:
         content = f.read()
@@ -446,7 +484,10 @@ def read_frontmatter(path):
     yaml_str = match.group(1)
     body = content[match.end() :]
 
-    data = yaml.safe_load(yaml_str)
+    try:
+        data = yaml.safe_load(yaml_str)
+    except yaml.YAMLError as exc:
+        raise ValidationError(_yaml_error_message(path, yaml_str, exc)) from exc
     if not isinstance(data, dict):
         return {}, content
 
@@ -514,10 +555,11 @@ def write_frontmatter(path, data, schema_type):
             "Frontmatter validation failed:\n" + "\n".join(f"  - {e}" for e in errors)
         )
 
-    # Read existing body if file exists
+    # Read existing body if file exists. The data above is already validated
+    # and complete, so an unparseable existing block is simply overwritten.
     body = ""
     if os.path.exists(path):
-        _, body = read_frontmatter(path)
+        body = _body_without_frontmatter(path)
 
     yaml_str = yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True)
     content = f"---\n{yaml_str}---\n{body}"
@@ -540,11 +582,23 @@ def update_frontmatter(path, updates, schema_type):
         updates: dict of fields to add/update
         schema_type: schema to validate against
 
+    If the existing frontmatter block is unparseable, it is replaced rather
+    than merged. This is the only repair path available: every writer goes
+    through here, so refusing would leave the caller no way to fix the file
+    except hand-editing YAML — which is what corrupts it in the first place.
+    The validation below is the guard. Updates that do not amount to a
+    complete, valid record still fail, so nothing is dropped silently.
+
     Raises:
         ValidationError: if merged data fails validation
         FileNotFoundError: if file doesn't exist
     """
-    data, body = read_frontmatter(path)
+    try:
+        data, body = read_frontmatter(path)
+    except ValidationError as exc:
+        print(f"Warning: replacing unparseable frontmatter — {exc}", file=sys.stderr)
+        data, body = {}, _body_without_frontmatter(path)
+
     for key, value in updates.items():
         if isinstance(value, dict) and isinstance(data.get(key), dict):
             data[key].update(value)

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -426,7 +426,13 @@ def get_schema_yaml(schema_type):
 
 # ─── Frontmatter Read/Write ────────────────────────────────────────────────────
 
-_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?\n)---\s*\n", re.DOTALL)
+# The closing delimiter must be anchored to the start of a line, and the block
+# body must be allowed to be empty. `(.*?\n)` requires at least one newline, so
+# on an empty block (`---\n---\n`) it consumes the closing delimiter and keeps
+# expanding to the next `---` in the body — swallowing markdown horizontal rules
+# and score tables into the YAML string. `[ \t]*` rather than `\s*` so a blank
+# line after the closing delimiter stays in the body.
+_FRONTMATTER_RE = re.compile(r"\A---[ \t]*\r?\n(.*?)^---[ \t]*\r?\n", re.DOTALL | re.MULTILINE)
 
 
 def _yaml_error_message(path, yaml_str, exc):
@@ -469,7 +475,10 @@ def read_frontmatter(path):
 
     Returns:
         (data_dict, body_string) — frontmatter as dict, remainder as string.
-        Returns ({}, full_content) if no frontmatter found.
+        Returns ({}, full_content) if no frontmatter found. An empty block
+        (`---\\n---\\n`) is valid frontmatter with no fields, so it returns
+        ({}, body) with the delimiters consumed — otherwise write_frontmatter
+        would leave a stale block sitting in the body.
 
     Raises:
         ValidationError: if the frontmatter block is present but unparseable.
@@ -488,6 +497,11 @@ def read_frontmatter(path):
         data = yaml.safe_load(yaml_str)
     except yaml.YAMLError as exc:
         raise ValidationError(_yaml_error_message(path, yaml_str, exc)) from exc
+    if data is None:
+        # An empty block is valid frontmatter with no fields. Consume the
+        # delimiters so a later write replaces the block rather than stacking a
+        # second one on top of it.
+        return {}, body
     if not isinstance(data, dict):
         return {}, content
 

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -458,16 +458,48 @@ def _yaml_error_message(path, yaml_str, exc):
     )
 
 
-def _body_without_frontmatter(path):
-    """Return the markdown body, ignoring the contents of the frontmatter block.
+def _looks_like_frontmatter_block(text):
+    """Heuristic: does `text` (the region between two `---` lines) plausibly hold
+    a YAML mapping, rather than body prose a stray `---` rule was mistaken for?
 
-    The delimiters are matched by regex, so the body is recoverable even when
-    the YAML between them does not parse.
+    Frontmatter written by this tool is a contiguous run of `key: value` lines.
+    A blank line, or a line that is neither a mapping key nor an indented
+    continuation/list item, means the matched closing `---` is almost certainly a
+    body horizontal rule — so the region above it is body and must be preserved,
+    not stripped.
+    """
+    saw_key = False
+    for line in text.splitlines():
+        if not line.strip():
+            return False  # blank line — we have run past the real block into body
+        if line[0] in " \t-":
+            continue  # indented continuation or a "- list" item
+        if re.match(r"[^\s:#][^:]*:(\s|$)", line):
+            saw_key = True
+            continue
+        return False  # prose, a markdown heading, etc.
+    return saw_key
+
+
+def _body_without_frontmatter(path):
+    """Return the markdown body, ignoring a leading frontmatter block.
+
+    The delimiters are matched by regex, so the body is recoverable even when the
+    YAML between them does not parse. But a lone `---` horizontal rule in the body
+    can be mistaken for the closing delimiter, so the leading block is stripped
+    only when it is empty or actually looks like a YAML mapping. Otherwise the
+    whole content is returned unchanged — better to leave a stale block stacked in
+    the body than to silently drop real content sitting above a body rule.
     """
     with open(path, encoding="utf-8") as f:
         content = f.read()
     match = _FRONTMATTER_RE.match(content)
-    return content[match.end() :] if match else content
+    if not match:
+        return content
+    region = match.group(1)
+    if region.strip() == "" or _looks_like_frontmatter_block(region):
+        return content[match.end() :]
+    return content
 
 
 def read_frontmatter(path):
@@ -475,10 +507,14 @@ def read_frontmatter(path):
 
     Returns:
         (data_dict, body_string) — frontmatter as dict, remainder as string.
-        Returns ({}, full_content) if no frontmatter found. An empty block
-        (`---\\n---\\n`) is valid frontmatter with no fields, so it returns
+        Returns ({}, full_content) if no frontmatter found. A genuinely empty
+        block (`---\\n---\\n`) is valid frontmatter with no fields, so it returns
         ({}, body) with the delimiters consumed — otherwise write_frontmatter
-        would leave a stale block sitting in the body.
+        would leave a stale block sitting in the body. A block that is present
+        but not a mapping (a bare scalar, or comment/heading-only content that
+        parses to null) returns ({}, full_content): the closing `---` we matched
+        may be a body horizontal rule, so the safe choice is to treat the whole
+        file as body rather than drop the region above the delimiter.
 
     Raises:
         ValidationError: if the frontmatter block is present but unparseable.
@@ -493,16 +529,23 @@ def read_frontmatter(path):
     yaml_str = match.group(1)
     body = content[match.end() :]
 
+    if yaml_str.strip() == "":
+        # A genuinely empty block is valid frontmatter with no fields. Consume
+        # the delimiters so a later write replaces it rather than stacking a
+        # second block on top. Only a *blank* block is consumed: content that
+        # merely parses to null is not — a markdown heading is a YAML comment, so
+        # `---\n## Heading\n---\nbody` also yields None, and the closing `---`
+        # there may be a body horizontal rule. Consuming up to it would silently
+        # drop the lines above.
+        return {}, body
+
     try:
         data = yaml.safe_load(yaml_str)
     except yaml.YAMLError as exc:
         raise ValidationError(_yaml_error_message(path, yaml_str, exc)) from exc
-    if data is None:
-        # An empty block is valid frontmatter with no fields. Consume the
-        # delimiters so a later write replaces the block rather than stacking a
-        # second one on top of it.
-        return {}, body
     if not isinstance(data, dict):
+        # Present but not a mapping (a bare scalar/list, or comment-only content
+        # that parsed to None). Preserve the whole file — see the docstring.
         return {}, content
 
     _migrate_fields(data)
@@ -600,8 +643,10 @@ def update_frontmatter(path, updates, schema_type):
     than merged. This is the only repair path available: every writer goes
     through here, so refusing would leave the caller no way to fix the file
     except hand-editing YAML — which is what corrupts it in the first place.
-    The validation below is the guard. Updates that do not amount to a
-    complete, valid record still fail, so nothing is dropped silently.
+    The validation below guards the *fields*: a partial update that does not
+    amount to a complete, valid record still fails. Body content is never
+    dropped — _body_without_frontmatter strips only a leading block it can
+    confidently identify as frontmatter and otherwise preserves the whole file.
 
     Raises:
         ValidationError: if merged data fails validation

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -459,25 +459,36 @@ def _yaml_error_message(path, yaml_str, exc):
 
 
 def _looks_like_frontmatter_block(text):
-    """Heuristic: does `text` (the region between two `---` lines) plausibly hold
-    a YAML mapping, rather than body prose a stray `---` rule was mistaken for?
+    """Does `text` (the region between two `---` lines) hold real frontmatter,
+    rather than body prose a stray `---` rule was mistaken for?
 
-    Frontmatter written by this tool is a contiguous run of `key: value` lines.
-    A blank line, or a line that is neither a mapping key nor an indented
-    continuation/list item, means the matched closing `---` is almost certainly a
-    body horizontal rule — so the region above it is body and must be preserved,
-    not stripped.
+    Valid frontmatter parses cleanly to a mapping, so that is the fast path (and
+    covers list- or nested-map values). The repair path must also recognise a
+    *malformed* mapping — the unquoted-colon corruption this feature targets — so
+    a fallback accepts a contiguous run of `key: value` lines. Anything else
+    means the matched `---` is almost certainly a body horizontal rule, so the
+    region is body and must be preserved, not stripped:
+
+    - a blank line (frontmatter this tool writes has none),
+    - a top-level `- ` sequence item not under a key (never valid frontmatter for
+      these schemas, and the mixed map+sequence shape below is invalid YAML),
+    - a prose line or a markdown heading (`#` is a YAML comment).
     """
+    try:
+        if isinstance(yaml.safe_load(text), dict):
+            return True
+    except yaml.YAMLError:
+        pass  # fall through to the malformed-but-recoverable mapping check
     saw_key = False
     for line in text.splitlines():
         if not line.strip():
             return False  # blank line — we have run past the real block into body
-        if line[0] in " \t-":
-            continue  # indented continuation or a "- list" item
+        if line[0] in " \t":
+            continue  # indented continuation of a value
         if re.match(r"[^\s:#][^:]*:(\s|$)", line):
             saw_key = True
             continue
-        return False  # prose, a markdown heading, etc.
+        return False  # prose, a markdown heading, or a top-level "- " list item
     return saw_key
 
 

--- a/scripts/collect_recommendations.py
+++ b/scripts/collect_recommendations.py
@@ -8,7 +8,7 @@ import sys
 import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from artifact_utils import read_frontmatter, resolve_ids
+from artifact_utils import ValidationError, read_frontmatter, resolve_ids
 
 ARTIFACTS_DIR = os.path.join(os.getcwd(), "artifacts")
 
@@ -72,7 +72,9 @@ def collect_errors(ids, entry_type="rfe"):
             continue
         try:
             data, _ = read_frontmatter(path)
-        except (OSError, UnicodeError, yaml.YAMLError):
+        # read_frontmatter wraps a bad YAML block in ValidationError, so an
+        # unparseable review counts as an error here rather than crashing the run.
+        except (OSError, UnicodeError, yaml.YAMLError, ValidationError):
             error_ids.append(item_id)
             continue
         if data.get("error"):

--- a/scripts/collect_recommendations.py
+++ b/scripts/collect_recommendations.py
@@ -19,17 +19,31 @@ def _review_dir(entry_type):
     return os.path.join(ARTIFACTS_DIR, subdir)
 
 
+def _read_review_data(path):
+    """Read a review's frontmatter, tolerating a missing file or corrupt block.
+
+    Returns the frontmatter dict, or None if the file is absent or its
+    frontmatter is unparseable. read_frontmatter raises ValidationError on a bad
+    YAML block (see artifact_utils), so every collection mode goes through here
+    and treats a malformed review as an error/no-op rather than letting one bad
+    file crash the whole batch.
+    """
+    if not os.path.exists(path):
+        return None
+    try:
+        data, _ = read_frontmatter(path)
+    except (OSError, UnicodeError, yaml.YAMLError, ValidationError):
+        return None
+    return data
+
+
 def collect_default(ids, entry_type="rfe"):
     """Group IDs by recommendation field."""
     groups = {"SUBMIT": [], "SPLIT": [], "REVISE": [], "REJECT": [], "ERRORS": []}
     review_dir = _review_dir(entry_type)
     for item_id in ids:
-        path = os.path.join(review_dir, f"{item_id}-review.md")
-        if not os.path.exists(path):
-            groups["ERRORS"].append(item_id)
-            continue
-        data, _ = read_frontmatter(path)
-        if data.get("error"):
+        data = _read_review_data(os.path.join(review_dir, f"{item_id}-review.md"))
+        if data is None or data.get("error"):
             groups["ERRORS"].append(item_id)
             continue
         rec = data.get("recommendation", "").upper()
@@ -48,12 +62,10 @@ def collect_reassess(ids, entry_type="rfe"):
     reassess, done = [], []
     review_dir = _review_dir(entry_type)
     for item_id in ids:
-        path = os.path.join(review_dir, f"{item_id}-review.md")
-        if not os.path.exists(path):
-            done.append(item_id)
-            continue
-        data, _ = read_frontmatter(path)
-        if data.get("auto_revised") and not data.get("pass"):
+        data = _read_review_data(os.path.join(review_dir, f"{item_id}-review.md"))
+        # A missing or corrupt review is not reassessable — bucket it as done so
+        # the run continues; --errors is the mode that surfaces it.
+        if data and data.get("auto_revised") and not data.get("pass"):
             reassess.append(item_id)
         else:
             done.append(item_id)
@@ -62,22 +74,12 @@ def collect_reassess(ids, entry_type="rfe"):
 
 
 def collect_errors(ids, entry_type="rfe"):
-    """Collect IDs with non-null error field or missing review files."""
+    """Collect IDs with non-null error field, missing files, or corrupt reviews."""
     error_ids = []
     review_dir = _review_dir(entry_type)
     for item_id in ids:
-        path = os.path.join(review_dir, f"{item_id}-review.md")
-        if not os.path.exists(path):
-            error_ids.append(item_id)
-            continue
-        try:
-            data, _ = read_frontmatter(path)
-        # read_frontmatter wraps a bad YAML block in ValidationError, so an
-        # unparseable review counts as an error here rather than crashing the run.
-        except (OSError, UnicodeError, yaml.YAMLError, ValidationError):
-            error_ids.append(item_id)
-            continue
-        if data.get("error"):
+        data = _read_review_data(os.path.join(review_dir, f"{item_id}-review.md"))
+        if data is None or data.get("error"):
             error_ids.append(item_id)
     print(f"ERRORS={','.join(error_ids)}")
 

--- a/tests/test_artifact_utils.py
+++ b/tests/test_artifact_utils.py
@@ -58,6 +58,17 @@ VALID_REVIEW_FM = {
     },
 }
 
+# A hand-written block whose free-text value carries an unquoted colon — the
+# shape seen in eval runs, where review agents wrote frontmatter themselves
+# instead of leaving it to scripts/frontmatter.py.
+CORRUPT_REVIEW = (
+    "---\n"
+    "rfe_id: RFE-015\n"
+    "needs_attention_reason: Blocked: needs architecture input\n"
+    "---\n"
+    "## Assessor Feedback\n\nKeep this body.\n"
+)
+
 
 # ── Schema & Validation ──────────────────────────────────────────────────────
 
@@ -179,6 +190,27 @@ class TestReadFrontmatter:
         data, _ = read_frontmatter("test.md")
         assert data["auto_revised"] is True
 
+    def test_unparseable_raises_validation_error(self, tmp_dir):
+        _write("review.md", CORRUPT_REVIEW)
+        with pytest.raises(ValidationError):
+            read_frontmatter("review.md")
+
+    def test_error_locates_the_offending_line(self, tmp_dir):
+        _write("review.md", CORRUPT_REVIEW)
+        with pytest.raises(ValidationError) as exc_info:
+            read_frontmatter("review.md")
+        message = str(exc_info.value)
+        assert "review.md" in message
+        assert "line 2" in message
+        assert "needs architecture input" in message
+
+    def test_error_is_a_single_line(self, tmp_dir):
+        """A raw PyYAML traceback is unreadable once agent logs truncate it."""
+        _write("review.md", CORRUPT_REVIEW)
+        with pytest.raises(ValidationError) as exc_info:
+            read_frontmatter("review.md")
+        assert "\n" not in str(exc_info.value)
+
 
 # ── read_frontmatter_validated ────────────────────────────────────────────────
 
@@ -267,6 +299,13 @@ class TestWriteFrontmatter:
         write_frontmatter("a/b/c/out.md", VALID_REVIEW_FM.copy(), "rfe-review")
         assert os.path.exists("a/b/c/out.md")
 
+    def test_overwrites_unparseable_block_keeping_body(self, tmp_dir):
+        _write("review.md", CORRUPT_REVIEW)
+        write_frontmatter("review.md", VALID_REVIEW_FM.copy(), "rfe-review")
+        data, body = read_frontmatter("review.md")
+        assert data["rfe_id"] == "RHAIRFE-1234"
+        assert "Keep this body." in body
+
 
 # ── update_frontmatter ────────────────────────────────────────────────────────
 
@@ -300,6 +339,64 @@ class TestUpdateFrontmatter:
         write_frontmatter("review.md", VALID_REVIEW_FM.copy(), "rfe-review")
         with pytest.raises(ValidationError):
             update_frontmatter("review.md", {"recommendation": "invalid"}, "rfe-review")
+
+
+class TestUpdateFrontmatterRepair:
+    """An unparseable block must be repairable through frontmatter.py.
+
+    update_frontmatter is the only writer, so if it refuses on corrupt input
+    the caller's only recourse is hand-editing YAML — the thing that corrupted
+    the file to begin with.
+    """
+
+    # What review-agent.md Step 4 actually passes: no auto_revised, which the
+    # schema defaults to False.
+    STEP_4_FIELDS = {
+        "rfe_id": "RFE-015",
+        "score": 8,
+        "pass": True,
+        "recommendation": "submit",
+        "feasibility": "feasible",
+        "needs_attention": True,
+        "needs_attention_reason": "Blocked: needs architecture input",
+        "scores": {"what": 2, "why": 2, "open_to_how": 2, "not_a_task": 1, "right_sized": 1},
+    }
+
+    def test_repairs_block_and_keeps_body(self, tmp_dir):
+        _write("review.md", CORRUPT_REVIEW)
+        update_frontmatter("review.md", dict(self.STEP_4_FIELDS), "rfe-review")
+        data, body = read_frontmatter("review.md")
+        assert data["rfe_id"] == "RFE-015"
+        assert data["auto_revised"] is False  # supplied by schema default
+        assert "Keep this body." in body
+
+    def test_repaired_value_with_colon_round_trips(self, tmp_dir):
+        """The colon that broke the file is fine once yaml.dump does the quoting."""
+        _write("review.md", CORRUPT_REVIEW)
+        update_frontmatter("review.md", dict(self.STEP_4_FIELDS), "rfe-review")
+        data, _ = read_frontmatter("review.md")
+        assert data["needs_attention_reason"] == "Blocked: needs architecture input"
+
+    def test_warns_that_the_block_was_replaced(self, tmp_dir, capsys):
+        _write("review.md", CORRUPT_REVIEW)
+        update_frontmatter("review.md", dict(self.STEP_4_FIELDS), "rfe-review")
+        assert "replacing unparseable frontmatter" in capsys.readouterr().err
+
+    def test_refuses_incomplete_updates(self, tmp_dir):
+        """Validation is the guard — a partial update must not silently drop fields.
+
+        This is the second Step 4 call, which normally relies on merging.
+        """
+        _write("review.md", CORRUPT_REVIEW)
+        with pytest.raises(ValidationError):
+            update_frontmatter("review.md", {"before_score": 8}, "rfe-review")
+
+    def test_leaves_file_untouched_when_it_refuses(self, tmp_dir):
+        _write("review.md", CORRUPT_REVIEW)
+        with pytest.raises(ValidationError):
+            update_frontmatter("review.md", {"before_score": 8}, "rfe-review")
+        with open("review.md") as f:
+            assert f.read() == CORRUPT_REVIEW
 
 
 # ── Initiative schemas ───────────────────────────────────────────────────────

--- a/tests/test_artifact_utils.py
+++ b/tests/test_artifact_utils.py
@@ -69,6 +69,21 @@ CORRUPT_REVIEW = (
     "## Assessor Feedback\n\nKeep this body.\n"
 )
 
+# An empty block written before any fields are stamped, followed by a body that
+# contains a markdown horizontal rule — the shape review agents produce when they
+# write the body first. The rule is what the old regex mistook for the closing
+# delimiter, handing the score table to yaml.safe_load.
+EMPTY_BLOCK_REVIEW = (
+    "---\n"
+    "---\n"
+    "### RFE-015 Review\n\n"
+    "| Criterion | Score |\n"
+    "| --- | --- |\n"
+    "| WHAT | 2/2 |\n\n"
+    "---\n\n"
+    "## Assessor Feedback\n\nKeep this body.\n"
+)
+
 
 # ── Schema & Validation ──────────────────────────────────────────────────────
 
@@ -210,6 +225,46 @@ class TestReadFrontmatter:
         with pytest.raises(ValidationError) as exc_info:
             read_frontmatter("review.md")
         assert "\n" not in str(exc_info.value)
+
+    def test_empty_block_followed_by_horizontal_rule(self, tmp_dir):
+        """An empty block plus a later `---` must not swallow the body as YAML.
+
+        This is the crash a review agent hits when it writes the review body
+        before the frontmatter: the score table's `---` separator became the
+        closing delimiter and yaml.safe_load raised ScannerError.
+        """
+        _write("review.md", EMPTY_BLOCK_REVIEW)
+        data, body = read_frontmatter("review.md")
+        assert data == {}
+        assert "### RFE-015 Review" in body
+        assert "| WHAT | 2/2 |" in body
+        # The empty block is consumed, so a later write replaces rather than
+        # duplicates it.
+        assert not body.startswith("---")
+
+    def test_empty_block_with_no_later_rule(self, tmp_dir):
+        _write("review.md", "---\n---\nBody only.\n")
+        data, body = read_frontmatter("review.md")
+        assert data == {}
+        assert body == "Body only.\n"
+
+    def test_body_horizontal_rule_preserved(self, tmp_dir):
+        _write("test.md", "---\ntitle: Hello\n---\nIntro.\n\n---\n\nMore.\n")
+        data, body = read_frontmatter("test.md")
+        assert data["title"] == "Hello"
+        assert body == "Intro.\n\n---\n\nMore.\n"
+
+    def test_scalar_block_is_not_frontmatter(self, tmp_dir):
+        _write("test.md", "---\njust a string\n---\nBody.\n")
+        data, body = read_frontmatter("test.md")
+        assert data == {}
+        assert body.startswith("---")
+
+    def test_crlf_line_endings(self, tmp_dir):
+        _write("test.md", "---\r\ntitle: Hello\r\n---\r\nBody.\r\n")
+        data, body = read_frontmatter("test.md")
+        assert data["title"] == "Hello"
+        assert "Body." in body
 
 
 # ── read_frontmatter_validated ────────────────────────────────────────────────
@@ -397,6 +452,28 @@ class TestUpdateFrontmatterRepair:
             update_frontmatter("review.md", {"before_score": 8}, "rfe-review")
         with open("review.md") as f:
             assert f.read() == CORRUPT_REVIEW
+
+    def test_stamping_over_an_empty_block_keeps_the_whole_body(self, tmp_dir):
+        """The recovery path slices on the same regex, so it truncated too.
+
+        With the old pattern the mis-detected delimiter sat in the middle of the
+        body, and everything above it — heading, score table — was dropped
+        silently instead of crashing.
+        """
+        _write("review.md", EMPTY_BLOCK_REVIEW)
+        update_frontmatter("review.md", dict(self.STEP_4_FIELDS), "rfe-review")
+        data, body = read_frontmatter("review.md")
+        assert data["rfe_id"] == "RFE-015"
+        assert body == EMPTY_BLOCK_REVIEW.split("---\n---\n", 1)[1]
+
+    def test_stamping_over_an_empty_block_leaves_one_block(self, tmp_dir):
+        _write("review.md", EMPTY_BLOCK_REVIEW)
+        update_frontmatter("review.md", dict(self.STEP_4_FIELDS), "rfe-review")
+        with open("review.md") as f:
+            content = f.read()
+        # The body's own horizontal rule is the only `---` line left below the
+        # block, so a duplicated empty block would show up as an extra one.
+        assert content.count("\n---\n") == 2
 
 
 # ── Initiative schemas ───────────────────────────────────────────────────────

--- a/tests/test_artifact_utils.py
+++ b/tests/test_artifact_utils.py
@@ -572,6 +572,23 @@ class TestBodyRuleNotMistakenForDelimiter:
         assert "Real body." in w
         assert read_frontmatter("w.md")[0]["rfe_id"] == "RFE-015"
 
+    def test_update_keeps_mapping_like_markdown_body(self, tmp_dir):
+        """A body that opens with `---`, a `key: value` line, and a `- ` list
+        item, then another `---`, is invalid YAML but must not be stripped.
+
+        The mapping key alone looks frontmatter-ish, but the top-level sequence
+        item makes it invalid YAML and never real frontmatter — so the region is
+        body and must survive the repair.
+        """
+        _write("review.md", "---\nSummary: needs review\n- investigate\n---\n\nReal body.\n")
+        update_frontmatter("review.md", dict(self.FIELDS), "rfe-review")
+        with open("review.md") as f:
+            out = f.read()
+        assert "Summary: needs review" in out
+        assert "- investigate" in out
+        assert "Real body." in out
+        assert read_frontmatter("review.md")[0]["rfe_id"] == "RFE-015"
+
 
 class TestLooksLikeFrontmatterBlock:
     def test_key_value_lines_are_a_block(self):
@@ -582,6 +599,16 @@ class TestLooksLikeFrontmatterBlock:
 
     def test_nested_mapping_is_a_block(self):
         assert _looks_like_frontmatter_block("scores:\n  what: 2\n  why: 2\n")
+
+    def test_valid_list_value_is_a_block(self):
+        # yaml.dump writes list values as "- item" at column 0; the parse-to-dict
+        # fast path must still recognise this as real frontmatter.
+        assert _looks_like_frontmatter_block("labels:\n- a\n- b\n")
+
+    def test_mapping_then_top_level_sequence_is_not_a_block(self):
+        # A key line followed by a top-level "- " item is invalid YAML and never
+        # real frontmatter — it is a markdown body that must be preserved.
+        assert not _looks_like_frontmatter_block("Summary: needs review\n- investigate\n")
 
     def test_blank_line_means_not_a_block(self):
         assert not _looks_like_frontmatter_block("rfe_id: RFE-1\n\nprose\n")

--- a/tests/test_artifact_utils.py
+++ b/tests/test_artifact_utils.py
@@ -11,6 +11,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 from artifact_utils import (
     SCHEMAS,
     ValidationError,
+    _body_without_frontmatter,
+    _looks_like_frontmatter_block,
     _migrate_fields,
     apply_defaults,
     read_frontmatter,
@@ -266,6 +268,22 @@ class TestReadFrontmatter:
         assert data["title"] == "Hello"
         assert "Body." in body
 
+    def test_regex_handles_raw_crlf(self):
+        """The `\\r?` in _FRONTMATTER_RE is what makes CRLF work — exercise it.
+
+        read_frontmatter opens files in universal-newline mode, which strips
+        every `\\r` before the content reaches the regex, so a file round-trip
+        cannot prove the `\\r?` branch fires. Match the regex against a raw CRLF
+        string to guard that robustness directly.
+        """
+        from artifact_utils import _FRONTMATTER_RE
+
+        raw = "---\r\ntitle: Hello\r\n---\r\nBody.\r\n"
+        match = _FRONTMATTER_RE.match(raw)
+        assert match is not None
+        assert match.group(1) == "title: Hello\r\n"
+        assert raw[match.end() :] == "Body.\r\n"
+
 
 # ── read_frontmatter_validated ────────────────────────────────────────────────
 
@@ -474,6 +492,116 @@ class TestUpdateFrontmatterRepair:
         # The body's own horizontal rule is the only `---` line left below the
         # block, so a duplicated empty block would show up as an extra one.
         assert content.count("\n---\n") == 2
+
+
+class TestBodyRuleNotMistakenForDelimiter:
+    """A `---` horizontal rule in the body must never be taken for the closing
+    delimiter, or the lines above it are silently dropped — the exact
+    crash->silent-truncation failure the repair path was meant to avoid.
+    """
+
+    FIELDS = {
+        "rfe_id": "RFE-015",
+        "score": 8,
+        "pass": True,
+        "recommendation": "submit",
+        "feasibility": "feasible",
+        "needs_attention": False,
+        "scores": {"what": 2, "why": 2, "open_to_how": 2, "not_a_task": 1, "right_sized": 1},
+    }
+
+    # Body-only file (per Step 3) whose body opens with a thematic-break rule and
+    # a heading. The heading is a YAML comment, so the block parses to null — but
+    # it is NOT an empty block, and the second `---` is a body rule.
+    LEADING_RULE_BODY = "---\n## Assessor Feedback\n---\n\nScores look good. Submit.\n"
+
+    def test_read_preserves_leading_rule_section(self, tmp_dir):
+        _write("review.md", self.LEADING_RULE_BODY)
+        data, body = read_frontmatter("review.md")
+        assert data == {}
+        assert body == self.LEADING_RULE_BODY  # nothing consumed
+
+    def test_update_keeps_heading_above_body_rule(self, tmp_dir):
+        _write("review.md", self.LEADING_RULE_BODY)
+        update_frontmatter("review.md", dict(self.FIELDS), "rfe-review")
+        data, body = read_frontmatter("review.md")
+        assert data["rfe_id"] == "RFE-015"
+        assert "## Assessor Feedback" in body
+        assert "Scores look good. Submit." in body
+
+    def test_unparseable_block_without_clean_close_keeps_body(self, tmp_dir):
+        """No valid closing `---`; a body rule is the first one the regex sees.
+
+        On the pre-fix repair path this truncated the body to everything below
+        the body rule, silently dropping the paragraph above it.
+        """
+        content = (
+            "---\n"
+            "rfe_id: RHAIRFE-1595\n"
+            "score: 7\n"
+            "# Review Summary\n"
+            "\n"
+            "Important analysis a stakeholder must not lose.\n"
+            "\n"
+            "---\n"
+            "\n"
+            "## Detailed scores\n"
+        )
+        _write("review.md", content)
+        update_frontmatter("review.md", dict(self.FIELDS), "rfe-review")
+        with open("review.md") as f:
+            out = f.read()
+        assert "Important analysis a stakeholder must not lose." in out
+        # And the file is now valid frontmatter that round-trips.
+        assert read_frontmatter("review.md")[0]["rfe_id"] == "RFE-015"
+
+    def test_write_and_update_agree_on_scalar_block(self, tmp_dir):
+        """The two writers must not disagree on a non-mapping block; both keep
+        the content (lossless) rather than one dropping it.
+        """
+        original = "---\njust a string\n---\nReal body.\n"
+        _write("w.md", original)
+        _write("u.md", original)
+        write_frontmatter("w.md", dict(self.FIELDS), "rfe-review")
+        update_frontmatter("u.md", dict(self.FIELDS), "rfe-review")
+        with open("w.md") as f:
+            w = f.read()
+        with open("u.md") as f:
+            u = f.read()
+        assert w == u
+        assert "Real body." in w
+        assert read_frontmatter("w.md")[0]["rfe_id"] == "RFE-015"
+
+
+class TestLooksLikeFrontmatterBlock:
+    def test_key_value_lines_are_a_block(self):
+        assert _looks_like_frontmatter_block("rfe_id: RFE-1\nscore: 8\n")
+
+    def test_value_with_colon_is_a_block(self):
+        assert _looks_like_frontmatter_block("reason: Blocked: needs input\n")
+
+    def test_nested_mapping_is_a_block(self):
+        assert _looks_like_frontmatter_block("scores:\n  what: 2\n  why: 2\n")
+
+    def test_blank_line_means_not_a_block(self):
+        assert not _looks_like_frontmatter_block("rfe_id: RFE-1\n\nprose\n")
+
+    def test_markdown_heading_is_not_a_block(self):
+        assert not _looks_like_frontmatter_block("## Assessor Feedback\n")
+
+    def test_prose_is_not_a_block(self):
+        assert not _looks_like_frontmatter_block("Some analysis without a colon\n")
+
+    def test_empty_is_not_a_block(self):
+        assert not _looks_like_frontmatter_block("")
+
+    def test_body_without_frontmatter_preserves_non_block(self, tmp_dir):
+        _write("f.md", "---\n## Heading\n---\nbody\n")
+        assert _body_without_frontmatter("f.md") == "---\n## Heading\n---\nbody\n"
+
+    def test_body_without_frontmatter_strips_real_block(self, tmp_dir):
+        _write("f.md", "---\nrfe_id: RFE-1\n---\nbody\n")
+        assert _body_without_frontmatter("f.md") == "body\n"
 
 
 # ── Initiative schemas ───────────────────────────────────────────────────────

--- a/tests/test_collect_recommendations.py
+++ b/tests/test_collect_recommendations.py
@@ -58,6 +58,21 @@ scores:
 Error occurred.
 """
 
+CORRUPT_REVIEW = """\
+---
+rfe_id: {rfe_id}
+score: 6
+pass: false
+recommendation: revise
+feasibility: indeterminate
+needs_attention: true
+needs_attention_reason: Blocked: needs architecture input
+---
+
+## Feedback
+The unquoted colon above makes this block unparseable.
+"""
+
 
 def _run(args):
     result = subprocess.run(
@@ -271,3 +286,15 @@ class TestCollectInitiative:
         assert rc == 0
         groups = _parse_output(out)
         assert "INIT-001" in groups["REASSESS"]
+
+
+class TestCollectErrors:
+    def test_unparseable_frontmatter_goes_to_errors(self, art_dir):
+        """A corrupt review is what --errors exists to find, so it must not crash."""
+        _write(
+            f"{art_dir}/artifacts/rfe-reviews/RFE-001-review.md",
+            CORRUPT_REVIEW.format(rfe_id="RFE-001"),
+        )
+        out, _, rc = _run(["--errors", "RFE-001"])
+        assert rc == 0
+        assert "RFE-001" in _parse_output(out)["ERRORS"]

--- a/tests/test_collect_recommendations.py
+++ b/tests/test_collect_recommendations.py
@@ -303,3 +303,42 @@ class TestCollectErrors:
         out, _, rc = _run(["--errors", "RFE-001"])
         assert rc == 0
         assert "RFE-001" in _parse_output(out)["ERRORS"]
+
+
+class TestCorruptReviewDoesNotCrashAnyMode:
+    """A single malformed review must not take down a batch in any mode.
+
+    read_frontmatter raises ValidationError on a bad block, so every collection
+    mode — not just --errors — has to tolerate it.
+    """
+
+    def test_default_mode_buckets_corrupt_as_error(self, art_dir):
+        _write(
+            f"{art_dir}/artifacts/rfe-reviews/RFE-001-review.md",
+            CORRUPT_REVIEW.format(rfe_id="RFE-001"),
+        )
+        _write(
+            f"{art_dir}/artifacts/rfe-reviews/RFE-002-review.md",
+            REVIEW_TEMPLATE.format(
+                rfe_id="RFE-002",
+                score=9,
+                pass_val="true",
+                recommendation="submit",
+                auto_revised="false",
+            ),
+        )
+        out, _, rc = _run(["RFE-001", "RFE-002"])
+        assert rc == 0
+        groups = _parse_output(out)
+        assert "RFE-001" in groups["ERRORS"]
+        assert "RFE-002" in groups["SUBMIT"]  # the healthy review is unaffected
+
+    def test_reassess_mode_does_not_crash_on_corrupt(self, art_dir):
+        _write(
+            f"{art_dir}/artifacts/rfe-reviews/RFE-001-review.md",
+            CORRUPT_REVIEW.format(rfe_id="RFE-001"),
+        )
+        out, _, rc = _run(["--reassess", "RFE-001"])
+        assert rc == 0
+        # Not reassessable — bucketed as done rather than crashing.
+        assert "RFE-001" in _parse_output(out)["DONE"]

--- a/tests/test_collect_recommendations.py
+++ b/tests/test_collect_recommendations.py
@@ -3,6 +3,7 @@
 
 import os
 import subprocess
+import sys
 
 import pytest
 
@@ -75,8 +76,12 @@ The unquoted colon above makes this block unparseable.
 
 
 def _run(args):
+    # sys.executable, not a bare "python3": the child then runs under the same
+    # interpreter (and dependencies) as the test session. A literal "python3"
+    # resolves to whatever is first on PATH, which under `uv run pytest` is an
+    # ephemeral interpreter without PyYAML installed, so the subprocess crashes.
     result = subprocess.run(
-        ["python3", SCRIPT] + args,
+        [sys.executable, SCRIPT] + args,
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Two ways review frontmatter breaks, both seen in eval runs, both landing on the same code path.

**1. A colon in a hand-written free-text value.** Review agents were writing the frontmatter block themselves:

    needs_attention_reason: Blocked: needs architecture input

`read_frontmatter` called `yaml.safe_load` unguarded, so this surfaced as a raw `ScannerError` traceback. `update_frontmatter` reads before it merges, which meant `frontmatter.py set` — the tool that exists to write correct frontmatter — was itself blocked by the corruption. The only way out was hand-editing YAML, which is what caused it. Two RFEs hit this in a single eval run.

**2. An empty block followed by a horizontal rule.** The delimiter pattern required at least one newline inside the block:

```python
_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?\n)---\s*\n", re.DOTALL)
```

`(.*?\n)` cannot match nothing, so on an empty block (`---\n---\n`) it consumes the closing delimiter and keeps expanding to the next `---` in the body. When the body is a review with a markdown score table, the table separator becomes the closing delimiter and the table is handed to `yaml.safe_load`:

```
yaml.scanner.ScannerError: while scanning a block scalar
```

This crashed `frontmatter.py set` seven times in the 2026-08-10 initiative-speedrun run, every time a review agent wrote the body before stamping frontmatter.

The two are coupled: the repair path for (1) slices the body on that same regex, so without the regex fix it recovers a truncated body and turns the crash into **silent content loss**. On the captured INIT-006 review it kept 59 of 93 body lines, dropping the heading and the score table. Fixing them together is what makes the repair non-lossy.

Changes:

- `review-agent.md` Step 3 now says to write the body only, with no `---` block. Step 4 creates the frontmatter. `fetch-agent.md` already words it this way.
- `read_frontmatter` raises `ValidationError` with the file, line, and offending text on one line. Callers already handle `ValidationError`, so this replaces a traceback with something readable when agent logs truncate it.
- `update_frontmatter` replaces an unparseable block instead of failing. The body is recovered by regex on the delimiters, so it survives. Validation is the guard: the Step 4 field set alone validates (`auto_revised` defaults to false) so the common case self-heals, while a partial update still fails rather than silently dropping fields. `write_frontmatter` reads the body the same tolerant way, since its data is already validated.
- The closing delimiter is anchored to the start of a line and the block is allowed to be empty, so a `---` inside the body is never mistaken for it. `[ \t]*` rather than `\s*` so a blank line after the delimiter stays in the body.
- An empty block is valid frontmatter with no fields, so it returns `({}, body)` with the delimiters consumed. Returning the full content there would leave `write_frontmatter` stacking a second block on the stale one.

No behavior change for well-formed files.

## How Has This Been Tested?

`uv run pytest tests/` — 774 passed. `ruff check` and `ruff format --check` clean.

`TestReadFrontmatter` and `TestUpdateFrontmatterRepair` cover both triggers: the unquoted-colon block (error message locates the line, repair keeps the body, partial updates still refused, file untouched when refused) and the empty-block-plus-table input (body preserved, a horizontal rule in a normal body left alone, scalar blocks, CRLF, and a rewrite over an empty block leaving one block rather than two).

Also replayed the real failure end to end: the exact `frontmatter.py set` command that crashed seven times in the run now succeeds against the captured INIT-006 review file, with the body byte-identical at 93 lines and a single frontmatter block in the output.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or empty review metadata, including clearer validation errors and safer recovery when metadata must be replaced.
  * Reviews with invalid metadata are now recorded as errors without interrupting processing.
  * Prevented body separators and Markdown content from being mistaken for metadata delimiters.

* **Documentation**
  * Updated review instructions to generate only the review body before metadata is added separately.

* **Tests**
  * Added coverage for malformed metadata, recovery behavior, empty blocks, line endings, and continued error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->