### PR TITLE
Bring the Initiative pipeline back to parity with RFE

### DIFF
--- a/.claude/skills/initiative-review/SKILL.md
+++ b/.claude/skills/initiative-review/SKILL.md
@@ -50,7 +50,7 @@ Sleep for the `NEXT_POLL` seconds reported by the script before polling again. O
 After all fetch agents complete, verify task files exist via Glob. For any missing, write an error to the review file:
 
 ```bash
-python3 scripts/frontmatter.py set artifacts/initiative-reviews/<ID>-review.md initiative_id=<ID> pass=false recommendation=revise feasibility=feasible auto_revised=false needs_attention=true error="fetch_failed: task file not created"
+python3 scripts/frontmatter.py set artifacts/initiative-reviews/<ID>-review.md initiative_id=<ID> score=0 pass=false recommendation=revise feasibility=feasible auto_revised=false needs_attention=true scores.what=0 scores.why=0 scores.scope=0 scores.open_to_how=0 scores.right_sized=0 error="fetch_failed: task file not created"
 ```
 
 Remove failed IDs from the processing list and continue with remaining IDs.
@@ -131,7 +131,7 @@ After completion, check prerequisites for each ID via Glob:
 For any missing prerequisite:
 
 ```bash
-python3 scripts/frontmatter.py set artifacts/initiative-reviews/<ID>-review.md initiative_id=<ID> pass=false recommendation=revise feasibility=feasible auto_revised=false needs_attention=true error="<assess_failed or feasibility_failed>: file not created"
+python3 scripts/frontmatter.py set artifacts/initiative-reviews/<ID>-review.md initiative_id=<ID> score=0 pass=false recommendation=revise feasibility=feasible auto_revised=false needs_attention=true scores.what=0 scores.why=0 scores.scope=0 scores.open_to_how=0 scores.right_sized=0 error="<assess_failed or feasibility_failed>: file not created"
 ```
 
 Remove failed IDs from the processing list and continue with remaining IDs.

--- a/.claude/skills/initiative-review/prompts/revise-agent.md
+++ b/.claude/skills/initiative-review/prompts/revise-agent.md
@@ -34,11 +34,21 @@ Auto-revise initiative {ID} to address review findings.
 
 When reframing, add suggestive language ("such as", "could leverage", "one approach would be") rather than removing the technology reference entirely.
 
-**Do not invent missing evidence.** If Problem Statement is flagged for missing data, do not fabricate evidence — set `needs_attention=true` in Step 4 so the author is notified.
+**Do not invent missing evidence.** If Problem Statement is flagged for missing data, do not fabricate evidence — set `needs_attention=true` in Step 3 so the author is notified.
 
-**Never use HTML comments (`<!-- -->`) in the task file.** HTML comments are invisible when rendered in Jira — authors will never see them. If you need to flag something for the author, set `needs_attention=true` and `needs_attention_reason` in frontmatter (Step 4), which gets posted as a visible Jira comment during submission.
+**Never use HTML comments (`<!-- -->`) in the task file.** HTML comments are invisible when rendered in Jira — authors will never see them. If you need to flag something for the author, set `needs_attention=true` and `needs_attention_reason` in frontmatter (Step 3), which gets posted as a visible Jira comment during submission.
 
-## Step 3: Content Preservation
+## Step 3: Update Frontmatter
+
+**Immediately after editing the task file**, run:
+
+```bash
+python3 scripts/frontmatter.py set artifacts/initiative-reviews/{ID}-review.md auto_revised=true needs_attention=<true/false> needs_attention_reason="<reason or null>"
+```
+
+Set `needs_attention=true` if human review is still needed (e.g., missing evidence the author must provide). When true, set `needs_attention_reason` to a concise explanation (1-2 sentences) of what the human needs to address. When false, set `needs_attention_reason=null`. This is the most important step — do not skip it, and do not defer it until after Step 4.
+
+## Step 4: Content Preservation
 
 ```bash
 python3 scripts/check_content_preservation.py artifacts/initiative-originals/{ID}.md artifacts/initiatives/{ID}.md --write-yaml
@@ -50,16 +60,6 @@ If the file `artifacts/initiatives/{ID}-removed-context.yaml` exists after this,
 - **`non-substantive`**: Marketing filler or empty template placeholders.
 
 Verify no `type: unclassified` entries remain.
-
-## Step 4: Update Frontmatter
-
-**Immediately after editing the task file**, run:
-
-```bash
-python3 scripts/frontmatter.py set artifacts/initiative-reviews/{ID}-review.md auto_revised=true needs_attention=<true/false> needs_attention_reason="<reason or null>"
-```
-
-Set `needs_attention=true` if human review is still needed (e.g., missing evidence the author must provide). When true, set `needs_attention_reason` to a concise explanation (1-2 sentences) of what the human needs to address. When false, set `needs_attention_reason=null`. This is the most important step — do not skip it.
 
 ## Step 5: Update Revision History
 

--- a/.claude/skills/initiative-speedrun/SKILL.md
+++ b/.claude/skills/initiative-speedrun/SKILL.md
@@ -17,7 +17,7 @@ Parse `$ARGUMENTS` for:
 - `--batch-size N`: Override batch size (default 5), passed to auto-fix
 - Remaining arguments: either a single Jira key (RHOAIENG-NNNN) or a free-text objective
 
-Clean temp state and persist parsed flags:
+Clean temp state and persist parsed flags. `batch_size` MUST always be a concrete integer — if the user did not pass `--batch-size`, substitute the speedrun default of `5`. Do not write `<N>`, `null`, or omit the field.
 
 ```bash
 python3 scripts/state.py clean


### PR DESCRIPTION
## Description

Three divergences the Initiative skills picked up when they were copied from their RFE counterparts. All three are Initiative-only — no RFE file changes.

**1. Error paths wrote no artifact at all.** The two error paths in `initiative-review` omitted `score` and `scores.*`. Both are `required: True` with no default in the `initiative-review` schema, so `frontmatter.py set` exits 1 and writes nothing: a fetch or assess failure produced *no review artifact*, rather than one recording the error. The RFE counterpart passes `score=0` and the five zeroed criteria. Note the criterion names differ — Initiative uses `scores.scope` where RFE uses `scores.not_a_task`.

**2. The revise agent ran its steps in the wrong order.** Content Preservation ran before Update Frontmatter, the reverse of RFE (which has had frontmatter first since before the Initiative pipeline was written). Content preservation is the expensive step, so an agent that exhausts its budget classifying removed blocks dies without ever setting `auto_revised=true`. Step 4 even claimed "immediately after editing the task file" while sitting behind Step 3.

The two steps touch different files — content preservation reads the initiative artifact and originals and writes `-removed-context.yaml`, the frontmatter step writes the review file — so the order is free to change with no dependency risk.

**3. `batch_size` could be persisted unresolved.** `initiative-speedrun` Step 0 dropped RFE's requirement that `batch_size` be written as a concrete integer, so a run started without `--batch-size` could persist the literal `<N>` or omit the field. The sentence added here is verbatim the one already in `rfe.speedrun`.

### Deliberately not included

`initiative-split`'s headless finalize is also divergent — it ends on a text-only response, which CLAUDE.md says terminates the CI process. It is left alone here because **RFE's equivalent block is not a usable reference**: it reads `tmp/autofix-config.yaml` and `tmp/autofix-batch-N-ids.txt`, which nothing has written since `rfe.auto-fix` moved to `tmp/pipeline-state.yaml`, and it points at "Step 3d: Between-Batch Summary", which no longer exists. It also chains with `; true`, which this repo's own Bash discipline says is denied in headless runs.

So the headless return protocol is broken on both sides, in different ways, and #150's parity lint won't catch it — the two forks aren't divergent from each other so much as both stale. That wants its own change covering both pipelines, not a parity edit here.

## How Has This Been Tested?

`uv run pytest tests/` — 757 passed. The changes are skill prose only; no Python touched.

Each divergence was found by diffing the Initiative skill against its RFE counterpart, then verified individually:

**(1)** Both forms of the error-path command were run against the real script. Before:

    Error: Frontmatter validation failed:
      - Missing required field: score
      - Missing required field: scores
    exit=1                      # and no file written

After: `exit=0`, and the review file is written with `score: 0`, the five zeroed criteria, and `error: 'fetch_failed: task file not created'`.

**(2)** Confirmed against the 2026-08-10 initiative-speedrun run archive. `INIT-012-review-state.json` records `before_score: 5` and a revision history, while `INIT-012-review.md` still carries `auto_revised: false` — the initiative was revised and the flag never got set. Per the skill's labeling table that flag drives the `initiative-auto-revised` label, so the one ticket actually revised is the one that would not get labeled. Step order is the most likely cause; a re-run is the real confirmation.

**(3)** Diffed against [rfe.speedrun/SKILL.md](.claude/skills/rfe.speedrun/SKILL.md) Step 0 — the added sentence matches it word for word.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Review results now record consistent zero scores when required fetch or assessment steps fail.
  - Revision guidance now clarifies the order for updating review status, checking preserved content, and recording revision history.
  - Speedrun instructions now require a concrete batch size and use **5** as the default when no batch size is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->