### PR TITLE
Report a refused split as blocked, not as a successful split

### DIFF
--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -26,7 +26,7 @@ TYPE_CONFIG = {
         "reviews_dir": "rfe-reviews",
         "item_key": "per_rfe",
         "output_prefix": "",
-        "extra_entry_fields": [],
+        "extra_entry_fields": ["needs_attention"],
         "scan_tasks": scan_task_files,
         "id_field": "rfe_id",
         # parent_key values that mean "split from"; see split_children_map.
@@ -51,6 +51,11 @@ TYPE_CONFIG = {
 }
 
 SCORE_FIELDS = TYPE_CONFIG["rfe"]["score_fields"]
+
+# submit.py writes this marker into review frontmatter when split_submit refuses
+# a split outright — too many leaf children (exit 2) or a Jira conflict (exit 3).
+# Nothing was created in Jira, so the parent is blocked, not split.
+SPLIT_REFUSED_PREFIX = "split_refused:"
 
 
 def split_children_map(artifacts_dir, config):
@@ -107,7 +112,7 @@ def build_report(
     before_totals = {f: [] for f in score_fields}
     after_totals = {f: [] for f in score_fields}
     before_score_list, after_score_list = [], []
-    counts = {"passed": 0, "failed": 0, "split": 0, "errors": 0}
+    counts = {"passed": 0, "failed": 0, "split": 0, "blocked": 0, "errors": 0}
 
     for item_id in expanded_ids:
         if entry_type == "rfe":
@@ -164,7 +169,18 @@ def build_report(
         if kids:
             entry["children"] = kids
 
-        if rec == "split":
+        # A refused split recommended `split` but produced nothing in Jira. Read
+        # the outcome submit.py recorded rather than re-deriving it here — the
+        # cap lives in split_submit and refusal has more than one cause.
+        review_error = data.get("error") or ""
+        blocked_reason = None
+        if review_error.startswith(SPLIT_REFUSED_PREFIX):
+            blocked_reason = data.get("needs_attention_reason") or review_error
+            entry["blocked_reason"] = blocked_reason
+
+        if blocked_reason:
+            counts["blocked"] += 1
+        elif rec == "split":
             counts["split"] += 1
         elif data.get("pass", False):
             counts["passed"] += 1

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -47,6 +47,30 @@ Looks good.
 """
 
 
+REVIEW_REFUSED_TEMPLATE = """\
+---
+rfe_id: {rfe_id}
+score: 6
+pass: false
+recommendation: split
+feasibility: feasible
+auto_revised: false
+needs_attention: true
+needs_attention_reason: {reason}
+error: '{error}'
+scores:
+  what: 2
+  why: 1
+  open_to_how: 2
+  not_a_task: 1
+  right_sized: 0
+---
+
+## Feedback
+Too big.
+"""
+
+
 def _write(path, content):
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w") as f:
@@ -385,3 +409,99 @@ class TestGenerateReviewPdfArtifactsDir:
         with open(out_file) as f:
             html = f.read()
         assert "RHAIRFE-500" in html
+
+
+class TestRefusedSplitIsBlockedNotSplit:
+    """A split split_submit refused created nothing in Jira — it is blocked work.
+
+    submit.py records the refusal in the review frontmatter; the report surfaces
+    it rather than re-deriving the leaf-count rule that lives in split_submit.
+    """
+
+    def _refused(self, art_dir, rfe_id, error, reason="Automatic splitting produced too many"):
+        _write(f"{art_dir}/rfe-tasks/{rfe_id}.md", TASK_TEMPLATE.format(rfe_id=rfe_id, extra=""))
+        _write(
+            f"{art_dir}/rfe-reviews/{rfe_id}-review.md",
+            REVIEW_REFUSED_TEMPLATE.format(rfe_id=rfe_id, reason=reason, error=error),
+        )
+
+    def test_too_many_children_is_blocked(self, art_dir):
+        self._refused(art_dir, "RHAIRFE-2429", "split_refused: too many leaf children")
+
+        report = build_report(["RHAIRFE-2429"], "2026-08-15T03:09:45Z", 5, [], [])
+
+        entry = report["per_rfe"][0]
+        assert entry["blocked_reason"] == "Automatic splitting produced too many"
+        assert report["results"]["blocked"] == 1
+        assert report["results"]["split"] == 0
+
+    def test_jira_conflict_is_also_blocked(self, art_dir):
+        self._refused(
+            art_dir,
+            "RHAIRFE-2455",
+            "split_refused: jira conflict",
+            reason="Parent description was modified in Jira since fetch.",
+        )
+
+        report = build_report(["RHAIRFE-2455"], "2026-08-15T03:09:45Z", 5, [], [])
+
+        assert report["per_rfe"][0]["blocked_reason"].startswith("Parent description")
+        assert report["results"]["blocked"] == 1
+
+    def test_recommendation_is_preserved(self, art_dir):
+        """`recommendation` is what the review advised; blocked_reason is what happened."""
+        self._refused(art_dir, "RHAIRFE-3121", "split_refused: too many leaf children")
+
+        report = build_report(["RHAIRFE-3121"], "2026-08-15T03:09:45Z", 5, [], [])
+
+        assert report["per_rfe"][0]["recommendation"] == "split"
+
+    def test_successful_split_is_untouched(self, art_dir):
+        """A split that went through still counts as split and carries no reason."""
+        _write(
+            f"{art_dir}/rfe-tasks/RHAIRFE-3079.md",
+            TASK_TEMPLATE.format(rfe_id="RHAIRFE-3079", extra=""),
+        )
+        _write(
+            f"{art_dir}/rfe-reviews/RHAIRFE-3079-review.md",
+            REVIEW_TEMPLATE.format(
+                rfe_id="RHAIRFE-3079",
+                score=8,
+                pass_val="false",
+                recommendation="split",
+                right_sized=1,
+            ),
+        )
+
+        report = build_report(["RHAIRFE-3079"], "2026-08-06T15:21:14Z", 5, [], [])
+
+        assert "blocked_reason" not in report["per_rfe"][0]
+        assert report["results"]["split"] == 1
+        assert report["results"]["blocked"] == 0
+
+    def test_unrelated_review_error_is_not_blocked(self, art_dir):
+        """Only the split_refused marker means blocked, not any error field."""
+        _write(
+            f"{art_dir}/rfe-tasks/RHAIRFE-9000.md",
+            TASK_TEMPLATE.format(rfe_id="RHAIRFE-9000", extra=""),
+        )
+        _write(
+            f"{art_dir}/rfe-reviews/RHAIRFE-9000-review.md",
+            REVIEW_REFUSED_TEMPLATE.format(
+                rfe_id="RHAIRFE-9000", reason="Scorer timed out", error="assess_failed: timeout"
+            ),
+        )
+
+        report = build_report(["RHAIRFE-9000"], "2026-08-15T03:09:45Z", 5, [], [])
+
+        assert "blocked_reason" not in report["per_rfe"][0]
+        assert report["results"]["blocked"] == 0
+        assert report["results"]["split"] == 1
+
+    def test_needs_attention_is_surfaced_on_rfe_entries(self, art_dir):
+        """The initiative report already carried this; the RFE side did not."""
+        self._refused(art_dir, "RHAIRFE-2429", "split_refused: too many leaf children")
+
+        report = build_report(["RHAIRFE-2429"], "2026-08-15T03:09:45Z", 5, [], [])
+
+        assert report["per_rfe"][0]["needs_attention"] is True

--- a/tests/test_initiative_run_report.py
+++ b/tests/test_initiative_run_report.py
@@ -277,7 +277,13 @@ class TestSplitChildrenIncluded:
         ids = [e["id"] for e in report["per_initiative"]]
         assert ids == ["INIT-001", "INIT-002", "INIT-003"]
         assert report["per_initiative"][0]["children"] == ["INIT-002", "INIT-003"]
-        assert report["results"] == {"passed": 2, "failed": 0, "split": 1, "errors": 0}
+        assert report["results"] == {
+            "passed": 2,
+            "failed": 0,
+            "split": 1,
+            "blocked": 0,
+            "errors": 0,
+        }
         # input_count reflects caller-supplied IDs only
         assert report["input_count"] == 1
 


### PR DESCRIPTION
## Problem

`split_submit` refuses a split outright when it would create more than `MAX_LEAF_CHILDREN` leaves (exit 2), or when the parent was edited in Jira since fetch (exit 3). Nothing is created and the parent stays open.

`submit.py` already handles this well on the Jira side — it comments on the parent, adds `rfe-creator-needs-attention`, and records the reason in the review frontmatter. But the run report still emitted `recommendation: split` and counted it under `results.split`, so **a refusal was published as a success**.

That is what kept it invisible to the RFE quality dashboard. `RHAIRFE-2429` and `RHAIRFE-2455` were refused on ~11 consecutive nightly runs in late June and are still unsplit; the reports show nothing. Across the 279 published run reports, 0 of 61 splits with 7+ leaves were ever submitted.

## Approach

Surface what submit already recorded rather than re-deriving the rule here. The cap lives in `split_submit`, refusal has more than one cause, and the review frontmatter already carries:

```yaml
error: 'split_refused: too many leaf children'
needs_attention: true
needs_attention_reason: Automatic splitting produced too many child RFEs...
```

`generate_run_report.py` reads that exact file and simply never read those fields. The miscount is `rec == "split"` short-circuiting before anything inspects `error`.

## Changes

- entries carrying a `split_refused:` marker gain `blocked_reason`
- `results` gains a `blocked` count; such entries no longer bump `split`
- `needs_attention` added to the rfe `extra_entry_fields`, matching the initiative side which already surfaced it

`recommendation` is left as `split` — it is what the review advised; `blocked_reason` is what happened.

## Verification

Full suite green (763 passed), ruff clean, six new tests.

Backfilled over all 279 run directories in `rfe-autofixer-results`, using each run's own `rfe-tasks/` + `rfe-reviews/` as the artifacts dir:

```
reviews carrying split_refused : 57
entries given blocked_reason   : 57
mismatches                     : 0
```

Every blocked entry retains `recommendation: split` (asserted).

Two notes from the backfill. 61 parents are over-cap by report structure but only 57 carry the marker — of the 4 without it, 3 sit in runs whose post-submit push never landed, so the published review file is the pre-submit version. And all 57 markers are `too many leaf children`: the exit-3 Jira-conflict path has never fired in production, so its test is correct-by-code but untriggered.

## Design note

Blocked entries are deliberately **not** added to the top-level `errors` list. `errors` is `[e for e in per_item if "error" in e]` and today means "the review file could not be read" — those entries have no score or recommendation. Putting a fully-populated blocked entry there would conflate the two conditions or desync `len(errors)` from `results.errors`.

## Not in this change

Three eval configs describe the report's `results` keys to judges and now omit the new count: `eval.yaml:131`, `eval-openrouter.yaml:197`, `eval-initiative.yaml:132`.

RHAIFIRST-562, part of RHAIFIRST-553.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run reports now flag entries that need attention.
  * Reports recognize refused split reviews and record them as blocked.
  * Blocked reports preserve the recommendation and reason for refusal.

* **Bug Fixes**
  * Refused splits are no longer counted as successful splits.
  * Existing review outcomes and unrelated report counts remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->