### PR TITLE
Compute run report before/after averages over the same items

### DIFF
--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -144,7 +144,10 @@ def build_report(
         before = data.get("before_score")
         if before is not None:
             entry["before_score"] = before
-            before_score_list.append(before)
+        # An item that was never revised has no before_score, but its "before"
+        # is its "after". Averaging only the revised items would compare two
+        # different populations and report a phantom regression.
+        before_score_list.append(before if before is not None else score)
 
         if data.get("auto_revised") and before is not None and before != score:
             entry["revision_cycles"] = 1
@@ -152,13 +155,14 @@ def build_report(
             entry["revision_cycles"] = 0
 
         scores = data.get("scores") or {}
+        before_scores = data.get("before_scores") or {}
         for f in score_fields:
             if f in scores:
                 after_totals[f].append(scores[f])
-        before_scores = data.get("before_scores") or {}
-        for f in score_fields:
             if f in before_scores:
                 before_totals[f].append(before_scores[f])
+            elif f in scores:
+                before_totals[f].append(scores[f])
 
         kids = children_map.get(item_id)
         if kids:

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -201,6 +201,122 @@ class TestSplitChildrenIncluded:
         assert report["per_rfe"][0]["id"] == "RHAIRFE-1234"
 
 
+REVISED_REVIEW_TEMPLATE = """\
+---
+rfe_id: {rfe_id}
+score: {score}
+pass: {pass_val}
+recommendation: {recommendation}
+feasibility: feasible
+auto_revised: true
+needs_attention: false
+before_score: {before_score}
+scores:
+  what: 2
+  why: 2
+  open_to_how: 2
+  not_a_task: 2
+  right_sized: {right_sized}
+before_scores:
+  what: 1
+  why: 1
+  open_to_how: 2
+  not_a_task: 2
+  right_sized: {right_sized}
+---
+
+## Feedback
+Revised.
+"""
+
+
+class TestScoreAveragePopulations:
+    """before/after averages must cover the same items.
+
+    An unrevised RFE has no before_score, so averaging only the items that
+    carry one compares 16 items against 17 and reports a regression that
+    never happened — what the 2026-08-10 run showed as "9.4 -> 9.2" when
+    nothing had been revised at all.
+    """
+
+    def _review(self, art_dir, rfe_id, score, right_sized=2):
+        _write(
+            f"{art_dir}/rfe-tasks/{rfe_id}.md",
+            TASK_TEMPLATE.format(rfe_id=rfe_id, extra=""),
+        )
+        _write(
+            f"{art_dir}/rfe-reviews/{rfe_id}-review.md",
+            REVIEW_TEMPLATE.format(
+                rfe_id=rfe_id,
+                score=score,
+                pass_val="true",
+                recommendation="submit",
+                right_sized=right_sized,
+            ),
+        )
+
+    def test_unrevised_low_scorer_does_not_fake_a_regression(self, art_dir):
+        for i in range(1, 4):
+            self._review(art_dir, f"RHAIRFE-{1000 + i}", 10)
+        # The odd one out: never revised, so no before_score, and a low score.
+        self._review(art_dir, "RHAIRFE-2000", 2)
+
+        ids = [f"RHAIRFE-{1000 + i}" for i in range(1, 4)] + ["RHAIRFE-2000"]
+        report = build_report(ids, "20260404-170041", 5, [], [], artifacts_dir=art_dir)
+
+        assert report["before_scores_avg"]["total"] == report["after_scores_avg"]["total"]
+        assert report["after_scores_avg"]["total"] == 8.0
+
+    def test_unrevised_item_omits_before_score_in_its_entry(self, art_dir):
+        self._review(art_dir, "RHAIRFE-2000", 7)
+        report = build_report(["RHAIRFE-2000"], "20260404-170041", 5, [], [], artifacts_dir=art_dir)
+        entry = report["per_rfe"][0]
+        assert "before_score" not in entry
+        assert entry["after_score"] == 7
+
+    def test_revised_item_still_shows_improvement(self, art_dir):
+        self._review(art_dir, "RHAIRFE-1001", 10)
+        _write(
+            f"{art_dir}/rfe-tasks/RHAIRFE-1002.md",
+            TASK_TEMPLATE.format(rfe_id="RHAIRFE-1002", extra=""),
+        )
+        _write(
+            f"{art_dir}/rfe-reviews/RHAIRFE-1002-review.md",
+            REVISED_REVIEW_TEMPLATE.format(
+                rfe_id="RHAIRFE-1002",
+                score=10,
+                pass_val="true",
+                recommendation="submit",
+                before_score=4,
+                right_sized=2,
+            ),
+        )
+
+        report = build_report(
+            ["RHAIRFE-1001", "RHAIRFE-1002"], "20260404-170041", 5, [], [], artifacts_dir=art_dir
+        )
+
+        # (10 + 4) / 2 vs (10 + 10) / 2 — the unrevised item contributes 10 to
+        # both sides, so only the real revision moves the average.
+        assert report["before_scores_avg"]["total"] == 7.0
+        assert report["after_scores_avg"]["total"] == 10.0
+        # Per-criterion follows the same rule.
+        assert report["before_scores_avg"]["what"] == 1.5
+        assert report["after_scores_avg"]["what"] == 2.0
+
+    def test_criterion_averages_cover_the_same_items(self, art_dir):
+        for i in range(1, 4):
+            self._review(art_dir, f"RHAIRFE-{1000 + i}", 10)
+        self._review(art_dir, "RHAIRFE-2000", 8, right_sized=0)
+
+        ids = [f"RHAIRFE-{1000 + i}" for i in range(1, 4)] + ["RHAIRFE-2000"]
+        report = build_report(ids, "20260404-170041", 5, [], [], artifacts_dir=art_dir)
+
+        for field in ("what", "why", "open_to_how", "not_a_task", "right_sized"):
+            assert report["before_scores_avg"][field] == report["after_scores_avg"][field], field
+        assert report["after_scores_avg"]["right_sized"] == 1.5
+
+
 class TestParseRunId:
     def test_yyyymmdd_hhmmss_format(self):
         """YYYYMMDD-HHMMSS passes through unchanged."""


### PR DESCRIPTION
## Description

`before_scores_avg` was averaged only over items that carry a `before_score`, while `after_scores_avg` averaged every item. Items that were never revised have no `before_score`, so the two averages covered different populations and the report showed a regression that never happened.

The 2026-08-10 initiative-speedrun run reported:

    before_scores_avg:  total: 9.4   what: 2.0  why: 1.5  scope: 2.0
    after_scores_avg:   total: 9.2   what: 1.9  why: 1.4  scope: 1.9

with `revision_cycles: 0` on all 17 initiatives — nothing was revised, so the two numbers must be equal. 16 items had a `before_score`; the 17th (INIT-012, score 5) pulled only the after average down. The same artifact showed on all five criteria.

An unrevised item's before is its after, so the fix falls back to the item's own score for the total and for each criterion. Report-only, and shared by the RFE and Initiative paths.

Per-item entries are unchanged: an item that was never revised still omits `before_score` in its own entry. Only the averages changed.

## How Has This Been Tested?

`uv run pytest tests/` — 761 passed. `ruff check` and `ruff format --check` clean.

Four new tests in `TestScoreAveragePopulations` cover the unrevised-low-scorer case, the per-criterion equivalent, entry-level `before_score` omission, and a genuinely revised item still showing improvement.

Replayed the 2026-08-10 run's own report through the fixed code:

    reported:  before=9.4 (n=16)  after=9.2 (n=17)
    fixed:     before=9.2 (n=17)  after=9.2 (n=17)

which matches the zero revisions the run actually performed.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected score-average reporting for items without revisions.
  * Unrevised items now contribute equally to before-and-after averages instead of appearing to regress.
  * Per-criterion averages now consistently include the same items.
  * Individual unrevised entries no longer display an unavailable before-score.
  * Revised items continue to show their actual improvements.

* **Tests**
  * Added regression coverage for mixed revised and unrevised score reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->