### PR TITLE
Gate both evals on auto_revised matching the evidence

### DIFF
--- a/eval-initiative.yaml
+++ b/eval-initiative.yaml
@@ -299,9 +299,12 @@ judges:
       # (rfe-tasks/rfe-originals vs initiatives/initiative-originals).
       names = {os.path.basename(k) for k in files}
       originals = {os.path.basename(k) for k in files if "-originals/" in k}
-      # revision_cycles per item from the shared run report
+      # revision_cycles per item from the shared run report. Iterate sorted and merge
+      # with max so a stale report can't nondeterministically mask a newer one's
+      # revision evidence with a 0.
       cycles = {}
-      for k, v in files.items():
+      for k in sorted(files):
+          v = files[k]
           if not (k.startswith("artifacts/auto-fix-runs/") and k.endswith(".yaml")):
               continue
           # Snapshot files (issue-snapshot-*, initiative-snapshot-*) are fetch
@@ -318,7 +321,9 @@ judges:
               continue
           for entry in (report.get("per_rfe") or []) + (report.get("per_initiative") or []):
               if isinstance(entry, dict) and entry.get("id"):
-                  cycles[entry["id"]] = entry.get("revision_cycles") or 0
+                  cycles[entry["id"]] = max(
+                      cycles.get(entry["id"], 0), entry.get("revision_cycles") or 0
+                  )
       errors = []
       checked = 0
       for fname, content in sorted(reviews.items()):
@@ -357,13 +362,16 @@ judges:
                       parsed = json.loads(state)
                   except ValueError:
                       parsed = None
-                  if isinstance(parsed, dict) and (parsed.get("revision_history") or "").strip():
-                      strong.append("review-state records a revision")
+                  if isinstance(parsed, dict):
+                      history = parsed.get("revision_history")
+                      # Normally a string; guard non-str so .strip() cannot raise.
+                      if history.strip() if isinstance(history, str) else history:
+                          strong.append("review-state records a revision")
           before, score = fm.get("before_score"), fm.get("score")
           if before is not None and score is not None and before != score:
               strong.append(f"before_score {before} != score {score}")
-          before_scores = fm.get("before_scores")
-          if before_scores is not None and before_scores != fm.get("scores"):
+          before_scores, cur_scores = fm.get("before_scores"), fm.get("scores")
+          if before_scores is not None and cur_scores is not None and before_scores != cur_scores:
               strong.append("before_scores != scores")
           # Written only when a revision removes content, so its presence proves a
           # revision even if the re-score landed on the same number.

--- a/eval-initiative.yaml
+++ b/eval-initiative.yaml
@@ -279,9 +279,12 @@ judges:
   - name: revision_flag_consistency
     description: |
       Verify auto_revised agrees with the evidence. The flag drives the
-      auto-revised Jira label, so a revision the flag misses is a revision no
-      reviewer is told about. Reads only shared artifacts, so the identical
-      check runs on both pipelines.
+      auto-revised Jira label, so a revision the flag misses ships unlabeled.
+      Proof of a revision (a leftover review-state file, a recorded revision
+      history, a moved score, or a removed-context companion) fails an unset
+      flag; a saved original only clears a set one, since -originals/ is also the
+      fetch baseline for existing issues. Reads only shared artifacts, so the
+      identical check runs on both pipelines.
     check: |
       import json
       import os
@@ -325,32 +328,44 @@ judges:
               continue
           checked += 1
           flag = bool(fm.get("auto_revised"))
-          # Strong: a revision demonstrably happened and changed something.
+          # Strong: proof a revision happened. Any of these with auto_revised=false is
+          # a missed revision (the flag drives the auto-revised Jira label, so a missed
+          # one ships unlabeled). Each both clears a set flag and raises an unset one,
+          # so it must never fire without a real revision.
           strong = []
           state = files.get(os.path.join(os.path.dirname(fname), f"{item_id}-review-state.json"))
-          if isinstance(state, str):
-              try:
-                  if (json.loads(state).get("revision_history") or "").strip():
-                      strong.append("review-state records a revision")
-              except ValueError:
-                  pass
+          if state is not None:
+              # restore() deletes the state file once a re-review cycle completes, so
+              # one left on disk is a save/restore cycle that never finished.
+              strong.append("leftover review-state file")
+              if isinstance(state, str):
+                  try:
+                      if (json.loads(state).get("revision_history") or "").strip():
+                          strong.append("review-state records a revision")
+                  except ValueError:
+                      pass
           before, score = fm.get("before_score"), fm.get("score")
           if before is not None and score is not None and before != score:
               strong.append(f"before_score {before} != score {score}")
           before_scores = fm.get("before_scores")
           if before_scores is not None and before_scores != fm.get("scores"):
               strong.append("before_scores != scores")
+          # Written only when a revision removes content, so its presence proves a
+          # revision even if the re-score landed on the same number.
+          if f"{item_id}-removed-context.yaml" in names:
+              strong.append("removed-context companion")
+          # Cross-check only: the run report derives revision_cycles from auto_revised
+          # itself, so cycles>0 already implies the flag was set at report time. It
+          # cannot witness a never-set flag (the signals above do that); it only
+          # catches a run-report / frontmatter divergence.
           if cycles.get(item_id, 0) > 0:
               strong.append(f"run report revision_cycles={cycles[item_id]}")
-          # Weak: the revise path ran, but a revision need not move the score,
-          # so these clear the flag without being able to prove it on their own.
+          # Weak: clears a set flag but cannot raise an unset one. A saved original is
+          # not proof - -originals/ is also the fetch baseline for existing Jira
+          # issues, so treating it as proof would false-fail on the 1.0 gate.
           weak = list(strong)
-          if state is not None:
-              weak.append("review-state file")
           if f"{item_id}.md" in originals:
               weak.append("pre-revision original saved")
-          if f"{item_id}-removed-context.yaml" in names:
-              weak.append("removed-context companion")
           if strong and not flag:
               errors.append(f"{item_id}: auto_revised=false but revised ({'; '.join(strong)})")
           elif flag and not weak:
@@ -361,7 +376,6 @@ judges:
           len(errors) == 0,
           "; ".join(errors[:5]) if errors else f"{checked} reviews: auto_revised matches evidence",
       )
-
   - name: pipeline_flow
     description: |
       Verify expected execution flow from stdout: all phases ran,

--- a/eval-initiative.yaml
+++ b/eval-initiative.yaml
@@ -353,7 +353,10 @@ judges:
           if not isinstance(fm, dict):
               continue
           item_id = fm.get("rfe_id") or fm.get("initiative_id")
-          if not item_id:
+          # A malformed id (list/dict) is truthy but unhashable; require a real
+          # string so cycles.get(item_id) below cannot raise and silently drop
+          # the case from the 1.0 gate.
+          if not isinstance(item_id, str) or not item_id:
               continue
           checked += 1
           # Legacy artifacts stored the flag as `revised`; artifact_utils migrates it

--- a/eval-initiative.yaml
+++ b/eval-initiative.yaml
@@ -315,15 +315,27 @@ judges:
               report = yaml.safe_load(v) or {}
           except yaml.YAMLError:
               continue
-          # A malformed report that parses to a non-dict must skip this signal, not
-          # raise - an uncaught error drops the whole case from the 1.0 gate silently.
+          # A malformed report must skip this signal, not raise - an uncaught error
+          # drops the whole case from the 1.0 gate silently. Validate the nested
+          # shapes too: a non-list section or non-int revision_cycles would otherwise
+          # raise a TypeError below.
           if not isinstance(report, dict):
               continue
-          for entry in (report.get("per_rfe") or []) + (report.get("per_initiative") or []):
-              if isinstance(entry, dict) and entry.get("id"):
-                  cycles[entry["id"]] = max(
-                      cycles.get(entry["id"], 0), entry.get("revision_cycles") or 0
-                  )
+          entries = []
+          for key in ("per_rfe", "per_initiative"):
+              section = report.get(key)
+              if isinstance(section, list):
+                  entries += section
+          for entry in entries:
+              if not isinstance(entry, dict):
+                  continue
+              item = entry.get("id")
+              if not isinstance(item, str) or not item:
+                  continue
+              rc = entry.get("revision_cycles")
+              if isinstance(rc, bool) or not isinstance(rc, int):
+                  rc = 0
+              cycles[item] = max(cycles.get(item, 0), rc)
       errors = []
       checked = 0
       for fname, content in sorted(reviews.items()):

--- a/eval-initiative.yaml
+++ b/eval-initiative.yaml
@@ -304,11 +304,17 @@ judges:
       for k, v in files.items():
           if not (k.startswith("artifacts/auto-fix-runs/") and k.endswith(".yaml")):
               continue
-          if "issue-snapshot" in k:
+          # Snapshot files (issue-snapshot-*, initiative-snapshot-*) are fetch
+          # artifacts, not run reports.
+          if "-snapshot-" in os.path.basename(k):
               continue
           try:
               report = yaml.safe_load(v) or {}
           except yaml.YAMLError:
+              continue
+          # A malformed report that parses to a non-dict must skip this signal, not
+          # raise - an uncaught error drops the whole case from the 1.0 gate silently.
+          if not isinstance(report, dict):
               continue
           for entry in (report.get("per_rfe") or []) + (report.get("per_initiative") or []):
               if isinstance(entry, dict) and entry.get("id"):
@@ -316,20 +322,28 @@ judges:
       errors = []
       checked = 0
       for fname, content in sorted(reviews.items()):
-          parts = content.split("---", 2)
-          if len(parts) < 3:
+          # Frontmatter is the leading ---...--- block; split on the closing fence
+          # only, so a literal --- inside a field value cannot truncate it.
+          if not content.startswith("---"):
+              continue
+          end = content.find("\n---", 3)
+          if end == -1:
               continue
           try:
-              fm = yaml.safe_load(parts[1]) or {}
+              fm = yaml.safe_load(content[3:end]) or {}
           except yaml.YAMLError:
+              continue
+          if not isinstance(fm, dict):
               continue
           item_id = fm.get("rfe_id") or fm.get("initiative_id")
           if not item_id:
               continue
           checked += 1
-          flag = bool(fm.get("auto_revised"))
-          # Strong: proof a revision happened. Any of these with auto_revised=false is
-          # a missed revision (the flag drives the auto-revised Jira label, so a missed
+          # Legacy artifacts stored the flag as `revised`; artifact_utils migrates it
+          # to `auto_revised` on read, but this parses raw YAML, so fall back here.
+          flag = bool(fm["auto_revised"] if "auto_revised" in fm else fm.get("revised"))
+          # Strong: proof a revision happened. Any of these with the flag unset is a
+          # missed revision (the flag drives the auto-revised Jira label, so a missed
           # one ships unlabeled). Each both clears a set flag and raises an unset one,
           # so it must never fire without a real revision.
           strong = []
@@ -340,10 +354,11 @@ judges:
               strong.append("leftover review-state file")
               if isinstance(state, str):
                   try:
-                      if (json.loads(state).get("revision_history") or "").strip():
-                          strong.append("review-state records a revision")
+                      parsed = json.loads(state)
                   except ValueError:
-                      pass
+                      parsed = None
+                  if isinstance(parsed, dict) and (parsed.get("revision_history") or "").strip():
+                      strong.append("review-state records a revision")
           before, score = fm.get("before_score"), fm.get("score")
           if before is not None and score is not None and before != score:
               strong.append(f"before_score {before} != score {score}")

--- a/eval-initiative.yaml
+++ b/eval-initiative.yaml
@@ -276,6 +276,92 @@ judges:
               errors.append(f"{fname}: alignment=weak but needs_attention=false")
       return (len(errors) == 0, "; ".join(errors[:5]) if errors else f"{len(reviews)} reviews consistent")
 
+  - name: revision_flag_consistency
+    description: |
+      Verify auto_revised agrees with the evidence. The flag drives the
+      auto-revised Jira label, so a revision the flag misses is a revision no
+      reviewer is told about. Reads only shared artifacts, so the identical
+      check runs on both pipelines.
+    check: |
+      import json
+      import os
+
+      import yaml
+
+      files = outputs.get("files", {})
+      reviews = {k: v for k, v in files.items() if k.endswith("-review.md")}
+      if not reviews:
+          return (False, "No review files to check")
+      # Index by basename: the two pipelines use different directory names
+      # (rfe-tasks/rfe-originals vs initiatives/initiative-originals).
+      names = {os.path.basename(k) for k in files}
+      originals = {os.path.basename(k) for k in files if "-originals/" in k}
+      # revision_cycles per item from the shared run report
+      cycles = {}
+      for k, v in files.items():
+          if not (k.startswith("artifacts/auto-fix-runs/") and k.endswith(".yaml")):
+              continue
+          if "issue-snapshot" in k:
+              continue
+          try:
+              report = yaml.safe_load(v) or {}
+          except yaml.YAMLError:
+              continue
+          for entry in (report.get("per_rfe") or []) + (report.get("per_initiative") or []):
+              if isinstance(entry, dict) and entry.get("id"):
+                  cycles[entry["id"]] = entry.get("revision_cycles") or 0
+      errors = []
+      checked = 0
+      for fname, content in sorted(reviews.items()):
+          parts = content.split("---", 2)
+          if len(parts) < 3:
+              continue
+          try:
+              fm = yaml.safe_load(parts[1]) or {}
+          except yaml.YAMLError:
+              continue
+          item_id = fm.get("rfe_id") or fm.get("initiative_id")
+          if not item_id:
+              continue
+          checked += 1
+          flag = bool(fm.get("auto_revised"))
+          # Strong: a revision demonstrably happened and changed something.
+          strong = []
+          state = files.get(os.path.join(os.path.dirname(fname), f"{item_id}-review-state.json"))
+          if isinstance(state, str):
+              try:
+                  if (json.loads(state).get("revision_history") or "").strip():
+                      strong.append("review-state records a revision")
+              except ValueError:
+                  pass
+          before, score = fm.get("before_score"), fm.get("score")
+          if before is not None and score is not None and before != score:
+              strong.append(f"before_score {before} != score {score}")
+          before_scores = fm.get("before_scores")
+          if before_scores is not None and before_scores != fm.get("scores"):
+              strong.append("before_scores != scores")
+          if cycles.get(item_id, 0) > 0:
+              strong.append(f"run report revision_cycles={cycles[item_id]}")
+          # Weak: the revise path ran, but a revision need not move the score,
+          # so these clear the flag without being able to prove it on their own.
+          weak = list(strong)
+          if state is not None:
+              weak.append("review-state file")
+          if f"{item_id}.md" in originals:
+              weak.append("pre-revision original saved")
+          if f"{item_id}-removed-context.yaml" in names:
+              weak.append("removed-context companion")
+          if strong and not flag:
+              errors.append(f"{item_id}: auto_revised=false but revised ({'; '.join(strong)})")
+          elif flag and not weak:
+              errors.append(f"{item_id}: auto_revised=true with no trace of a revision")
+      if checked == 0:
+          return (False, "No review files to check")
+      return (
+          len(errors) == 0,
+          "; ".join(errors[:5]) if errors else f"{checked} reviews: auto_revised matches evidence",
+      )
+
   - name: pipeline_flow
     description: |
       Verify expected execution flow from stdout: all phases ran,
@@ -469,6 +555,8 @@ thresholds:
   run_report_exists:
     min_pass_rate: 1.0
   recommendation_consistency:
+    min_pass_rate: 1.0
+  revision_flag_consistency:
     min_pass_rate: 1.0
   pipeline_flow:
     min_pass_rate: 1.0

--- a/eval.yaml
+++ b/eval.yaml
@@ -295,9 +295,12 @@ judges:
       # (rfe-tasks/rfe-originals vs initiatives/initiative-originals).
       names = {os.path.basename(k) for k in files}
       originals = {os.path.basename(k) for k in files if "-originals/" in k}
-      # revision_cycles per item from the shared run report
+      # revision_cycles per item from the shared run report. Iterate sorted and merge
+      # with max so a stale report can't nondeterministically mask a newer one's
+      # revision evidence with a 0.
       cycles = {}
-      for k, v in files.items():
+      for k in sorted(files):
+          v = files[k]
           if not (k.startswith("artifacts/auto-fix-runs/") and k.endswith(".yaml")):
               continue
           # Snapshot files (issue-snapshot-*, initiative-snapshot-*) are fetch
@@ -314,7 +317,9 @@ judges:
               continue
           for entry in (report.get("per_rfe") or []) + (report.get("per_initiative") or []):
               if isinstance(entry, dict) and entry.get("id"):
-                  cycles[entry["id"]] = entry.get("revision_cycles") or 0
+                  cycles[entry["id"]] = max(
+                      cycles.get(entry["id"], 0), entry.get("revision_cycles") or 0
+                  )
       errors = []
       checked = 0
       for fname, content in sorted(reviews.items()):
@@ -353,13 +358,16 @@ judges:
                       parsed = json.loads(state)
                   except ValueError:
                       parsed = None
-                  if isinstance(parsed, dict) and (parsed.get("revision_history") or "").strip():
-                      strong.append("review-state records a revision")
+                  if isinstance(parsed, dict):
+                      history = parsed.get("revision_history")
+                      # Normally a string; guard non-str so .strip() cannot raise.
+                      if history.strip() if isinstance(history, str) else history:
+                          strong.append("review-state records a revision")
           before, score = fm.get("before_score"), fm.get("score")
           if before is not None and score is not None and before != score:
               strong.append(f"before_score {before} != score {score}")
-          before_scores = fm.get("before_scores")
-          if before_scores is not None and before_scores != fm.get("scores"):
+          before_scores, cur_scores = fm.get("before_scores"), fm.get("scores")
+          if before_scores is not None and cur_scores is not None and before_scores != cur_scores:
               strong.append("before_scores != scores")
           # Written only when a revision removes content, so its presence proves a
           # revision even if the re-score landed on the same number.

--- a/eval.yaml
+++ b/eval.yaml
@@ -300,11 +300,17 @@ judges:
       for k, v in files.items():
           if not (k.startswith("artifacts/auto-fix-runs/") and k.endswith(".yaml")):
               continue
-          if "issue-snapshot" in k:
+          # Snapshot files (issue-snapshot-*, initiative-snapshot-*) are fetch
+          # artifacts, not run reports.
+          if "-snapshot-" in os.path.basename(k):
               continue
           try:
               report = yaml.safe_load(v) or {}
           except yaml.YAMLError:
+              continue
+          # A malformed report that parses to a non-dict must skip this signal, not
+          # raise - an uncaught error drops the whole case from the 1.0 gate silently.
+          if not isinstance(report, dict):
               continue
           for entry in (report.get("per_rfe") or []) + (report.get("per_initiative") or []):
               if isinstance(entry, dict) and entry.get("id"):
@@ -312,20 +318,28 @@ judges:
       errors = []
       checked = 0
       for fname, content in sorted(reviews.items()):
-          parts = content.split("---", 2)
-          if len(parts) < 3:
+          # Frontmatter is the leading ---...--- block; split on the closing fence
+          # only, so a literal --- inside a field value cannot truncate it.
+          if not content.startswith("---"):
+              continue
+          end = content.find("\n---", 3)
+          if end == -1:
               continue
           try:
-              fm = yaml.safe_load(parts[1]) or {}
+              fm = yaml.safe_load(content[3:end]) or {}
           except yaml.YAMLError:
+              continue
+          if not isinstance(fm, dict):
               continue
           item_id = fm.get("rfe_id") or fm.get("initiative_id")
           if not item_id:
               continue
           checked += 1
-          flag = bool(fm.get("auto_revised"))
-          # Strong: proof a revision happened. Any of these with auto_revised=false is
-          # a missed revision (the flag drives the auto-revised Jira label, so a missed
+          # Legacy artifacts stored the flag as `revised`; artifact_utils migrates it
+          # to `auto_revised` on read, but this parses raw YAML, so fall back here.
+          flag = bool(fm["auto_revised"] if "auto_revised" in fm else fm.get("revised"))
+          # Strong: proof a revision happened. Any of these with the flag unset is a
+          # missed revision (the flag drives the auto-revised Jira label, so a missed
           # one ships unlabeled). Each both clears a set flag and raises an unset one,
           # so it must never fire without a real revision.
           strong = []
@@ -336,10 +350,11 @@ judges:
               strong.append("leftover review-state file")
               if isinstance(state, str):
                   try:
-                      if (json.loads(state).get("revision_history") or "").strip():
-                          strong.append("review-state records a revision")
+                      parsed = json.loads(state)
                   except ValueError:
-                      pass
+                      parsed = None
+                  if isinstance(parsed, dict) and (parsed.get("revision_history") or "").strip():
+                      strong.append("review-state records a revision")
           before, score = fm.get("before_score"), fm.get("score")
           if before is not None and score is not None and before != score:
               strong.append(f"before_score {before} != score {score}")

--- a/eval.yaml
+++ b/eval.yaml
@@ -275,9 +275,12 @@ judges:
   - name: revision_flag_consistency
     description: |
       Verify auto_revised agrees with the evidence. The flag drives the
-      auto-revised Jira label, so a revision the flag misses is a revision no
-      reviewer is told about. Reads only shared artifacts, so the identical
-      check runs on both pipelines.
+      auto-revised Jira label, so a revision the flag misses ships unlabeled.
+      Proof of a revision (a leftover review-state file, a recorded revision
+      history, a moved score, or a removed-context companion) fails an unset
+      flag; a saved original only clears a set one, since -originals/ is also the
+      fetch baseline for existing issues. Reads only shared artifacts, so the
+      identical check runs on both pipelines.
     check: |
       import json
       import os
@@ -321,32 +324,44 @@ judges:
               continue
           checked += 1
           flag = bool(fm.get("auto_revised"))
-          # Strong: a revision demonstrably happened and changed something.
+          # Strong: proof a revision happened. Any of these with auto_revised=false is
+          # a missed revision (the flag drives the auto-revised Jira label, so a missed
+          # one ships unlabeled). Each both clears a set flag and raises an unset one,
+          # so it must never fire without a real revision.
           strong = []
           state = files.get(os.path.join(os.path.dirname(fname), f"{item_id}-review-state.json"))
-          if isinstance(state, str):
-              try:
-                  if (json.loads(state).get("revision_history") or "").strip():
-                      strong.append("review-state records a revision")
-              except ValueError:
-                  pass
+          if state is not None:
+              # restore() deletes the state file once a re-review cycle completes, so
+              # one left on disk is a save/restore cycle that never finished.
+              strong.append("leftover review-state file")
+              if isinstance(state, str):
+                  try:
+                      if (json.loads(state).get("revision_history") or "").strip():
+                          strong.append("review-state records a revision")
+                  except ValueError:
+                      pass
           before, score = fm.get("before_score"), fm.get("score")
           if before is not None and score is not None and before != score:
               strong.append(f"before_score {before} != score {score}")
           before_scores = fm.get("before_scores")
           if before_scores is not None and before_scores != fm.get("scores"):
               strong.append("before_scores != scores")
+          # Written only when a revision removes content, so its presence proves a
+          # revision even if the re-score landed on the same number.
+          if f"{item_id}-removed-context.yaml" in names:
+              strong.append("removed-context companion")
+          # Cross-check only: the run report derives revision_cycles from auto_revised
+          # itself, so cycles>0 already implies the flag was set at report time. It
+          # cannot witness a never-set flag (the signals above do that); it only
+          # catches a run-report / frontmatter divergence.
           if cycles.get(item_id, 0) > 0:
               strong.append(f"run report revision_cycles={cycles[item_id]}")
-          # Weak: the revise path ran, but a revision need not move the score,
-          # so these clear the flag without being able to prove it on their own.
+          # Weak: clears a set flag but cannot raise an unset one. A saved original is
+          # not proof - -originals/ is also the fetch baseline for existing Jira
+          # issues, so treating it as proof would false-fail on the 1.0 gate.
           weak = list(strong)
-          if state is not None:
-              weak.append("review-state file")
           if f"{item_id}.md" in originals:
               weak.append("pre-revision original saved")
-          if f"{item_id}-removed-context.yaml" in names:
-              weak.append("removed-context companion")
           if strong and not flag:
               errors.append(f"{item_id}: auto_revised=false but revised ({'; '.join(strong)})")
           elif flag and not weak:
@@ -357,7 +372,6 @@ judges:
           len(errors) == 0,
           "; ".join(errors[:5]) if errors else f"{checked} reviews: auto_revised matches evidence",
       )
-
   - name: pipeline_flow
     description: |
       Verify expected execution flow from stdout: all phases ran,

--- a/eval.yaml
+++ b/eval.yaml
@@ -349,7 +349,10 @@ judges:
           if not isinstance(fm, dict):
               continue
           item_id = fm.get("rfe_id") or fm.get("initiative_id")
-          if not item_id:
+          # A malformed id (list/dict) is truthy but unhashable; require a real
+          # string so cycles.get(item_id) below cannot raise and silently drop
+          # the case from the 1.0 gate.
+          if not isinstance(item_id, str) or not item_id:
               continue
           checked += 1
           # Legacy artifacts stored the flag as `revised`; artifact_utils migrates it

--- a/eval.yaml
+++ b/eval.yaml
@@ -272,6 +272,92 @@ judges:
               errors.append(f"{fname}: feasibility=infeasible but recommendation=submit")
       return (len(errors) == 0, "; ".join(errors[:5]) if errors else f"{len(reviews)} reviews consistent")
 
+  - name: revision_flag_consistency
+    description: |
+      Verify auto_revised agrees with the evidence. The flag drives the
+      auto-revised Jira label, so a revision the flag misses is a revision no
+      reviewer is told about. Reads only shared artifacts, so the identical
+      check runs on both pipelines.
+    check: |
+      import json
+      import os
+
+      import yaml
+
+      files = outputs.get("files", {})
+      reviews = {k: v for k, v in files.items() if k.endswith("-review.md")}
+      if not reviews:
+          return (False, "No review files to check")
+      # Index by basename: the two pipelines use different directory names
+      # (rfe-tasks/rfe-originals vs initiatives/initiative-originals).
+      names = {os.path.basename(k) for k in files}
+      originals = {os.path.basename(k) for k in files if "-originals/" in k}
+      # revision_cycles per item from the shared run report
+      cycles = {}
+      for k, v in files.items():
+          if not (k.startswith("artifacts/auto-fix-runs/") and k.endswith(".yaml")):
+              continue
+          if "issue-snapshot" in k:
+              continue
+          try:
+              report = yaml.safe_load(v) or {}
+          except yaml.YAMLError:
+              continue
+          for entry in (report.get("per_rfe") or []) + (report.get("per_initiative") or []):
+              if isinstance(entry, dict) and entry.get("id"):
+                  cycles[entry["id"]] = entry.get("revision_cycles") or 0
+      errors = []
+      checked = 0
+      for fname, content in sorted(reviews.items()):
+          parts = content.split("---", 2)
+          if len(parts) < 3:
+              continue
+          try:
+              fm = yaml.safe_load(parts[1]) or {}
+          except yaml.YAMLError:
+              continue
+          item_id = fm.get("rfe_id") or fm.get("initiative_id")
+          if not item_id:
+              continue
+          checked += 1
+          flag = bool(fm.get("auto_revised"))
+          # Strong: a revision demonstrably happened and changed something.
+          strong = []
+          state = files.get(os.path.join(os.path.dirname(fname), f"{item_id}-review-state.json"))
+          if isinstance(state, str):
+              try:
+                  if (json.loads(state).get("revision_history") or "").strip():
+                      strong.append("review-state records a revision")
+              except ValueError:
+                  pass
+          before, score = fm.get("before_score"), fm.get("score")
+          if before is not None and score is not None and before != score:
+              strong.append(f"before_score {before} != score {score}")
+          before_scores = fm.get("before_scores")
+          if before_scores is not None and before_scores != fm.get("scores"):
+              strong.append("before_scores != scores")
+          if cycles.get(item_id, 0) > 0:
+              strong.append(f"run report revision_cycles={cycles[item_id]}")
+          # Weak: the revise path ran, but a revision need not move the score,
+          # so these clear the flag without being able to prove it on their own.
+          weak = list(strong)
+          if state is not None:
+              weak.append("review-state file")
+          if f"{item_id}.md" in originals:
+              weak.append("pre-revision original saved")
+          if f"{item_id}-removed-context.yaml" in names:
+              weak.append("removed-context companion")
+          if strong and not flag:
+              errors.append(f"{item_id}: auto_revised=false but revised ({'; '.join(strong)})")
+          elif flag and not weak:
+              errors.append(f"{item_id}: auto_revised=true with no trace of a revision")
+      if checked == 0:
+          return (False, "No review files to check")
+      return (
+          len(errors) == 0,
+          "; ".join(errors[:5]) if errors else f"{checked} reviews: auto_revised matches evidence",
+      )
+
   - name: pipeline_flow
     description: |
       Verify expected execution flow from stdout: all phases ran,
@@ -443,6 +529,8 @@ thresholds:
   run_report_exists:
     min_pass_rate: 1.0
   recommendation_consistency:
+    min_pass_rate: 1.0
+  revision_flag_consistency:
     min_pass_rate: 1.0
   pipeline_flow:
     min_pass_rate: 1.0

--- a/eval.yaml
+++ b/eval.yaml
@@ -311,15 +311,27 @@ judges:
               report = yaml.safe_load(v) or {}
           except yaml.YAMLError:
               continue
-          # A malformed report that parses to a non-dict must skip this signal, not
-          # raise - an uncaught error drops the whole case from the 1.0 gate silently.
+          # A malformed report must skip this signal, not raise - an uncaught error
+          # drops the whole case from the 1.0 gate silently. Validate the nested
+          # shapes too: a non-list section or non-int revision_cycles would otherwise
+          # raise a TypeError below.
           if not isinstance(report, dict):
               continue
-          for entry in (report.get("per_rfe") or []) + (report.get("per_initiative") or []):
-              if isinstance(entry, dict) and entry.get("id"):
-                  cycles[entry["id"]] = max(
-                      cycles.get(entry["id"], 0), entry.get("revision_cycles") or 0
-                  )
+          entries = []
+          for key in ("per_rfe", "per_initiative"):
+              section = report.get(key)
+              if isinstance(section, list):
+                  entries += section
+          for entry in entries:
+              if not isinstance(entry, dict):
+                  continue
+              item = entry.get("id")
+              if not isinstance(item, str) or not item:
+                  continue
+              rc = entry.get("revision_cycles")
+              if isinstance(rc, bool) or not isinstance(rc, int):
+                  rc = 0
+              cycles[item] = max(cycles.get(item, 0), rc)
       errors = []
       checked = 0
       for fname, content in sorted(reviews.items()):

--- a/tests/test_eval_revision_flag_judge.py
+++ b/tests/test_eval_revision_flag_judge.py
@@ -350,3 +350,18 @@ def test_non_int_revision_cycles_ignored():
         }
     )
     assert passed is True
+
+
+def test_malformed_id_is_skipped_valid_review_decides():
+    # A non-string id (list/dict) is truthy but unhashable; it must be skipped,
+    # not crash on cycles.get(item_id), and a valid review still decides.
+    malformed = "---\nrfe_id:\n  - RFE-BAD\nscore: 8\nauto_revised: false\n---\n"
+    valid = _review("RFE-30", auto_revised=False, score=8, before_score=6)
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-bad-review.md": malformed,
+            f"{RFE_REVIEWS}/RFE-30-review.md": valid,
+        }
+    )
+    assert passed is False
+    assert "RFE-30" in msg

--- a/tests/test_eval_revision_flag_judge.py
+++ b/tests/test_eval_revision_flag_judge.py
@@ -51,6 +51,7 @@ def _run(files):
 
 # --- Drift guard: the two configs must carry the identical judge body ---------
 
+
 def test_both_configs_identical():
     assert _check_body(EVAL_YAML) == _check_body(EVAL_INITIATIVE_YAML), (
         "revision_flag_consistency has drifted between eval.yaml and "
@@ -60,35 +61,46 @@ def test_both_configs_identical():
 
 # --- Stable behaviours (correct before and after the fixes) -------------------
 
+
 def test_motivating_case_flag_false_but_state_records_revision():
     # The INIT-012 class: auto_revised=false while a leftover review-state file
     # records a real revision history.
-    passed, msg = _run({
-        f"{RFE_REVIEWS}/RFE-1-review.md": _review("RFE-1", auto_revised=False, score=8),
-        f"{RFE_REVIEWS}/RFE-1-review-state.json": '{"revision_history": "- cycle 1: fixed WHY"}',
-    })
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-1-review.md": _review("RFE-1", auto_revised=False, score=8),
+            f"{RFE_REVIEWS}/RFE-1-review-state.json": '{"revision_history": "- fixed WHY"}',
+        }
+    )
     assert passed is False
     assert "RFE-1" in msg and "revised" in msg
 
 
 def test_normal_revision_flag_true_score_moved():
-    passed, _ = _run({
-        f"{RFE_REVIEWS}/RFE-2-review.md": _review("RFE-2", auto_revised=True, score=8, before_score=6),
-    })
+    passed, _ = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-2-review.md": _review(
+                "RFE-2", auto_revised=True, score=8, before_score=6
+            ),
+        }
+    )
     assert passed is True
 
 
 def test_not_revised_no_signals():
-    passed, _ = _run({
-        f"{RFE_REVIEWS}/RFE-3-review.md": _review("RFE-3", auto_revised=False, score=8),
-    })
+    passed, _ = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-3-review.md": _review("RFE-3", auto_revised=False, score=8),
+        }
+    )
     assert passed is True
 
 
 def test_flag_true_with_no_trace_fails():
-    passed, msg = _run({
-        f"{RFE_REVIEWS}/RFE-4-review.md": _review("RFE-4", auto_revised=True, score=8),
-    })
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-4-review.md": _review("RFE-4", auto_revised=True, score=8),
+        }
+    )
     assert passed is False
     assert "no trace" in msg
 
@@ -96,20 +108,26 @@ def test_flag_true_with_no_trace_fails():
 def test_saved_original_alone_never_raises_a_flag():
     # -originals/ doubles as the fetch baseline for existing Jira issues, so a
     # saved original may clear a set flag but must never fail an unset one.
-    passed, _ = _run({
-        f"{RFE_REVIEWS}/RHAIRFE-1-review.md": _review("RHAIRFE-1", auto_revised=True, score=8),
-        "artifacts/rfe-originals/RHAIRFE-1.md": "raw jira description",
-    })
+    passed, _ = _run(
+        {
+            f"{RFE_REVIEWS}/RHAIRFE-1-review.md": _review("RHAIRFE-1", auto_revised=True, score=8),
+            "artifacts/rfe-originals/RHAIRFE-1.md": "raw jira description",
+        }
+    )
     assert passed is True
 
 
 def test_removed_context_raises_missed_flag():
     # A revision that removed content but landed on the same score leaves a
     # removed-context companion; auto_revised=false is then a missed revision.
-    passed, msg = _run({
-        f"{RFE_REVIEWS}/RFE-10-review.md": _review("RFE-10", auto_revised=False, score=7, before_score=7),
-        "artifacts/rfe-tasks/RFE-10-removed-context.yaml": "blocks: []\n",
-    })
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-10-review.md": _review(
+                "RFE-10", auto_revised=False, score=7, before_score=7
+            ),
+            "artifacts/rfe-tasks/RFE-10-removed-context.yaml": "blocks: []\n",
+        }
+    )
     assert passed is False
     assert "removed-context" in msg
 
@@ -117,49 +135,67 @@ def test_removed_context_raises_missed_flag():
 def test_leftover_state_file_raises_missed_flag():
     # restore() deletes the state file on a completed cycle, so a leftover one
     # (even with empty history) is proof a re-review cycle ran.
-    passed, msg = _run({
-        f"{RFE_REVIEWS}/RFE-11-review.md": _review("RFE-11", auto_revised=False, score=7, before_score=7),
-        f"{RFE_REVIEWS}/RFE-11-review-state.json": '{"revision_history": ""}',
-    })
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-11-review.md": _review(
+                "RFE-11", auto_revised=False, score=7, before_score=7
+            ),
+            f"{RFE_REVIEWS}/RFE-11-review-state.json": '{"revision_history": ""}',
+        }
+    )
     assert passed is False
     assert "leftover review-state file" in msg
 
 
 def test_removed_context_clears_a_set_flag():
-    passed, _ = _run({
-        f"{RFE_REVIEWS}/RFE-12-review.md": _review("RFE-12", auto_revised=True, score=7),
-        "artifacts/rfe-tasks/RFE-12-removed-context.yaml": "blocks: []\n",
-    })
+    passed, _ = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-12-review.md": _review("RFE-12", auto_revised=True, score=7),
+            "artifacts/rfe-tasks/RFE-12-removed-context.yaml": "blocks: []\n",
+        }
+    )
     assert passed is True
 
 
 def test_saved_original_does_not_raise_unset_flag():
     # A saved original is a weak signal: it clears a set flag but must never
     # fail an unset one (it is also the fetch baseline, not only a backup).
-    passed, _ = _run({
-        f"{RFE_REVIEWS}/RFE-13-review.md": _review("RFE-13", auto_revised=False, score=7, before_score=7),
-        "artifacts/rfe-originals/RFE-13.md": "old body",
-    })
+    passed, _ = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-13-review.md": _review(
+                "RFE-13", auto_revised=False, score=7, before_score=7
+            ),
+            "artifacts/rfe-originals/RFE-13.md": "old body",
+        }
+    )
     assert passed is True
 
 
 def test_revision_cycles_divergence_flagged():
     # The run report says a revision happened but the frontmatter flag is unset.
-    passed, msg = _run({
-        f"{RFE_REVIEWS}/RFE-14-review.md": _review("RFE-14", auto_revised=False, score=8, before_score=8),
-        "artifacts/auto-fix-runs/20260101-000000.yaml": yaml.safe_dump(
-            {"per_rfe": [{"id": "RFE-14", "revision_cycles": 1}]}
-        ),
-    })
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-14-review.md": _review(
+                "RFE-14", auto_revised=False, score=8, before_score=8
+            ),
+            "artifacts/auto-fix-runs/20260101-000000.yaml": yaml.safe_dump(
+                {"per_rfe": [{"id": "RFE-14", "revision_cycles": 1}]}
+            ),
+        }
+    )
     assert passed is False
     assert "revision_cycles" in msg
 
 
 def test_initiative_pipeline_flag_false_but_revised():
-    passed, msg = _run({
-        f"{INIT_REVIEWS}/INIT-1-review.md": _review("INIT-1", id_field="initiative_id", auto_revised=False, score=8),
-        f"{INIT_REVIEWS}/INIT-1-review-state.json": '{"revision_history": "- cycle 1"}',
-    })
+    passed, msg = _run(
+        {
+            f"{INIT_REVIEWS}/INIT-1-review.md": _review(
+                "INIT-1", id_field="initiative_id", auto_revised=False, score=8
+            ),
+            f"{INIT_REVIEWS}/INIT-1-review-state.json": '{"revision_history": "- cycle 1"}',
+        }
+    )
     assert passed is False
     assert "INIT-1" in msg
 
@@ -168,3 +204,74 @@ def test_no_review_files():
     passed, msg = _run({"artifacts/rfe-tasks/RFE-1.md": "body"})
     assert passed is False
     assert "No review files" in msg
+
+
+# --- Robustness: malformed / legacy inputs must never raise --------------------
+# A raising check is recorded as value=None and dropped from the pass-rate
+# denominator, so on a 1.0 gate a crash silently passes. These must degrade to a
+# skipped signal instead.
+
+
+def test_non_dict_run_report_does_not_raise():
+    passed, _ = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-20-review.md": _review(
+                "RFE-20", auto_revised=True, score=8, before_score=6
+            ),
+            "artifacts/auto-fix-runs/oops.yaml": "- a\n- b\n",  # valid YAML, but a list
+        }
+    )
+    assert passed is True
+
+
+def test_non_dict_review_state_does_not_raise():
+    # A non-dict review-state.json still counts as a leftover file (existence),
+    # but must not raise while trying to read revision_history.
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review("RFE-21", auto_revised=False, score=8),
+            f"{RFE_REVIEWS}/RFE-21-review-state.json": "[1, 2, 3]",
+        }
+    )
+    assert passed is False
+    assert "leftover review-state file" in msg
+
+
+def test_initiative_snapshot_excluded_from_reports():
+    # initiative-snapshot-*.yaml is a fetch artifact, not a run report.
+    passed, _ = _run(
+        {
+            f"{INIT_REVIEWS}/INIT-2-review.md": _review(
+                "INIT-2", id_field="initiative_id", auto_revised=True, score=8, before_score=6
+            ),
+            "artifacts/auto-fix-runs/initiative-snapshot-20260101.yaml": "issues:\n- {id: x}\n",
+        }
+    )
+    assert passed is True
+
+
+def test_legacy_revised_field_honored():
+    # Old artifacts stored the flag as `revised`; a score-moving revision with
+    # revised=true must not be reported as a missed flag.
+    passed, _ = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-22-review.md": _review(
+                "RFE-22", revised=True, score=8, before_score=6
+            ),
+        }
+    )
+    assert passed is True
+
+
+def test_dashes_in_frontmatter_value_not_truncated():
+    content = (
+        "---\n"
+        "rfe_id: RFE-23\n"
+        "needs_attention_reason: 'foo --- bar'\n"
+        "auto_revised: true\n"
+        "score: 8\n"
+        "before_score: 6\n"
+        "---\n\nbody\n"
+    )
+    passed, _ = _run({f"{RFE_REVIEWS}/RFE-23-review.md": content})
+    assert passed is True

--- a/tests/test_eval_revision_flag_judge.py
+++ b/tests/test_eval_revision_flag_judge.py
@@ -275,3 +275,47 @@ def test_dashes_in_frontmatter_value_not_truncated():
     )
     passed, _ = _run({f"{RFE_REVIEWS}/RFE-23-review.md": content})
     assert passed is True
+
+
+def test_stale_report_does_not_mask_revision_evidence():
+    # Two reports name the same id; the alphabetically-later one says 0 cycles.
+    # Merging with max (not last-write-wins) keeps the revision evidence.
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-24-review.md": _review(
+                "RFE-24", auto_revised=False, score=8, before_score=8
+            ),
+            "artifacts/auto-fix-runs/aaa.yaml": yaml.safe_dump(
+                {"per_rfe": [{"id": "RFE-24", "revision_cycles": 1}]}
+            ),
+            "artifacts/auto-fix-runs/zzz.yaml": yaml.safe_dump(
+                {"per_rfe": [{"id": "RFE-24", "revision_cycles": 0}]}
+            ),
+        }
+    )
+    assert passed is False
+    assert "revision_cycles" in msg
+
+
+def test_review_state_history_non_string_does_not_crash():
+    # revision_history is normally a string; a list/dict must not raise on strip.
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-25-review.md": _review("RFE-25", auto_revised=False, score=8),
+            f"{RFE_REVIEWS}/RFE-25-review-state.json": '{"revision_history": ["- x"]}',
+        }
+    )
+    assert passed is False
+    assert "records a revision" in msg
+
+
+def test_before_scores_without_scores_not_flagged():
+    # before_scores present but scores absent must not be read as "scores moved".
+    passed, _ = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-26-review.md": _review(
+                "RFE-26", auto_revised=False, score=8, before_scores={"what": 2}
+            ),
+        }
+    )
+    assert passed is True

--- a/tests/test_eval_revision_flag_judge.py
+++ b/tests/test_eval_revision_flag_judge.py
@@ -2,9 +2,9 @@
 """Tests for the ``revision_flag_consistency`` inline-check judge.
 
 The judge body lives inline in both ``eval.yaml`` (rfe.speedrun) and
-``eval-initiative.yaml`` (initiative-speedrun). The PR that added it relies on
-the two copies being byte-identical; ``test_both_configs_identical`` fails the
-build if they ever drift. The behavioural tests exec the body exactly the way
+``eval-initiative.yaml`` (initiative-speedrun) and the two copies must remain
+byte-identical; ``test_both_configs_identical`` fails the build if they drift.
+The behavioural tests exec the body exactly the way
 the harness does (``def _check(outputs): <indented body>``) against crafted
 ``outputs`` records, so the logic has real coverage even though it is stored as
 YAML text rather than an importable module.

--- a/tests/test_eval_revision_flag_judge.py
+++ b/tests/test_eval_revision_flag_judge.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Tests for the ``revision_flag_consistency`` inline-check judge.
+
+The judge body lives inline in both ``eval.yaml`` (rfe.speedrun) and
+``eval-initiative.yaml`` (initiative-speedrun). The PR that added it relies on
+the two copies being byte-identical; ``test_both_configs_identical`` fails the
+build if they ever drift. The behavioural tests exec the body exactly the way
+the harness does (``def _check(outputs): <indented body>``) against crafted
+``outputs`` records, so the logic has real coverage even though it is stored as
+YAML text rather than an importable module.
+"""
+
+import os
+import textwrap
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+EVAL_YAML = os.path.join(REPO_ROOT, "eval.yaml")
+EVAL_INITIATIVE_YAML = os.path.join(REPO_ROOT, "eval-initiative.yaml")
+JUDGE = "revision_flag_consistency"
+
+RFE_REVIEWS = "artifacts/rfe-reviews"
+INIT_REVIEWS = "artifacts/initiative-reviews"
+
+
+def _check_body(config_path):
+    config = yaml.safe_load(open(config_path))
+    judge = next(j for j in config["judges"] if j["name"] == JUDGE)
+    return judge["check"]
+
+
+def _load_check(config_path=EVAL_YAML):
+    """Compile the inline check body into a callable, mirroring score.py."""
+    body = _check_body(config_path)
+    wrapped = "def _check(outputs):\n" + textwrap.indent(body, "    ")
+    ns = {}
+    exec(compile(wrapped, f"<check:{JUDGE}>", "exec"), ns)  # noqa: S102 - trusted repo config
+    return ns["_check"]
+
+
+def _review(item_id, id_field="rfe_id", history="none", **frontmatter):
+    frontmatter.setdefault(id_field, item_id)
+    fm = yaml.safe_dump(frontmatter, sort_keys=True)
+    return f"---\n{fm}---\n\n## Revision History\n{history}\n"
+
+
+def _run(files):
+    return _load_check()(outputs={"files": files})
+
+
+# --- Drift guard: the two configs must carry the identical judge body ---------
+
+def test_both_configs_identical():
+    assert _check_body(EVAL_YAML) == _check_body(EVAL_INITIATIVE_YAML), (
+        "revision_flag_consistency has drifted between eval.yaml and "
+        "eval-initiative.yaml; keep the two copies byte-identical."
+    )
+
+
+# --- Stable behaviours (correct before and after the fixes) -------------------
+
+def test_motivating_case_flag_false_but_state_records_revision():
+    # The INIT-012 class: auto_revised=false while a leftover review-state file
+    # records a real revision history.
+    passed, msg = _run({
+        f"{RFE_REVIEWS}/RFE-1-review.md": _review("RFE-1", auto_revised=False, score=8),
+        f"{RFE_REVIEWS}/RFE-1-review-state.json": '{"revision_history": "- cycle 1: fixed WHY"}',
+    })
+    assert passed is False
+    assert "RFE-1" in msg and "revised" in msg
+
+
+def test_normal_revision_flag_true_score_moved():
+    passed, _ = _run({
+        f"{RFE_REVIEWS}/RFE-2-review.md": _review("RFE-2", auto_revised=True, score=8, before_score=6),
+    })
+    assert passed is True
+
+
+def test_not_revised_no_signals():
+    passed, _ = _run({
+        f"{RFE_REVIEWS}/RFE-3-review.md": _review("RFE-3", auto_revised=False, score=8),
+    })
+    assert passed is True
+
+
+def test_flag_true_with_no_trace_fails():
+    passed, msg = _run({
+        f"{RFE_REVIEWS}/RFE-4-review.md": _review("RFE-4", auto_revised=True, score=8),
+    })
+    assert passed is False
+    assert "no trace" in msg
+
+
+def test_saved_original_alone_never_raises_a_flag():
+    # -originals/ doubles as the fetch baseline for existing Jira issues, so a
+    # saved original may clear a set flag but must never fail an unset one.
+    passed, _ = _run({
+        f"{RFE_REVIEWS}/RHAIRFE-1-review.md": _review("RHAIRFE-1", auto_revised=True, score=8),
+        "artifacts/rfe-originals/RHAIRFE-1.md": "raw jira description",
+    })
+    assert passed is True
+
+
+def test_initiative_pipeline_flag_false_but_revised():
+    passed, msg = _run({
+        f"{INIT_REVIEWS}/INIT-1-review.md": _review("INIT-1", id_field="initiative_id", auto_revised=False, score=8),
+        f"{INIT_REVIEWS}/INIT-1-review-state.json": '{"revision_history": "- cycle 1"}',
+    })
+    assert passed is False
+    assert "INIT-1" in msg
+
+
+def test_no_review_files():
+    passed, msg = _run({"artifacts/rfe-tasks/RFE-1.md": "body"})
+    assert passed is False
+    assert "No review files" in msg

--- a/tests/test_eval_revision_flag_judge.py
+++ b/tests/test_eval_revision_flag_judge.py
@@ -103,6 +103,58 @@ def test_saved_original_alone_never_raises_a_flag():
     assert passed is True
 
 
+def test_removed_context_raises_missed_flag():
+    # A revision that removed content but landed on the same score leaves a
+    # removed-context companion; auto_revised=false is then a missed revision.
+    passed, msg = _run({
+        f"{RFE_REVIEWS}/RFE-10-review.md": _review("RFE-10", auto_revised=False, score=7, before_score=7),
+        "artifacts/rfe-tasks/RFE-10-removed-context.yaml": "blocks: []\n",
+    })
+    assert passed is False
+    assert "removed-context" in msg
+
+
+def test_leftover_state_file_raises_missed_flag():
+    # restore() deletes the state file on a completed cycle, so a leftover one
+    # (even with empty history) is proof a re-review cycle ran.
+    passed, msg = _run({
+        f"{RFE_REVIEWS}/RFE-11-review.md": _review("RFE-11", auto_revised=False, score=7, before_score=7),
+        f"{RFE_REVIEWS}/RFE-11-review-state.json": '{"revision_history": ""}',
+    })
+    assert passed is False
+    assert "leftover review-state file" in msg
+
+
+def test_removed_context_clears_a_set_flag():
+    passed, _ = _run({
+        f"{RFE_REVIEWS}/RFE-12-review.md": _review("RFE-12", auto_revised=True, score=7),
+        "artifacts/rfe-tasks/RFE-12-removed-context.yaml": "blocks: []\n",
+    })
+    assert passed is True
+
+
+def test_saved_original_does_not_raise_unset_flag():
+    # A saved original is a weak signal: it clears a set flag but must never
+    # fail an unset one (it is also the fetch baseline, not only a backup).
+    passed, _ = _run({
+        f"{RFE_REVIEWS}/RFE-13-review.md": _review("RFE-13", auto_revised=False, score=7, before_score=7),
+        "artifacts/rfe-originals/RFE-13.md": "old body",
+    })
+    assert passed is True
+
+
+def test_revision_cycles_divergence_flagged():
+    # The run report says a revision happened but the frontmatter flag is unset.
+    passed, msg = _run({
+        f"{RFE_REVIEWS}/RFE-14-review.md": _review("RFE-14", auto_revised=False, score=8, before_score=8),
+        "artifacts/auto-fix-runs/20260101-000000.yaml": yaml.safe_dump(
+            {"per_rfe": [{"id": "RFE-14", "revision_cycles": 1}]}
+        ),
+    })
+    assert passed is False
+    assert "revision_cycles" in msg
+
+
 def test_initiative_pipeline_flag_false_but_revised():
     passed, msg = _run({
         f"{INIT_REVIEWS}/INIT-1-review.md": _review("INIT-1", id_field="initiative_id", auto_revised=False, score=8),

--- a/tests/test_eval_revision_flag_judge.py
+++ b/tests/test_eval_revision_flag_judge.py
@@ -319,3 +319,34 @@ def test_before_scores_without_scores_not_flagged():
         }
     )
     assert passed is True
+
+
+def test_non_list_report_section_does_not_raise():
+    # per_rfe as a dict (not a list) must not raise on dict + list concatenation.
+    passed, _ = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-27-review.md": _review(
+                "RFE-27", auto_revised=True, score=8, before_score=6
+            ),
+            "artifacts/auto-fix-runs/r.yaml": yaml.safe_dump(
+                {"per_rfe": {"id": "RFE-27", "revision_cycles": 1}}
+            ),
+        }
+    )
+    assert passed is True
+
+
+def test_non_int_revision_cycles_ignored():
+    # A string/bool revision_cycles must not raise inside max(); it is ignored,
+    # so it cannot invent revision evidence.
+    passed, _ = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-28-review.md": _review(
+                "RFE-28", auto_revised=False, score=8, before_score=8
+            ),
+            "artifacts/auto-fix-runs/r.yaml": yaml.safe_dump(
+                {"per_rfe": [{"id": "RFE-28", "revision_cycles": "1"}]}
+            ),
+        }
+    )
+    assert passed is True


### PR DESCRIPTION
## Description

Adds one inline check judge, `revision_flag_consistency`, to both `eval.yaml` and `eval-initiative.yaml`, gated at `min_pass_rate: 1.0`. It fails a run when a review's `auto_revised` flag disagrees with the artifacts left behind by the revise path.

An initiative-speedrun run revised INIT-012 and left `auto_revised: false` on the review. `INIT-012-review-state.json` records `before_score: 5` and a full `revision_history`; the review frontmatter records neither, and the body's Revision History section reads "none". That flag drives the auto-revised Jira label, so the one Initiative in the run that was actually revised is the one that would ship unlabeled. No judge noticed — the eval reported PASS.

**Not Initiative-specific**, which is why the same block goes in both configs. Every artifact the flag should agree with comes from code shared with the RFE pipeline: [preserve_review_state.py](scripts/preserve_review_state.py) branches on the ID prefix and writes the same `{ID}-review-state.json` either way, [generate_run_report.py](scripts/generate_run_report.py) is one script whose only difference is `per_rfe` vs `per_initiative`, and both review schemas in [artifact_utils.py](scripts/artifact_utils.py) carry the same `auto_revised`, `before_score` and `before_scores`. The judge block is byte-identical in the two files: it locates the review-state file relative to the review it is checking, indexes companions by basename, reads `rfe_id or initiative_id`, and accepts whichever of `per_rfe`/`per_initiative` the run report happens to use.

### How it decides

**Strong signals** — proof a revision happened. Any of these with `auto_revised: false` is a failure, and each also clears a set flag:

- a leftover `{ID}-review-state.json` — `preserve_review_state.py restore` deletes it once a re-review cycle completes, so a survivor on disk is a save/restore cycle that never finished
- a recorded `revision_history` inside that state file
- `before_score` differing from `score`
- `before_scores` differing from `scores` (when both are present)
- a `{ID}-removed-context.yaml` companion — written only when a revision removes content, so it proves a revision even when the re-score landed on the same number

`revision_cycles > 0` for that ID in the run report is a **cross-check, not an independent witness**: `generate_run_report.py` derives `revision_cycles` from `auto_revised` itself, so within one run's artifacts it can only catch a run-report / frontmatter divergence — never a flag that was simply never set (the signals above do that).

**Weak signal** — clears `auto_revised: true` but never fails an unset flag: a saved pre-revision original in `-originals/`. That asymmetry is deliberate. `-originals/` is also the fetch baseline for existing Jira issues, not only a revision backup, so treating it as proof of revision would produce false regressions on a 1.0 gate. So a `false` flag fails only when a strong signal is present, and a `true` flag fails only on a *total* absence of any trace.

The body's `## Revision History` section is deliberately **not** a signal. It is template boilerplate that read "none" on all 16 reviews in the run, INIT-012's included — a second symptom of the same bug, not an independent witness.

`min_pass_rate: 1.0` because this is a consistency invariant, not a quality score: one violation is a regression.

### Follow-up commits (review hardening)

Later commits on the branch extend the judge and lock it down; both configs stay byte-identical throughout:

- **Raise a missed flag, not only clear a set one.** Originally a leftover review-state file, a saved original, and a removed-context companion could only *clear* `auto_revised: true` — so a revision that reworded or removed content without moving the rubric score slipped through with `auto_revised: false` (a sibling of INIT-012 with no recorded `revision_history`). The two revision-only artifacts (leftover state file, removed-context companion) are now strong signals that also fail an unset flag; the saved original stays weak-only.
- **Never raise on malformed input.** A raising check is recorded as `value=None` and dropped from the pass-rate denominator, so on a 1.0 gate a crash *silently passes*. The check now guards non-dict reports/review-state/frontmatter, validates the nested `per_rfe`/`per_initiative`/`revision_cycles` shapes, hardens the `revision_history` read against non-string values, merges duplicate run reports with `max` (so a stale report can't mask newer evidence), and splits frontmatter on the closing fence only (a literal `---` in a value can't truncate it).
- **Cross-pipeline + legacy correctness.** Excludes both snapshot prefixes (`issue-snapshot-` and `initiative-snapshot-`), and honors the legacy `revised` field (`artifact_utils` migrates it to `auto_revised` on read, but the judge parses raw YAML).
- **Committed tests + drift guard.** `tests/test_eval_revision_flag_judge.py` execs the check body the way the harness does and covers every case above; `test_both_configs_identical` fails the build if the two inline copies ever diverge (a drift guard, since a shared `module:` judge would break `validate_eval`, which can't import a repo-root module). Runs in the existing pytest CI.

## How Has This Been Tested?

`uv run pytest tests/` passes, including the committed `tests/test_eval_revision_flag_judge.py` added by the follow-up commits.

**Replayed against the archived 2026-08-10 initiative-speedrun run**, extracting the check body from `eval-initiative.yaml` itself so the tested text and the shipped text are provably the same:

    PASS  case-001 … 15 cases pass
    FAIL  case-012: INIT-012: auto_revised=false but revised (review-state records a revision)

    16 cases, 1 failed, pass_rate=0.938
    threshold min_pass_rate=1.0

That is the intended outcome — the judge catches on the real run the bug it was written for, and would have failed the eval that passed.

**Synthetic cases**, now committed as unit tests, cover the RFE directory layout (`rfe-tasks`/`rfe-originals`) and the Initiative one, the converse direction (`auto_revised: true` with no trace), `revision_cycles` of 0 and 1, a stale run report, snapshot YAMLs under `artifacts/auto-fix-runs/` that must not be parsed as a run report, non-dict / unparseable review-state and reports, the legacy `revised` field, and a run with no review files. All produce the expected verdict, and every malformed input degrades to "skip this signal" rather than erroring.

`scripts/validate_eval.py config` on both files: judges 9 → 10, no new errors or warnings — same status as `main` (the pre-existing top-level `skill:` deprecation warning is unchanged).

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Quality Improvements**
  * Improved revision tracking across evaluation workflows for more consistent results.
  * Strengthened handling of review history, score comparisons, revision indicators, and supporting evidence.
  * Improved resilience when processing legacy, incomplete, malformed, or stale evaluation data.
  * Added safeguards for consistent revision-signal evaluation across RFE and Initiative workflows.
  * Updated evaluation criteria to require a 100% minimum pass rate.

* **Tests**
  * Added comprehensive coverage for revision tracking, legacy inputs, malformed data, snapshot files, and stale reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
