### PR TITLE
Make two more initiative eval cases exercise the revise path

### DIFF
--- a/eval/initiative-dataset/cases/case-007-gpu-utilization-observability/annotations.yaml
+++ b/eval/initiative-dataset/cases/case-007-gpu-utilization-observability/annotations.yaml
@@ -1,16 +1,23 @@
 difficulty: null
 expected_alignment: not_assessed
 expected_feasibility: null
-expected_pass: null
+expected_pass: false
 expected_recommendation: revise
 expected_scores:
   what: null
   why: null
   scope: null
-  open_to_how: null
+  open_to_how: 0
   right_sized: null
 expected_total: null
-known_issues: []
+known_issues:
+  - 'Mandates a settled implementation stack (Telegraf, InfluxDB, Superset, Kapacitor) and
+    tells engineering not to reopen it. Should score open_to_how 0 and fail on the no-zeros
+    rule despite strong what/why/scope.'
+  - 'Designed to exercise the recoverable revise path: prescriptive technology choices can be
+    reframed into suggestive language, so revision should lift the score rather than flag for
+    a human.'
 tags:
   - infrastructure
   - prescriptive
+  - revise-candidate

--- a/eval/initiative-dataset/cases/case-007-gpu-utilization-observability/input.yaml
+++ b/eval/initiative-dataset/cases/case-007-gpu-utilization-observability/input.yaml
@@ -1,22 +1,27 @@
 clarifying_context: 'We are spending a lot on GPU clusters and have almost no visibility
-  into how well they are actually being used. People request nodes for KServe inference
-  endpoints or training operator jobs, saturate them for an hour, and then the hardware
-  sits idle until someone else comes along. We do not even have basic utilization
-  dashboards, so nobody can answer simple questions like which vLLM deployments are
-  over-provisioned or whether we could consolidate training workloads onto fewer nodes.
+  into how well they are actually being used. The last three months of billing put GPU
+  nodes at 61 percent of platform cloud spend, and the two spot checks we ran found
+  average utilization under 20 percent on the training pool. People request nodes for
+  KServe inference endpoints or training operator jobs, saturate them for an hour, and
+  then the hardware sits idle until someone else comes along. Four capacity escalations
+  last quarter ended the same way -- we bought more nodes because nobody could show that
+  the ones we had were free.
 
-  The idea is to build an observability layer that collects GPU metrics at the pod and
-  node level, feeds them into our existing monitoring stack, and surfaces dashboards that
-  show utilization trends over time. We also want alerting for sustained low utilization
-  so we can right-size allocations. The implementation should use Prometheus with DCGM
-  Exporter for GPU metric collection, Grafana for the dashboards, and TimescaleDB as
-  the long-term metrics store for historical trend analysis. Eventually we would like
-  to tie this into the scheduling layer so the platform can bin-pack more aggressively,
-  but that is a follow-on -- the first milestone is just getting the data flowing and
-  visible. We think this could save us a meaningful chunk of our cloud bill once teams
-  can actually see what they are using.'
+  What we want to deliver is an observability layer that collects GPU metrics at the pod
+  and node level, retains them long enough for trend analysis, and surfaces dashboards
+  that answer the questions we cannot answer today: which deployments are over-provisioned,
+  which pools sit idle overnight, and where we could consolidate. It also needs alerting
+  on sustained low utilization so teams get told to right-size instead of finding out at
+  the next bill review. In scope: metric collection, retention, the dashboards, and the
+  low-utilization alerts. Out of scope: acting on the data automatically -- feeding it to
+  the scheduler for tighter bin-packing is a follow-on initiative -- and CPU or memory
+  accounting, which is already covered elsewhere. The technical decisions here are made
+  and closed: Telegraf runs as the collection agent on every node, InfluxDB is the metrics
+  store, Superset renders the dashboards, and Kapacitor evaluates the alerting rules.
+  Engineering should build against those four choices rather than reopen the evaluation.'
 priority: Critical
 prompt: We need real visibility into GPU utilization across our clusters. Right now
   nobody can tell which workloads are wasting capacity, and we are spending a lot of
-  money on hardware that sits idle between jobs. We want to implement this using
-  Prometheus with DCGM Exporter and Grafana dashboards for the observability layer.
+  money on hardware that sits idle between jobs. The stack for this is already settled --
+  Telegraf for collection, InfluxDB for storage, Superset for dashboards, Kapacitor for
+  alerting -- so the work is to build it out on those components.

--- a/eval/initiative-dataset/cases/case-013-scaleup-test-matrix-dynamic/annotations.yaml
+++ b/eval/initiative-dataset/cases/case-013-scaleup-test-matrix-dynamic/annotations.yaml
@@ -1,15 +1,30 @@
 difficulty: null
 expected_alignment: not_assessed
 expected_feasibility: null
-expected_pass: null
-expected_recommendation: null
+expected_pass: false
+expected_recommendation: revise
 expected_scores:
   what: null
-  why: null
+  why: 0
   scope: null
   open_to_how: null
   right_sized: null
 expected_total: null
-known_issues: []
+known_issues:
+  - 'Circular justification -- it should be dynamic because it is static -- with the input
+    explicitly stating no measurement, tickets, or complaints exist. Should score why 0 and
+    fail on the no-zeros rule despite strong what/scope/open_to_how/right_sized.'
+  - 'Designed to exercise the terminal end of the revise path: the revise agent is forbidden
+    from inventing evidence, so revision should mark the gap and set needs_attention rather
+    than recover the score.'
+  - 'The input negates the structural argument, not just the evidence. Withholding numbers
+    alone scored why 1 twice: the create agent reconstructed drift, combinatorial burden,
+    slow turnaround, and no-single-source-of-truth from the deliverable itself, and the
+    assessor credited those as plausible mechanisms. The context now states the list is
+    edited twice a year, no run has failed on a stale configuration, changes land same-day,
+    and no team has been blocked, so those mechanisms cannot be asserted without
+    contradicting the source.'
 tags:
   - infrastructure
+  - no-evidence
+  - revise-candidate

--- a/eval/initiative-dataset/cases/case-013-scaleup-test-matrix-dynamic/input.yaml
+++ b/eval/initiative-dataset/cases/case-013-scaleup-test-matrix-dynamic/input.yaml
@@ -1,7 +1,28 @@
-clarifying_context: 'Our scale-up test configurations are all hardcoded today, so every time
-  someone needs a new combination of parameters they have to go edit pipeline definitions
-  by hand. We want to make the matrix composable at runtime so teams can declare what they
-  need and the job figures out the right set of runs on its own.'
+clarifying_context: 'The deliverable is a matrix service the nightly scale-up job calls
+  before it schedules anything. Teams declare the axes they care about -- node count,
+  accelerator type, model size, batch profile -- in a versioned config, the service expands
+  those into a concrete run list, drops the combinations that no longer have hardware
+  behind them, and hands the job a plan it can execute as-is. In scope: the declarative
+  config format, the expansion service, the hardware compatibility filter, and the handoff
+  to the existing nightly job. Out of scope: changing the tests themselves, provisioning
+  new hardware, and the reporting side, which stays exactly where it is. How the expansion
+  gets built -- a standalone service, a library the job imports, a generation step at build
+  time -- is wide open, and whoever picks this up should choose.
+
+  On why now, I would rather be accurate than persuasive, and the accurate answer is that
+  nothing is going wrong. The list has not gone stale: it is edited about twice a year, and
+  the last hardware retirement was handled in the same PR that decommissioned the nodes. No
+  nightly run has ever failed on a configuration that no longer exists. A matrix change is a
+  one-line edit that lands the same day it is opened. The two teams that use the job have
+  never asked for an axis they did not get, nobody has been blocked, and nobody has
+  complained. Coverage is what we intend it to be.
+
+  So the case is just that the matrix is static and we would rather it were dynamic --
+  a test platform at our scale should have a dynamic matrix. That is the entire argument.
+  Please do not write up drift, maintenance burden, slow turnaround, or coverage gaps as
+  problems we are having; we are not having them, and I would rather this say plainly that
+  there is no evidence than manufacture a case for it.'
 priority: Critical
 prompt: We need the scale-up test matrix to be assembled and executed dynamically rather than
-  maintained as a static list of configurations.
+  maintained as a static list of configurations. We do not have a dynamic matrix today and a
+  test platform at our scale should have one.


### PR DESCRIPTION
## Description

Recalibrates two existing Initiative eval cases so the pipeline is forced down the revise path to add more coverage. No cases added or removed — the dataset stays at 16.

The two cases below take the opposite ends of that path — one revision that should succeed, one that structurally cannot.

### case-007 — recoverable revision

This case was **already** tagged `prescriptive` with `expected_recommendation: revise`. It scored `open_to_how: 1`, total 9, and passed — the annotation said revise, the pipeline said submit.

The cause is the technology list. Prometheus, DCGM Exporter and Grafana are on the [assess-initiative rubric](https://github.com/opendatahub-io/assess-rfe)'s allowlist of established RHOAI technologies, where naming them counts as platform vocabulary rather than architecture prescription — exactly as the rubric intends. The case was never prescriptive in the way it claimed to be.

Swapped to Telegraf / InfluxDB / Superset / Kapacitor: all off the allowlist, all with obvious alternatives, and framed as a decision that is closed and not to be reopened. Also strengthened WHY (61% of platform cloud spend, sub-20% utilization on the training pool, four capacity escalations) and added explicit in/out scope, so `open_to_how` is the only zero and the case fails purely on the no-zeros rule at a total of ~8.

This one is recoverable. The revise agent's "Reframe, don't remove" rule covers it directly, so a revision should convert the mandated stack into suggestive language and lift the score. That exercises `check_content_preservation.py`, the `-removed-context.yaml` block classification, the re-assess cycle, `before_score` vs `score`, `auto_revised: true`, and the `initiative-auto-revised` label path.

### case-013 — unrecoverable revision

This was the lowest-information case in the set: a 311-character `clarifying_context`, every annotation null, and `infrastructure` as its only tag — already covered by cases 007, 008 and 014.

Kept the domain and rewrote it around a circular justification. It now has a specific deliverable, explicit in/out scope, and an explicitly open implementation, but the entire WHY is that the matrix is static and should not be. Expected `why: 0`, everything else strong.

**Withholding the evidence is not enough on its own.** An earlier draft of this case said only that nobody had counted the blocking, no complaint had been filed, and no numbers existed. It scored `why: 1` in the 2026-08-10 run and again in the 2026-08-11 run, and the assessor's rationale was explicit both times — it credited "four concrete failure modes ... with plausible mechanisms" and read the no-data admission as a well-reasoned engineering argument, which the rubric scores as a 1.

None of those four mechanisms — configuration drift, manual combinatorial management, slow turnaround, no single source of truth — appear anywhere in the input. The create agent derived all four from the deliverable itself. A well-specified WHAT implies its own structural WHY, so staying silent on the evidence just leaves the write-up free to reconstruct the argument from the deliverable.

So the case now **negates** those mechanisms rather than staying silent on them: the list is edited about twice a year, the last hardware retirement was handled in the same PR that decommissioned the nodes, no nightly run has ever failed on a configuration that no longer exists, a matrix change is a one-line edit that lands the same day, and the two consuming teams have never asked for an axis they did not get. The write-up cannot assert drift or turnaround pain without contradicting its source, which leaves bare assertion: the matrix is static and we would rather it were dynamic.

`what`, `scope` and `open_to_how` are untouched, so `why` remains the only candidate zero — and a single zero routes to `revise`, not `reject` ([review-agent.md](.claude/skills/initiative-review/prompts/review-agent.md) reserves reject for 3+ zeros).

This one cannot be fixed by revision — [revise-agent.md](.claude/skills/initiative-review/prompts/revise-agent.md) explicitly forbids inventing evidence — so it should mark the gap, set `needs_attention=true` with a `needs_attention_reason`, and stop at the 2-cycle cap. That is the terminal state the eval has never produced, and it runs the `preserve_review_state.py` save/restore round-trip that the `auto_revised` bug in #154 was hiding in.

Note that case-012 now covers the regression end of that path organically (5 → 4 → `autorevise_reject` in the 2026-08-11 run), so case-013's remaining job is specifically the `needs_attention_reason` path.

### Design constraints

Neither case trips a revise bypass in [filter_for_revision.py](scripts/filter_for_revision.py): `right_sized: 0` routes to split and `feasibility: infeasible` skips revision, so both are avoided.

`expected_feasibility` stays null on both. Off-standard tooling on 007 may legitimately read as `indeterminate`, which does not bypass revision — asserting `feasible` would add a failure mode without testing anything. Following the existing annotation convention, only the targeted criterion is filled in; the rest stay null.

## How Has This Been Tested?

- All 16 cases round-trip through `yaml.safe_load`; annotation keys and `expected_scores` keys match the existing schema exactly; no duplicate prompts across the dataset.
- `scripts/validate_batch_input.py --type initiative --strict` over a batch assembled from all 16 inputs: `ERROR_COUNT=0 WARNING_COUNT=0 VALID=true`.
- `uv run pytest tests/` — 757 passed. No Python touched.
- Whether case-013 actually reaches `why: 0` is only knowable from a live run. The material the assessor credited in the two prior runs has been removed, but this is the third calibration attempt at that criterion.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Evaluation Updates**
  * Refined GPU observability and dynamic scale-up matrix assessment scenarios.
  * Added clearer requirements, scope boundaries, and implementation context for both initiatives.
  * Updated assessment outcomes, recommendations, scoring, and review tags to reflect identified issues and revision needs.
  * Documented concerns including prescriptive technology choices, unsupported evidence, circular justification, and insufficient operational rationale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
