### PR TITLE
Stop skills from steering agents into denied Bash calls

### DIFF
--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -17,9 +17,9 @@ If `artifacts/strat-reviews/` exists and contains review files for the strategie
 
 ## Architecture Context
 
-Check for architecture context in `.context/architecture-context/architecture/`. If a `rhoai-*` directory exists, read `PLATFORM.md` and the component docs relevant to each strategy.
+Read `.context/architecture-context/LATEST_VERSION` directly with the Read tool to get the version directory name (e.g., `rhoai-3.4-ea.2`). Do NOT use Glob or Bash to check existence first — just Read it; if the file is missing, Read returns an error, which is the fallback condition below. Then Read `.context/architecture-context/architecture/<version>/PLATFORM.md` and the component docs relevant to each strategy.
 
-If architecture context is not available, skip this review and output:
+If the Read on `LATEST_VERSION` returns an error (file not found) or the PLATFORM.md read fails, skip this review and output:
 ```
 Architecture review skipped — no architecture context available.
 ```

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -28,6 +28,8 @@ Architecture review skipped — no architecture context available.
 
 Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter can run past 30 lines, so pass `limit: 40` to Read for this filtering pass rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
+For each active overlay, read its `## Fact` and `## Impact on Strategies` sections — the correction lives in the body, not the frontmatter, so the filtering pass above is not enough on its own.
+
 When reviewing a strategy's architecture claims, check whether any active overlay corrects or updates the information the strategy references. If a strategy uses outdated information that an overlay corrects (e.g., references KFP SDK 2.15 when an overlay says 2.16), flag it as a finding. Overlays take precedence over the generated architecture docs when they conflict.
 
 When overlays are applied, print which ones were used:

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -26,7 +26,7 @@ Architecture review skipped — no architecture context available.
 
 ## Architecture Context Overlays
 
-Check for overlay files in `.context/architecture-context/overlays/`. If the directory exists, read all `*.md` files (excluding `README.md`) with `status: active` in their frontmatter. These are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter sits in the first few lines, so pass `limit` to Read rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — Bash is denied in headless runs, so a loop costs a turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
 When reviewing a strategy's architecture claims, check whether any active overlay corrects or updates the information the strategy references. If a strategy uses outdated information that an overlay corrects (e.g., references KFP SDK 2.15 when an overlay says 2.16), flag it as a finding. Overlays take precedence over the generated architecture docs when they conflict.
 

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -17,7 +17,7 @@ If `artifacts/strat-reviews/` exists and contains review files for the strategie
 
 ## Architecture Context
 
-Read `.context/architecture-context/LATEST_VERSION` directly with the Read tool to get the version directory name (e.g., `rhoai-3.4-ea.2`). Do NOT use Glob or Bash to check existence first — just Read it; if the file is missing, Read returns an error, which is the fallback condition below. Then Read `.context/architecture-context/architecture/<version>/PLATFORM.md` and the component docs relevant to each strategy.
+Read `.context/architecture-context/LATEST_VERSION` directly with the Read tool to get the version directory name (e.g., `rhoai-3.4-ea.2`). Do NOT use Glob or Bash to check existence first — just Read it; if the file is missing, Read returns an error, which is the fallback condition below. Then Read `.context/architecture-context/architecture/<version>/PLATFORM.md` and the component docs relevant to each strategy. Use these to ground the architecture assessment in the actual platform.
 
 If the Read on `LATEST_VERSION` returns an error (file not found) or the PLATFORM.md read fails, skip this review and output:
 ```

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -26,9 +26,7 @@ Architecture review skipped — no architecture context available.
 
 ## Architecture Context Overlays
 
-Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter can run past 30 lines, so pass `limit: 40` to Read for this filtering pass rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
-
-For each active overlay, read its `## Fact` and `## Impact on Strategies` sections — the correction lives in the body, not the frontmatter, so the filtering pass above is not enough on its own.
+Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` in full and keep the ones with `status: active` in their frontmatter — this skill filters on status alone, so a frontmatter-only pre-pass saves nothing, and the correction lives in the body's `## Fact` and `## Impact on Strategies` sections anyway. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
 When reviewing a strategy's architecture claims, check whether any active overlay corrects or updates the information the strategy references. If a strategy uses outdated information that an overlay corrects (e.g., references KFP SDK 2.15 when an overlay says 2.16), flag it as a finding. Overlays take precedence over the generated architecture docs when they conflict.
 

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -26,7 +26,7 @@ Architecture review skipped — no architecture context available.
 
 ## Architecture Context Overlays
 
-Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter sits in the first few lines, so pass `limit` to Read rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — Bash is denied in headless runs, so a loop costs a turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter can run past 30 lines, so pass `limit: 40` to Read for this filtering pass rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
 When reviewing a strategy's architecture claims, check whether any active overlay corrects or updates the information the strategy references. If a strategy uses outdated information that an overlay corrects (e.g., references KFP SDK 2.15 when an overlay says 2.16), flag it as a finding. Overlays take precedence over the generated architecture docs when they conflict.
 

--- a/.claude/skills/feasibility-review/SKILL.md
+++ b/.claude/skills/feasibility-review/SKILL.md
@@ -17,7 +17,7 @@ If `artifacts/strat-reviews/` exists and contains review files for the strategie
 
 ## Architecture Context
 
-Check for architecture context in `.context/architecture-context/architecture/`. If a `rhoai-*` directory exists, read `PLATFORM.md` and relevant component docs to ground your assessment.
+Read `.context/architecture-context/LATEST_VERSION` directly with the Read tool to get the version directory name (e.g., `rhoai-3.4-ea.2`). Do NOT use Glob or Bash to check existence first — just Read it. Then Read `.context/architecture-context/architecture/<version>/PLATFORM.md` and relevant component docs to ground your assessment. If either Read fails, assess based on the strategy content alone and state that architecture context was not available.
 
 ## Architecture Context Overlays
 

--- a/.claude/skills/feasibility-review/SKILL.md
+++ b/.claude/skills/feasibility-review/SKILL.md
@@ -21,7 +21,7 @@ Check for architecture context in `.context/architecture-context/architecture/`.
 
 ## Architecture Context Overlays
 
-Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter sits in the first few lines, so pass `limit` to Read rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — Bash is denied in headless runs, so a loop costs a turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter can run past 30 lines, so pass `limit: 40` to Read for this filtering pass rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
 Filter for relevant overlays:
 1. **Status**: `status` must be `active` (ignore `superseded`)

--- a/.claude/skills/feasibility-review/SKILL.md
+++ b/.claude/skills/feasibility-review/SKILL.md
@@ -21,7 +21,7 @@ Read `.context/architecture-context/LATEST_VERSION` directly with the Read tool 
 
 ## Architecture Context Overlays
 
-Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter can run past 30 lines, so pass `limit: 40` to Read for this filtering pass rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter can run to 40 lines and keeps growing, so pass `limit: 60` to Read for this filtering pass rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
 Filter for relevant overlays:
 1. **Status**: `status` must be `active` (ignore `superseded`)

--- a/.claude/skills/feasibility-review/SKILL.md
+++ b/.claude/skills/feasibility-review/SKILL.md
@@ -21,7 +21,7 @@ Check for architecture context in `.context/architecture-context/architecture/`.
 
 ## Architecture Context Overlays
 
-Check for overlay files in `.context/architecture-context/overlays/`. If the directory exists, read all `*.md` files (excluding `README.md`) with `status: active` in their frontmatter. These are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter sits in the first few lines, so pass `limit` to Read rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — Bash is denied in headless runs, so a loop costs a turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
 Filter for relevant overlays:
 1. **Status**: `status` must be `active` (ignore `superseded`)

--- a/.claude/skills/initiative-feasibility-review/SKILL.md
+++ b/.claude/skills/initiative-feasibility-review/SKILL.md
@@ -26,7 +26,7 @@ If the Read on `LATEST_VERSION` returns an error (file not found) or the PLATFOR
 
 ## Architecture Context Overlays
 
-Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter sits in the first few lines, so pass `limit` to Read rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — Bash is denied in headless runs, so a loop costs a turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter can run past 30 lines, so pass `limit: 40` to Read for this filtering pass rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
 Filter for relevant overlays:
 1. **Status**: `status` must be `active` (ignore `superseded`)

--- a/.claude/skills/initiative-feasibility-review/SKILL.md
+++ b/.claude/skills/initiative-feasibility-review/SKILL.md
@@ -53,7 +53,7 @@ If `artifacts/initiative-review-report.md` exists, read it. This is a re-review 
 
 ## Output
 
-Write your assessment to `artifacts/initiative-reviews/{ID}-feasibility.md` where `{ID}` is exactly the Initiative ID passed to you (e.g., `INIT-001` or `RHOAIENG-12345`). Create the directory if needed.
+Write your assessment to `artifacts/initiative-reviews/{ID}-feasibility.md` where `{ID}` is exactly the Initiative ID passed to you (e.g., `INIT-001` or `RHOAIENG-12345`). The Write tool creates parent directories on its own — do not run `mkdir` first.
 
 ```
 ### {ID}: <title>

--- a/.claude/skills/initiative-feasibility-review/SKILL.md
+++ b/.claude/skills/initiative-feasibility-review/SKILL.md
@@ -26,7 +26,7 @@ If the Read on `LATEST_VERSION` returns an error (file not found) or the PLATFOR
 
 ## Architecture Context Overlays
 
-Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter can run past 30 lines, so pass `limit: 40` to Read for this filtering pass rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter can run to 40 lines and keeps growing, so pass `limit: 60` to Read for this filtering pass rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
 Filter for relevant overlays:
 1. **Status**: `status` must be `active` (ignore `superseded`)

--- a/.claude/skills/initiative-feasibility-review/SKILL.md
+++ b/.claude/skills/initiative-feasibility-review/SKILL.md
@@ -26,7 +26,7 @@ If the Read on `LATEST_VERSION` returns an error (file not found) or the PLATFOR
 
 ## Architecture Context Overlays
 
-Check for overlay files in `.context/architecture-context/overlays/`. If the directory exists, read all `*.md` files (excluding `README.md`) with `status: active` in their frontmatter. These are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter sits in the first few lines, so pass `limit` to Read rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — Bash is denied in headless runs, so a loop costs a turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
 Filter for relevant overlays:
 1. **Status**: `status` must be `active` (ignore `superseded`)

--- a/.claude/skills/initiative-review/SKILL.md
+++ b/.claude/skills/initiative-review/SKILL.md
@@ -320,12 +320,17 @@ Re-read flags (in case context was compressed):
 python3 scripts/state.py read tmp/initiative-review-config.yaml
 ```
 
-**If `headless: true`**: Output the text "initiative-review step completed." then run:
+**If `headless: true`**: Output the text "initiative-review step completed." then run each of these as its own Bash call — never chain them with `;` (chained commands are denied in headless mode):
 
 ```bash
 python3 scripts/state.py read tmp/initiative-review-config.yaml
-python3 scripts/state.py read tmp/initiative-split-config.yaml 2>/dev/null; true
 ```
+
+```bash
+python3 scripts/state.py read tmp/initiative-split-config.yaml
+```
+
+A "State file not found" error just means that caller's config does not exist — continue with what was found.
 
 Check the `caller` field above:
 - **`split`**: Returning to **Split Step 3: Right-sizing Self-Correction** of `/initiative-split`. Re-read parent IDs from `tmp/initiative-split-all-ids.txt`. If the split config is not visible, re-read `/initiative-split` SKILL.md for the full flow.

--- a/.claude/skills/rfe-feasibility-review/SKILL.md
+++ b/.claude/skills/rfe-feasibility-review/SKILL.md
@@ -26,7 +26,7 @@ If the Read on `LATEST_VERSION` returns an error (file not found) or the PLATFOR
 
 ## Architecture Context Overlays
 
-Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter sits in the first few lines, so pass `limit` to Read rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — Bash is denied in headless runs, so a loop costs a turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter can run past 30 lines, so pass `limit: 40` to Read for this filtering pass rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
 Filter for relevant overlays:
 1. **Status**: `status` must be `active` (ignore `superseded`)

--- a/.claude/skills/rfe-feasibility-review/SKILL.md
+++ b/.claude/skills/rfe-feasibility-review/SKILL.md
@@ -26,7 +26,7 @@ If the Read on `LATEST_VERSION` returns an error (file not found) or the PLATFOR
 
 ## Architecture Context Overlays
 
-Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter can run past 30 lines, so pass `limit: 40` to Read for this filtering pass rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter can run to 40 lines and keeps growing, so pass `limit: 60` to Read for this filtering pass rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
 Filter for relevant overlays:
 1. **Status**: `status` must be `active` (ignore `superseded`)

--- a/.claude/skills/rfe-feasibility-review/SKILL.md
+++ b/.claude/skills/rfe-feasibility-review/SKILL.md
@@ -53,7 +53,7 @@ If `artifacts/rfe-review-report.md` exists, read it. This is a re-review after r
 
 ## Output
 
-Write your assessment to `artifacts/rfe-reviews/{ID}-feasibility.md` where `{ID}` is exactly the RFE ID passed to you (e.g., `RFE-005` or `RHAIRFE-1234`). Create the directory if needed.
+Write your assessment to `artifacts/rfe-reviews/{ID}-feasibility.md` where `{ID}` is exactly the RFE ID passed to you (e.g., `RFE-005` or `RHAIRFE-1234`). The Write tool creates parent directories on its own — do not run `mkdir` first.
 
 ```
 ### RFE-NNN: <title>

--- a/.claude/skills/rfe-feasibility-review/SKILL.md
+++ b/.claude/skills/rfe-feasibility-review/SKILL.md
@@ -26,7 +26,7 @@ If the Read on `LATEST_VERSION` returns an error (file not found) or the PLATFOR
 
 ## Architecture Context Overlays
 
-Check for overlay files in `.context/architecture-context/overlays/`. If the directory exists, read all `*.md` files (excluding `README.md`) with `status: active` in their frontmatter. These are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter sits in the first few lines, so pass `limit` to Read rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — Bash is denied in headless runs, so a loop costs a turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
 Filter for relevant overlays:
 1. **Status**: `status` must be `active` (ignore `superseded`)

--- a/.claude/skills/rfe.review/SKILL.md
+++ b/.claude/skills/rfe.review/SKILL.md
@@ -299,12 +299,21 @@ Re-read flags (in case context was compressed):
 python3 scripts/state.py read tmp/review-config.yaml
 ```
 
-**If `headless: true`**: Output the text "rfe.review step completed." then run:
+**If `headless: true`**: Output the text "rfe.review step completed." then run each of these as its own Bash call — never chain them with `;` (chained commands are denied in headless mode):
 
 ```bash
 python3 scripts/state.py read tmp/review-config.yaml
-python3 scripts/state.py read tmp/autofix-config.yaml 2>/dev/null; python3 scripts/state.py read tmp/split-config.yaml 2>/dev/null; true
 ```
+
+```bash
+python3 scripts/state.py read tmp/autofix-config.yaml
+```
+
+```bash
+python3 scripts/state.py read tmp/split-config.yaml
+```
+
+A "State file not found" error just means that caller's config does not exist — continue with what was found.
 
 Check the `caller` field above:
 - **`autofix`**: Returning to **Step 3b: Collect Results** of `/rfe.auto-fix`. Re-read batch IDs from `tmp/autofix-batch-N-ids.txt` (where N = `current_batch` from `tmp/autofix-config.yaml`). If the autofix config is not visible, re-read `/rfe.auto-fix` SKILL.md for the full batch loop.

--- a/.claude/skills/rfe.split/SKILL.md
+++ b/.claude/skills/rfe.split/SKILL.md
@@ -147,8 +147,10 @@ python3 scripts/state.py read tmp/split-config.yaml
 **If `headless: true`**: Output the text "rfe.split step on current iteration of rfe.auto-fix batch loop completed." then run:
 
 ```bash
-python3 scripts/state.py read tmp/autofix-config.yaml 2>/dev/null; true
+python3 scripts/state.py read tmp/autofix-config.yaml
 ```
+
+A "State file not found" error just means the config was not persisted — the fallback below covers it.
 
 Returning to **Step 3d: Between-Batch Summary** of `/rfe.auto-fix`. Re-read the batch IDs from `tmp/autofix-batch-N-ids.txt` (where N = `current_batch` from the config above). If the autofix config is not visible, re-read `/rfe.auto-fix` SKILL.md for the full batch loop. Do not summarize or stop.
 

--- a/.claude/skills/strategic-alignment-review/SKILL.md
+++ b/.claude/skills/strategic-alignment-review/SKILL.md
@@ -76,13 +76,9 @@ When uncertain between two verdicts, choose the more conservative one (partial o
 
 ## Step 6: Write Output
 
-Create directory if needed:
-
-```bash
-mkdir -p artifacts/initiative-reviews
-```
-
-Write `artifacts/initiative-reviews/{ID}-alignment.md`:
+Write `artifacts/initiative-reviews/{ID}-alignment.md` with the Write tool, which
+creates parent directories on its own. Do not run `mkdir` first — it is denied in
+headless runs and costs a turn per agent.
 
 ```
 ### {ID}: Strategic Alignment with {PARENT_KEY}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,12 @@ python3 scripts/frontmatter.py read <path>
 python3 scripts/frontmatter.py rebuild-index
 ```
 
+Invoke `scripts/*.py` by the relative path exactly as written above, even when
+the working directory is given to you as an absolute path. The headless
+permission allowlist matches command text literally, so expanding
+`scripts/frontmatter.py` to `/abs/path/to/scripts/frontmatter.py` is denied and
+costs a retry.
+
 ### State Persistence
 
 Long-running skills use `scripts/state.py` to persist state to `tmp/` files so it survives context compression. All skills must use this utility instead of inline bash commands (cat, echo, mkdir) to avoid unnecessary auth prompts.


### PR DESCRIPTION
## Description

An initiative-speedrun run took 64 Bash permission denials — 31 in the main session and 33 more inside subagents, which the harness warning does not count. Every one of them recovered on retry, so nothing failed, but each cost a turn.

They come from 33 distinct commands, and three sources account for all of them:

**18 denials — overlay shell loops.** The overlay instruction said to "read all `*.md` files (excluding `README.md`) with `status: active` in their frontmatter" without naming a tool, so agents reached for Bash:

```bash
cd .context/architecture-context/overlays && for f in *.md; do [ "$f" = "README.md" ] && continue; head -20 "$f" | grep -E '(status:|release:|affects:)'; done
```

Denied, then re-done with Glob and Read anyway. The instruction now names Glob and Read up front, and points at Read's `limit` so the frontmatter can be filtered without loading whole files — preserving the efficiency the shell loop was reaching for. Applied to all four skills carrying the sentence (`rfe-feasibility-review`, `initiative-feasibility-review`, `feasibility-review`, `architecture-review`) so the RFE and Initiative forks stay in step.

**13 denials — `mkdir` before writing.** `strategic-alignment-review` Step 6 told agents to `mkdir -p artifacts/initiative-reviews` before writing the alignment file. Write creates parent directories on its own, and AGENTS.md already bans inline `mkdir` for exactly this reason ("All skills must use this utility instead of inline bash commands (cat, echo, mkdir) to avoid unnecessary auth prompts"). All 16 artifacts landed in the run despite the denials, confirming the step was never needed. Dropped it.

**2 denials — absolute script paths.** Agents expanded `scripts/frontmatter.py` to `/tmp/agent-eval/<run>/scripts/frontmatter.py` because the invoking prompt gave the working directory as an absolute path. The allowlist matches command text literally, so the absolute form never matches `Bash(python3 scripts/frontmatter.py *)`. Noted the constraint in AGENTS.md next to the documented invocation.

That last trigger originates in the eval harness prompt rather than this repo, so the AGENTS.md note is a mitigation, not the root fix.

No pipeline behavior changes: the overlays are still read, and the artifacts still go to the same paths.

## How Has This Been Tested?

`uv run pytest tests/` — 757 passed. Changes are skill prose and AGENTS.md; no Python touched.

Denial counts were taken from the run archive by mapping each denied `tool_result` back to its `tool_use` command across `stdout.log` and all 18 subagent transcripts, then de-duplicating. The overlays directory does exist in the run workspace and holds 14 files, so these loops were doing real work — just through a tool that is denied in headless runs.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated review guidance to load the appropriate architecture context and identify only active, relevant overlays.
  - Clarified handling of missing configuration or state files so reviews can continue when optional data is unavailable.
  - Improved instructions for generating review outputs and using documented command paths in headless workflows.
  - Added clearer safeguards around file discovery and command execution for more consistent automated reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->