### PR TITLE
Skill-parity drift lint for rfe.* / initiative-* forks (follow-up to #143)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
       run: find . -name '*.sh' -type f -exec shellcheck {} +
 
     - name: Check skill parity (rfe.* vs initiative-*)
-      run: python3 scripts/check_skill_parity.py
+      run: python3 scripts/check_skill_parity.py --strict
 
     - name: Run tests
       run: python3 -m pytest tests/ -v -k "not integration"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,5 +44,8 @@ jobs:
     - name: Run shellcheck
       run: find . -name '*.sh' -type f -exec shellcheck {} +
 
+    - name: Check skill parity (rfe.* vs initiative-*)
+      run: python3 scripts/check_skill_parity.py
+
     - name: Run tests
       run: python3 -m pytest tests/ -v -k "not integration"

--- a/scripts/check_skill_parity.py
+++ b/scripts/check_skill_parity.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Lint: enforce parity of invariant procedural regions across skill-pair forks.
+
+The RFE (``rfe.*``) and Initiative (``initiative-*``) skills were created by
+fork-and-modify: each ``initiative-X`` began as a copy of ``rfe.X`` with
+type-specific edits. That is a deliberate, defensible choice for the divergent
+*judgment* prose (rubric, strategic-alignment gating, split calibration). But a
+set of procedural disciplines is meant to stay identical in BOTH forks, and
+copying has repeatedly dropped them by accident (PR #143 shipped, and later
+fixed, an initiative-review that had lost the bounded review poll barrier and the
+reassess cycle, and an initiative-speedrun that had dropped the --priority
+passthrough).
+
+This check flags, for each pair, when one fork contains an invariant its sibling
+lacks. It checks *parity between the pair*, not absolute presence: a pattern
+absent from both forks is consistent (reported only as a warning).
+
+All known drifts are currently fixed, so the baseline (skill_parity_baseline.json)
+is empty and the check is fully enforcing. If a legitimate, intentional
+divergence is ever introduced, add its rule id to the baseline to record it as
+tracked debt; a NEW divergence fails CI. Run with ``--strict`` to also fail when
+a baselined drift has since been fixed (so the baseline cannot accumulate stale
+entries).
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(_HERE)
+DEFAULT_SKILLS_DIR = os.path.join(_REPO_ROOT, ".claude", "skills")
+DEFAULT_BASELINE = os.path.join(_HERE, "skill_parity_baseline.json")
+
+# Rule kinds:
+#   require_both -> `pattern` must appear (>=1x) in BOTH forks, or neither.
+#                   Violated when exactly one fork has it (an invariant was
+#                   dropped from the copy).
+#   arg_parity   -> if `pattern` (a CLI flag) appears in the rfe fork it must
+#                   also appear in the initiative fork. Directional: catches a
+#                   passthrough the copy forgot to forward.
+#
+# Pairs use the on-disk skill dir names: RFE skills are dotted (rfe.review),
+# Initiative skills are dashed (initiative-review).
+RULES = [
+    {
+        "id": "review:poll-barrier",
+        "pair": ("rfe.review", "initiative-review"),
+        "kind": "require_both",
+        "pattern": r"check_review_progress",
+        "desc": "bounded review poll barrier (check_review_progress.py)",
+    },
+    {
+        "id": "review:reassess-cycle",
+        "pair": ("rfe.review", "initiative-review"),
+        "kind": "require_both",
+        "pattern": r"reassess_cycle",
+        "desc": "bounded reassess cycle counter",
+    },
+    {
+        "id": "review:regression-guard",
+        "pair": ("rfe.review", "initiative-review"),
+        "kind": "require_both",
+        "pattern": r"filter_for_revision",
+        "desc": "score-regression guard (filter_for_revision.py)",
+    },
+    {
+        "id": "speedrun:priority",
+        "pair": ("rfe.speedrun", "initiative-speedrun"),
+        "kind": "arg_parity",
+        "pattern": r"--priority",
+        "desc": "per-entry --priority passthrough to the create agent",
+    },
+    {
+        "id": "speedrun:labels",
+        "pair": ("rfe.speedrun", "initiative-speedrun"),
+        "kind": "arg_parity",
+        "pattern": r"--labels",
+        "desc": "per-entry --labels passthrough to the create agent",
+    },
+    {
+        "id": "autofix:wave-barrier",
+        "pair": ("rfe.auto-fix", "initiative-auto-fix"),
+        "kind": "require_both",
+        "pattern": r"wait-for-wave",
+        "desc": "pipeline wave synchronization barrier (wait-for-wave)",
+    },
+]
+
+
+def _read_skill(skill, skills_dir):
+    """Return the SKILL.md text for a skill dir, or '' if it does not exist."""
+    path = os.path.join(skills_dir, skill, "SKILL.md")
+    if not os.path.isfile(path):
+        return ""
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def evaluate_rule(rule, skills_dir):
+    """Evaluate one rule.
+
+    Returns (status, message) where status is one of:
+      "ok"        -> parity holds
+      "violation" -> an invariant is present in one fork but missing in the other
+      "warning"   -> pattern absent from both forks (rule may be stale, or a
+                     shared regression); not a failure
+    """
+    rfe_skill, init_skill = rule["pair"]
+    rfe_text = _read_skill(rfe_skill, skills_dir)
+    init_text = _read_skill(init_skill, skills_dir)
+    rfe_n = len(re.findall(rule["pattern"], rfe_text))
+    init_n = len(re.findall(rule["pattern"], init_text))
+
+    if rule["kind"] == "arg_parity":
+        if rfe_n > 0 and init_n == 0:
+            return "violation", (
+                f"{init_skill} drops '{rule['pattern']}' ({rule['desc']}) "
+                f"that {rfe_skill} passes ({rfe_n}x)"
+            )
+        return "ok", ""
+
+    # require_both
+    if rfe_n > 0 and init_n == 0:
+        return "violation", (
+            f"{init_skill} is missing '{rule['pattern']}' ({rule['desc']}) "
+            f"present in {rfe_skill} ({rfe_n}x)"
+        )
+    if init_n > 0 and rfe_n == 0:
+        return "violation", (
+            f"{rfe_skill} is missing '{rule['pattern']}' ({rule['desc']}) "
+            f"present in {init_skill} ({init_n}x)"
+        )
+    if rfe_n == 0 and init_n == 0:
+        return "warning", (
+            f"'{rule['pattern']}' ({rule['desc']}) absent from BOTH "
+            f"{rfe_skill} and {init_skill} — rule may be stale or a shared regression"
+        )
+    return "ok", ""
+
+
+def load_baseline(path):
+    """Return the set of baselined (known-drift) rule ids."""
+    if not path or not os.path.isfile(path):
+        return set()
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    return set(data.get("known_drifts", []))
+
+
+def run(skills_dir=DEFAULT_SKILLS_DIR, baseline_path=DEFAULT_BASELINE, strict=False):
+    """Run all rules. Return (exit_code, report) where report is a dict."""
+    baseline = load_baseline(baseline_path)
+    report = {"new": [], "known": [], "warnings": [], "resolved": []}
+
+    for rule in RULES:
+        status, msg = evaluate_rule(rule, skills_dir)
+        if status == "violation":
+            if rule["id"] in baseline:
+                report["known"].append((rule["id"], msg))
+            else:
+                report["new"].append((rule["id"], msg))
+        elif status == "warning":
+            report["warnings"].append((rule["id"], msg))
+
+    # Baselined ids that no longer violate -> the drift was fixed; suggest cleanup.
+    rules_by_id = {r["id"]: r for r in RULES}
+    for rid in sorted(baseline):
+        rule = rules_by_id.get(rid)
+        if rule is None:
+            report["resolved"].append((rid, "baseline id has no matching rule"))
+            continue
+        status, _ = evaluate_rule(rule, skills_dir)
+        if status != "violation":
+            report["resolved"].append((rid, "drift fixed — remove from baseline to lock it in"))
+
+    exit_code = 1 if report["new"] else 0
+    if strict and report["resolved"]:
+        exit_code = 1
+    return exit_code, report
+
+
+def _print_report(report, strict):
+    for rid, msg in report["warnings"]:
+        print(f"  ⚠ WARN  [{rid}] {msg}")
+    for rid, msg in report["known"]:
+        print(f"  ○ KNOWN [{rid}] {msg} (baselined)")
+    for rid, msg in report["resolved"]:
+        tag = "FIXED" if not strict else "FIXED (strict → failing)"
+        print(f"  ✓ {tag} [{rid}] {msg}")
+    for rid, msg in report["new"]:
+        print(f"  ✗ DRIFT [{rid}] {msg}")
+
+    if report["new"]:
+        print(
+            f"\nSkill-parity check FAILED: {len(report['new'])} new divergence(s). "
+            "A procedural invariant present in one fork is missing from its sibling. "
+            "Fix the copy, or (if intended) add the rule id to skill_parity_baseline.json."
+        )
+    else:
+        summary = "Skill-parity check passed"
+        if report["known"]:
+            summary += f" ({len(report['known'])} known drift(s) baselined)"
+        print(f"\n{summary}.")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skills-dir", default=DEFAULT_SKILLS_DIR)
+    parser.add_argument("--baseline", default=DEFAULT_BASELINE)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="also fail if a baselined drift has been fixed (forces baseline cleanup)",
+    )
+    args = parser.parse_args(argv)
+    exit_code, report = run(args.skills_dir, args.baseline, args.strict)
+    _print_report(report, args.strict)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_skill_parity.py
+++ b/scripts/check_skill_parity.py
@@ -194,6 +194,10 @@ def run(skills_dir=DEFAULT_SKILLS_DIR, baseline_path=DEFAULT_BASELINE, strict=Fa
             report["resolved"].append((rid, "baseline id has no matching rule"))
             continue
         status, _ = evaluate_rule(rule, skills_dir)
+        if status == "missing":
+            # Already reported (and failing) via report["missing"]; a vanished
+            # skill is not a "resolved" drift.
+            continue
         if status != "violation":
             report["resolved"].append((rid, "drift fixed — remove from baseline to lock it in"))
 

--- a/scripts/check_skill_parity.py
+++ b/scripts/check_skill_parity.py
@@ -91,10 +91,15 @@ RULES = [
 
 
 def _read_skill(skill, skills_dir):
-    """Return the SKILL.md text for a skill dir, or '' if it does not exist."""
+    """Return the SKILL.md text for a skill dir, or None if the file is absent.
+
+    None (missing) is deliberately distinct from "" (present but empty): a
+    monitored skill that has vanished — e.g. renamed without updating the rule —
+    is a structural failure, not an empty comparison.
+    """
     path = os.path.join(skills_dir, skill, "SKILL.md")
     if not os.path.isfile(path):
-        return ""
+        return None
     with open(path, encoding="utf-8") as f:
         return f.read()
 
@@ -103,6 +108,9 @@ def evaluate_rule(rule, skills_dir):
     """Evaluate one rule.
 
     Returns (status, message) where status is one of:
+      "missing"   -> a paired SKILL.md does not exist; the rule cannot be
+                     evaluated. Always a failure, never baseline-suppressible
+                     (fix the rule or restore the skill).
       "ok"        -> parity holds
       "violation" -> an invariant is present in one fork but missing in the other
       "warning"   -> pattern absent from both forks (rule may be stale, or a
@@ -111,6 +119,15 @@ def evaluate_rule(rule, skills_dir):
     rfe_skill, init_skill = rule["pair"]
     rfe_text = _read_skill(rfe_skill, skills_dir)
     init_text = _read_skill(init_skill, skills_dir)
+
+    absent = [s for s, t in ((rfe_skill, rfe_text), (init_skill, init_text)) if t is None]
+    if absent:
+        return "missing", (
+            "monitored skill file(s) not found: "
+            + ", ".join(f"{s}/SKILL.md" for s in absent)
+            + f" — cannot check '{rule['pattern']}' ({rule['desc']})"
+        )
+
     rfe_n = len(re.findall(rule["pattern"], rfe_text))
     init_n = len(re.findall(rule["pattern"], init_text))
 
@@ -153,11 +170,15 @@ def load_baseline(path):
 def run(skills_dir=DEFAULT_SKILLS_DIR, baseline_path=DEFAULT_BASELINE, strict=False):
     """Run all rules. Return (exit_code, report) where report is a dict."""
     baseline = load_baseline(baseline_path)
-    report = {"new": [], "known": [], "warnings": [], "resolved": []}
+    report = {"new": [], "known": [], "warnings": [], "resolved": [], "missing": []}
 
     for rule in RULES:
         status, msg = evaluate_rule(rule, skills_dir)
-        if status == "violation":
+        if status == "missing":
+            # A vanished monitored skill always fails, regardless of baseline —
+            # it means a rule is stale or a skill was renamed/deleted.
+            report["missing"].append((rule["id"], msg))
+        elif status == "violation":
             if rule["id"] in baseline:
                 report["known"].append((rule["id"], msg))
             else:
@@ -176,7 +197,7 @@ def run(skills_dir=DEFAULT_SKILLS_DIR, baseline_path=DEFAULT_BASELINE, strict=Fa
         if status != "violation":
             report["resolved"].append((rid, "drift fixed — remove from baseline to lock it in"))
 
-    exit_code = 1 if report["new"] else 0
+    exit_code = 1 if (report["new"] or report["missing"]) else 0
     if strict and report["resolved"]:
         exit_code = 1
     return exit_code, report
@@ -184,20 +205,28 @@ def run(skills_dir=DEFAULT_SKILLS_DIR, baseline_path=DEFAULT_BASELINE, strict=Fa
 
 def _print_report(report, strict):
     for rid, msg in report["warnings"]:
-        print(f"  ⚠ WARN  [{rid}] {msg}")
+        print(f"  ⚠ WARN    [{rid}] {msg}")
     for rid, msg in report["known"]:
-        print(f"  ○ KNOWN [{rid}] {msg} (baselined)")
+        print(f"  ○ KNOWN   [{rid}] {msg} (baselined)")
     for rid, msg in report["resolved"]:
         tag = "FIXED" if not strict else "FIXED (strict → failing)"
         print(f"  ✓ {tag} [{rid}] {msg}")
+    for rid, msg in report["missing"]:
+        print(f"  ✗ MISSING [{rid}] {msg}")
     for rid, msg in report["new"]:
-        print(f"  ✗ DRIFT [{rid}] {msg}")
+        print(f"  ✗ DRIFT   [{rid}] {msg}")
 
-    if report["new"]:
+    if report["missing"] or report["new"]:
+        parts = []
+        if report["missing"]:
+            parts.append(f"{len(report['missing'])} missing skill file(s)")
+        if report["new"]:
+            parts.append(f"{len(report['new'])} new divergence(s)")
         print(
-            f"\nSkill-parity check FAILED: {len(report['new'])} new divergence(s). "
-            "A procedural invariant present in one fork is missing from its sibling. "
-            "Fix the copy, or (if intended) add the rule id to skill_parity_baseline.json."
+            f"\nSkill-parity check FAILED: {', '.join(parts)}. "
+            "A procedural invariant present in one fork is missing from its sibling, "
+            "or a monitored skill has vanished. Fix the copy / restore the skill / update "
+            "the rule, or (for an intended divergence) add the rule id to the baseline."
         )
     else:
         summary = "Skill-parity check passed"

--- a/scripts/skill_parity_baseline.json
+++ b/scripts/skill_parity_baseline.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Known, intentional rfe.* / initiative-* skill-parity drifts, recorded so check_skill_parity.py can land green while a divergence is deliberately accepted. Each entry is a rule id from check_skill_parity.RULES; a NEW (unlisted) drift fails CI. The list is currently EMPTY: the drifts that PR #143 introduced and fixed (poll barrier, reassess cycle, --priority) all hold in both forks today, so the check is fully enforcing. Only add an id here for a divergence you intend to keep, and remove it once resolved (run with --strict to catch stale entries).",
+  "known_drifts": []
+}

--- a/tests/test_check_skill_parity.py
+++ b/tests/test_check_skill_parity.py
@@ -12,29 +12,47 @@ import check_skill_parity as csp  # noqa: E402
 REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
 
 
-def _make_pair(tmp_path, review_rfe="", review_init="", speedrun_rfe="", speedrun_init=""):
-    """Create a minimal skills dir with the pairs the tests exercise.
+def _all_skills():
+    """Every skill dir referenced by any rule (both forks)."""
+    skills = set()
+    for rule in csp.RULES:
+        skills.update(rule["pair"])
+    return sorted(skills)
 
-    Dir names match the on-disk convention the rules target: RFE dotted,
-    Initiative dashed.
+
+def _make_skills(tmp_path, content=None, omit=()):
+    """Build a skills dir containing every configured skill pair.
+
+    content: {skill_dir: SKILL.md text} overrides (default empty body).
+    omit:    skill dirs to NOT create at all (to exercise the missing-file path).
+    Creating every pair by default keeps unrelated rules from tripping the
+    missing-file failure during a targeted test.
     """
+    content = content or {}
     skills = tmp_path / "skills"
-    for name, text in [
-        ("rfe.review", review_rfe),
-        ("initiative-review", review_init),
-        ("rfe.speedrun", speedrun_rfe),
-        ("initiative-speedrun", speedrun_init),
-    ]:
-        d = skills / name
+    for skill in _all_skills():
+        if skill in omit:
+            continue
+        d = skills / skill
         d.mkdir(parents=True)
-        (d / "SKILL.md").write_text(text)
+        (d / "SKILL.md").write_text(content.get(skill, ""))
     return str(skills)
 
 
+def _run(skills, baseline_entries=None, strict=False, tmp_path=None):
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"known_drifts": baseline_entries or []}))
+    return csp.run(skills_dir=skills, baseline_path=str(baseline), strict=strict)
+
+
+# ── Shipped tree ────────────────────────────────────────────────────────────
+
+
 def test_real_tree_passes_with_empty_baseline():
-    # The shipped tree has no known drifts, and the baseline is empty, so the
+    # The shipped tree has no known drifts and the baseline is empty, so the
     # check is fully enforcing and must be green — proving the PR #143 drifts
-    # (poll barrier, reassess cycle, --priority) still hold in both forks.
+    # (poll barrier, reassess cycle, --priority) still hold in both forks and
+    # that every monitored skill exists.
     exit_code, report = csp.run(
         skills_dir=os.path.join(REPO_ROOT, ".claude", "skills"),
         baseline_path=os.path.join(REPO_ROOT, "scripts", "skill_parity_baseline.json"),
@@ -43,6 +61,7 @@ def test_real_tree_passes_with_empty_baseline():
     assert not report["new"], report["new"]
     assert not report["known"], report["known"]
     assert not report["warnings"], report["warnings"]
+    assert not report["missing"], report["missing"]
 
 
 def test_shipped_baseline_is_empty():
@@ -50,31 +69,32 @@ def test_shipped_baseline_is_empty():
     assert baseline == set()
 
 
+# ── Drift detection ─────────────────────────────────────────────────────────
+
+
 def test_new_require_both_drift_is_caught(tmp_path):
-    skills = _make_pair(
+    skills = _make_skills(
         tmp_path,
-        review_rfe="run check_review_progress.py and reassess_cycle and filter_for_revision",
-        review_init="just wait for all to complete",  # dropped all three
+        content={
+            "rfe.review": "check_review_progress and reassess_cycle and filter_for_revision",
+            "initiative-review": "just wait for all to complete",  # dropped all three
+        },
     )
-    baseline = tmp_path / "baseline.json"
-    baseline.write_text(json.dumps({"known_drifts": []}))
-    exit_code, report = csp.run(skills_dir=skills, baseline_path=str(baseline))
+    exit_code, report = _run(skills, tmp_path=tmp_path)
     assert exit_code == 1
     new_ids = {rid for rid, _ in report["new"]}
-    assert "review:poll-barrier" in new_ids
-    assert "review:reassess-cycle" in new_ids
-    assert "review:regression-guard" in new_ids
+    assert {"review:poll-barrier", "review:reassess-cycle", "review:regression-guard"} <= new_ids
 
 
 def test_new_arg_parity_drift_is_caught(tmp_path):
-    skills = _make_pair(
+    skills = _make_skills(
         tmp_path,
-        speedrun_rfe="create --priority <priority> --labels <labels> <prompt>",
-        speedrun_init="create <prompt>",  # dropped --priority and --labels
+        content={
+            "rfe.speedrun": "create --priority <priority> --labels <labels> <prompt>",
+            "initiative-speedrun": "create <prompt>",  # dropped --priority and --labels
+        },
     )
-    baseline = tmp_path / "baseline.json"
-    baseline.write_text(json.dumps({"known_drifts": []}))
-    exit_code, report = csp.run(skills_dir=skills, baseline_path=str(baseline))
+    exit_code, report = _run(skills, tmp_path=tmp_path)
     assert exit_code == 1
     new_ids = {rid for rid, _ in report["new"]}
     assert "speedrun:priority" in new_ids
@@ -82,45 +102,80 @@ def test_new_arg_parity_drift_is_caught(tmp_path):
 
 
 def test_baseline_suppresses_known_drift(tmp_path):
-    skills = _make_pair(
+    skills = _make_skills(
         tmp_path,
-        speedrun_rfe="create --priority <priority> <prompt>",
-        speedrun_init="create <prompt>",
+        content={
+            "rfe.speedrun": "create --priority <priority> <prompt>",
+            "initiative-speedrun": "",
+        },
     )
-    baseline = tmp_path / "baseline.json"
-    baseline.write_text(json.dumps({"known_drifts": ["speedrun:priority"]}))
-    exit_code, report = csp.run(skills_dir=skills, baseline_path=str(baseline))
+    exit_code, report = _run(skills, baseline_entries=["speedrun:priority"], tmp_path=tmp_path)
     assert exit_code == 0
     assert {rid for rid, _ in report["known"]} == {"speedrun:priority"}
 
 
 def test_arg_parity_not_violated_when_rfe_lacks_flag(tmp_path):
     # If the rfe fork never passes --priority, the initiative fork isn't required to.
-    skills = _make_pair(
-        tmp_path,
-        speedrun_rfe="create <prompt>",
-        speedrun_init="create <prompt>",
-    )
-    baseline = tmp_path / "baseline.json"
-    baseline.write_text(json.dumps({"known_drifts": []}))
-    exit_code, report = csp.run(skills_dir=skills, baseline_path=str(baseline))
+    skills = _make_skills(tmp_path)  # all present, all empty
+    exit_code, report = _run(skills, tmp_path=tmp_path)
     assert exit_code == 0
     assert not report["new"]
+    assert not report["missing"]
 
 
 def test_resolved_baseline_entry_reported_and_strict_fails(tmp_path):
     # Baseline claims a drift, but both forks now have the invariant -> resolved.
-    skills = _make_pair(
+    skills = _make_skills(
         tmp_path,
-        speedrun_rfe="create --priority <priority> <prompt>",
-        speedrun_init="create --priority <priority> <prompt>",
+        content={
+            "rfe.speedrun": "create --priority <priority> <prompt>",
+            "initiative-speedrun": "create --priority <priority> <prompt>",
+        },
     )
-    baseline = tmp_path / "baseline.json"
-    baseline.write_text(json.dumps({"known_drifts": ["speedrun:priority"]}))
-
-    exit_code, report = csp.run(skills_dir=skills, baseline_path=str(baseline))
+    exit_code, report = _run(skills, baseline_entries=["speedrun:priority"], tmp_path=tmp_path)
     assert exit_code == 0
     assert any(rid == "speedrun:priority" for rid, _ in report["resolved"])
 
-    exit_code_strict, _ = csp.run(skills_dir=skills, baseline_path=str(baseline), strict=True)
+    exit_code_strict, _ = _run(
+        skills, baseline_entries=["speedrun:priority"], strict=True, tmp_path=tmp_path
+    )
     assert exit_code_strict == 1
+
+
+# ── Missing skill files (a monitored skill vanished / rule went stale) ───────
+
+
+def test_missing_skill_file_fails(tmp_path):
+    # A renamed/deleted skill must fail the check, not silently pass.
+    skills = _make_skills(tmp_path, omit={"initiative-speedrun"})
+    exit_code, report = _run(skills, tmp_path=tmp_path)
+    assert exit_code == 1
+    missing_ids = {rid for rid, _ in report["missing"]}
+    assert {"speedrun:priority", "speedrun:labels"} <= missing_ids
+    # It's reported as missing, not as an arg-parity drift.
+    assert not report["new"]
+
+
+def test_missing_arg_parity_source_is_not_silently_ok(tmp_path):
+    # Previously a missing rfe (source) skill made arg_parity return "ok" (exit 0).
+    skills = _make_skills(tmp_path, omit={"rfe.speedrun"})
+    exit_code, report = _run(skills, tmp_path=tmp_path)
+    assert exit_code == 1
+    assert {rid for rid, _ in report["missing"]} >= {"speedrun:priority", "speedrun:labels"}
+
+
+def test_missing_is_not_suppressed_by_baseline(tmp_path):
+    # A vanished skill fails even if its rule id is baselined — baseline is for
+    # intentional divergences, not for a structurally broken/renamed skill.
+    skills = _make_skills(tmp_path, omit={"initiative-review"})
+    exit_code, report = _run(
+        skills,
+        baseline_entries=[
+            "review:poll-barrier",
+            "review:reassess-cycle",
+            "review:regression-guard",
+        ],
+        tmp_path=tmp_path,
+    )
+    assert exit_code == 1
+    assert report["missing"]

--- a/tests/test_check_skill_parity.py
+++ b/tests/test_check_skill_parity.py
@@ -162,6 +162,8 @@ def test_missing_arg_parity_source_is_not_silently_ok(tmp_path):
     exit_code, report = _run(skills, tmp_path=tmp_path)
     assert exit_code == 1
     assert {rid for rid, _ in report["missing"]} >= {"speedrun:priority", "speedrun:labels"}
+    # Missing must be reported as missing, not as a spurious arg-parity drift.
+    assert not report["new"]
 
 
 def test_missing_is_not_suppressed_by_baseline(tmp_path):
@@ -179,3 +181,7 @@ def test_missing_is_not_suppressed_by_baseline(tmp_path):
     )
     assert exit_code == 1
     assert report["missing"]
+    # A missing+baselined rule is reported only as missing, not also as resolved.
+    missing_ids = {rid for rid, _ in report["missing"]}
+    resolved_ids = {rid for rid, _ in report["resolved"]}
+    assert not (missing_ids & resolved_ids)

--- a/tests/test_check_skill_parity.py
+++ b/tests/test_check_skill_parity.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_skill_parity.py — the rfe.* / initiative-* drift lint."""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import check_skill_parity as csp  # noqa: E402
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+
+
+def _make_pair(tmp_path, review_rfe="", review_init="", speedrun_rfe="", speedrun_init=""):
+    """Create a minimal skills dir with the pairs the tests exercise.
+
+    Dir names match the on-disk convention the rules target: RFE dotted,
+    Initiative dashed.
+    """
+    skills = tmp_path / "skills"
+    for name, text in [
+        ("rfe.review", review_rfe),
+        ("initiative-review", review_init),
+        ("rfe.speedrun", speedrun_rfe),
+        ("initiative-speedrun", speedrun_init),
+    ]:
+        d = skills / name
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(text)
+    return str(skills)
+
+
+def test_real_tree_passes_with_empty_baseline():
+    # The shipped tree has no known drifts, and the baseline is empty, so the
+    # check is fully enforcing and must be green — proving the PR #143 drifts
+    # (poll barrier, reassess cycle, --priority) still hold in both forks.
+    exit_code, report = csp.run(
+        skills_dir=os.path.join(REPO_ROOT, ".claude", "skills"),
+        baseline_path=os.path.join(REPO_ROOT, "scripts", "skill_parity_baseline.json"),
+    )
+    assert exit_code == 0
+    assert not report["new"], report["new"]
+    assert not report["known"], report["known"]
+    assert not report["warnings"], report["warnings"]
+
+
+def test_shipped_baseline_is_empty():
+    baseline = csp.load_baseline(os.path.join(REPO_ROOT, "scripts", "skill_parity_baseline.json"))
+    assert baseline == set()
+
+
+def test_new_require_both_drift_is_caught(tmp_path):
+    skills = _make_pair(
+        tmp_path,
+        review_rfe="run check_review_progress.py and reassess_cycle and filter_for_revision",
+        review_init="just wait for all to complete",  # dropped all three
+    )
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"known_drifts": []}))
+    exit_code, report = csp.run(skills_dir=skills, baseline_path=str(baseline))
+    assert exit_code == 1
+    new_ids = {rid for rid, _ in report["new"]}
+    assert "review:poll-barrier" in new_ids
+    assert "review:reassess-cycle" in new_ids
+    assert "review:regression-guard" in new_ids
+
+
+def test_new_arg_parity_drift_is_caught(tmp_path):
+    skills = _make_pair(
+        tmp_path,
+        speedrun_rfe="create --priority <priority> --labels <labels> <prompt>",
+        speedrun_init="create <prompt>",  # dropped --priority and --labels
+    )
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"known_drifts": []}))
+    exit_code, report = csp.run(skills_dir=skills, baseline_path=str(baseline))
+    assert exit_code == 1
+    new_ids = {rid for rid, _ in report["new"]}
+    assert "speedrun:priority" in new_ids
+    assert "speedrun:labels" in new_ids
+
+
+def test_baseline_suppresses_known_drift(tmp_path):
+    skills = _make_pair(
+        tmp_path,
+        speedrun_rfe="create --priority <priority> <prompt>",
+        speedrun_init="create <prompt>",
+    )
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"known_drifts": ["speedrun:priority"]}))
+    exit_code, report = csp.run(skills_dir=skills, baseline_path=str(baseline))
+    assert exit_code == 0
+    assert {rid for rid, _ in report["known"]} == {"speedrun:priority"}
+
+
+def test_arg_parity_not_violated_when_rfe_lacks_flag(tmp_path):
+    # If the rfe fork never passes --priority, the initiative fork isn't required to.
+    skills = _make_pair(
+        tmp_path,
+        speedrun_rfe="create <prompt>",
+        speedrun_init="create <prompt>",
+    )
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"known_drifts": []}))
+    exit_code, report = csp.run(skills_dir=skills, baseline_path=str(baseline))
+    assert exit_code == 0
+    assert not report["new"]
+
+
+def test_resolved_baseline_entry_reported_and_strict_fails(tmp_path):
+    # Baseline claims a drift, but both forks now have the invariant -> resolved.
+    skills = _make_pair(
+        tmp_path,
+        speedrun_rfe="create --priority <priority> <prompt>",
+        speedrun_init="create --priority <priority> <prompt>",
+    )
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"known_drifts": ["speedrun:priority"]}))
+
+    exit_code, report = csp.run(skills_dir=skills, baseline_path=str(baseline))
+    assert exit_code == 0
+    assert any(rid == "speedrun:priority" for rid, _ in report["resolved"])
+
+    exit_code_strict, _ = csp.run(skills_dir=skills, baseline_path=str(baseline), strict=True)
+    assert exit_code_strict == 1


### PR DESCRIPTION
**Follow-up to #143** — a CI guard against `rfe.*` / `initiative-*` skill-fork drift.

The `initiative-*` skills were created by forking the `rfe.*` skills. That's fine for the parts that legitimately differ (rubric, strategic-alignment gating, split calibration), but the *procedural spine* is supposed to stay identical — and it kept drifting. #143 shipped, then fixed, an `initiative-review` that had lost the bounded review poll barrier and the reassess cycle, and an `initiative-speedrun` that had dropped the `--priority` passthrough. Nothing prevents that recurring on the next edit.

## What this adds
- **`scripts/check_skill_parity.py`** — checks, per skill pair, that an invariant present in one fork is present in the other (bounded poll barrier, reassess cycle, `filter_for_revision` guard, `--priority`/`--labels` passthrough, `wait-for-wave`). Parity-based: a pattern absent from *both* forks is fine; one-sided is a failure.
- **wired into the `Lint` workflow** so a new divergence fails CI.
- **`scripts/skill_parity_baseline.json`** — empty. All the PR #143 drifts are fixed, so the check is fully enforcing today; an intentional future divergence can be recorded here as tracked debt (and `--strict` flags stale entries).
- **`tests/test_check_skill_parity.py`** — covers detection, baseline suppression, resolution, and that the shipped tree passes with the empty baseline.

## Relationship to #143
This is the trimmed-down survivor of the original draft. The registry/score-field half was **dropped** — #143 already fixed the phantom initiative report keys inline and added `tests/test_score_field_registry.py`, which guards the score-field set across the schema, run report, and PDF. This PR covers the complementary gap that test does *not*: **skill-prose discipline** across the forks.

Validation: `check_skill_parity.py` exits 0 on `main`; new tests pass; `ruff check`/`ruff format` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to detect inconsistencies between related RFE and Initiative skills.
  * Added reporting for missing files, parity violations, warnings, and approved baseline differences.
  * Added strict checking to flag previously accepted differences that have been resolved.

* **Bug Fixes**
  * CI now automatically runs skill parity validation and fails when required consistency checks do not pass.

* **Tests**
  * Added comprehensive coverage for parity detection, baseline handling, missing files, and conditional arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->