### PR TITLE
Stop the snapshot bootstrap from failing silently

### DIFF
--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -55,7 +55,13 @@ BOOTSTRAP_CONFIG = {
 def _load_run_report(results_dir, run_name, config=None):
     """Load processed IDs and report from the run's item list.
 
-    Returns (set_of_ids, report_dict) or (None, None) if no report found.
+    Returns (set_of_ids, report_dict), or (None, None) if no report file exists.
+
+    Raises ValueError when the file exists but cannot be understood — unreadable, malformed YAML,
+    not a mapping, or entries without an id. That is a different situation from absence: absence
+    has a documented fallback, whereas a corrupt report says nothing about what the run processed,
+    and treating it as absent would misdiagnose it (0 of the 278 published reports have any of
+    these shapes, so this is defence, not compatibility).
     """
     cfg = config or BOOTSTRAP_CONFIG["rfe"]
     report_prefix = cfg["report_prefix"]
@@ -63,9 +69,17 @@ def _load_run_report(results_dir, run_name, config=None):
     path = os.path.join(results_dir, run_name, "auto-fix-runs", f"{report_prefix}{run_name}.yaml")
     if not os.path.exists(path):
         return None, None
-    with open(path, encoding="utf-8") as f:
-        report = yaml.safe_load(f)
-    ids = {e["id"] for e in report.get(item_key, [])}
+    try:
+        with open(path, encoding="utf-8") as f:
+            report = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError) as e:
+        raise ValueError(f"run report {path} is unreadable: {e}") from e
+    if not isinstance(report, dict):
+        raise ValueError(f"run report {path} is not a mapping (got {type(report).__name__})")
+    try:
+        ids = {e["id"] for e in report.get(item_key, [])}
+    except (TypeError, KeyError) as e:
+        raise ValueError(f"run report {path} has malformed {item_key} entries: {e}") from e
     if not ids:
         return None, None
     return ids, report
@@ -369,7 +383,21 @@ def main():
     print(f"Fetched {len(current)} issues from Jira", file=sys.stderr)
 
     # Filter to issues that were actually processed in the run
-    processed_ids, report = _load_run_report(args.results_dir, run_name, config=boot_config)
+    try:
+        # The report half of the tuple is unused here — main() only needs the ID filter.
+        processed_ids, _ = _load_run_report(args.results_dir, run_name, config=boot_config)
+    except ValueError as e:
+        # Present but not understood is not the same as absent: absence has a documented
+        # fallback, a corrupt report does not. Only an explicit --include-all proceeds.
+        if not args.include_all:
+            print(
+                f"Error: {e}. Pass --include-all to snapshot every fetched issue "
+                f"as unprocessed instead.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(f"Warning: {e} — --include-all set, including all issues", file=sys.stderr)
+        processed_ids = None
     unfiltered = processed_ids is None
     if unfiltered:
         if not args.include_all and _run_dir_has_snapshots(args.results_dir, run_name):

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -76,6 +76,12 @@ def _load_run_report(results_dir, run_name, config=None):
         raise ValueError(f"run report {path} is unreadable: {e}") from e
     if not isinstance(report, dict):
         raise ValueError(f"run report {path} is not a mapping (got {type(report).__name__})")
+    if item_key not in report:
+        # The drift shape: a report written under a different item key. An empty LIST is a
+        # legitimate zero-count run and keeps the documented fallback; a missing KEY means the
+        # writer and this reader disagree about the schema, and pretending the report is absent
+        # would hide exactly that.
+        raise ValueError(f"run report {path} has no {item_key} item list")
     try:
         ids = {e["id"] for e in report.get(item_key, [])}
     except (TypeError, KeyError) as e:

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -71,6 +71,24 @@ def _load_run_report(results_dir, run_name, config=None):
     return ids, report
 
 
+def _run_dir_has_snapshots(results_dir, run_name):
+    """True if the run directory holds issue snapshots.
+
+    A run published by the pipeline always carries both a snapshot and a run report, so snapshots
+    without a report means the results directory is partial — most often a clone made by
+    clone_results_repo.py, whose sparse-checkout set deliberately materializes
+    `issue-snapshot-*.yaml` and not the run report. Bootstrap cannot filter against a report it
+    cannot see, and including every issue instead is not a safe default at this scale.
+    """
+    run_dir = os.path.join(results_dir, run_name, "auto-fix-runs")
+    if not os.path.isdir(run_dir):
+        return False
+    return any(
+        name.startswith("issue-snapshot-") and name.endswith(".yaml")
+        for name in os.listdir(run_dir)
+    )
+
+
 def find_latest_run_timestamp(results_dir):
     """Find the timestamp of the latest run from directory names.
 
@@ -313,6 +331,15 @@ def main():
         default="rfe",
         help="Issue type (default: rfe)",
     )
+    parser.add_argument(
+        "--include-all",
+        action="store_true",
+        help=(
+            "Proceed without the run-report filter even when the results directory looks "
+            "incomplete. Escape hatch for recovery — the snapshot will cover every fetched "
+            "issue, marked unprocessed"
+        ),
+    )
     args = parser.parse_args()
 
     snap_config = SNAPSHOT_CONFIG[args.type]
@@ -343,7 +370,17 @@ def main():
 
     # Filter to issues that were actually processed in the run
     processed_ids, report = _load_run_report(args.results_dir, run_name, config=boot_config)
-    if processed_ids is None:
+    unfiltered = processed_ids is None
+    if unfiltered:
+        if not args.include_all and _run_dir_has_snapshots(args.results_dir, run_name):
+            print(
+                f"Error: {run_name} has issue snapshots but no readable run report — "
+                f"the results directory looks partial (clone_results_repo.py omits run "
+                f"reports by design). Point --results-dir at a full clone, or pass "
+                f"--include-all to snapshot every fetched issue as unprocessed.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         print("Warning: no run report — including all issues", file=sys.stderr)
     else:
         before = len(current)
@@ -409,9 +446,26 @@ def main():
     if done_excluded:
         print(f"Excluded {done_excluded} issues (Done at run time)", file=sys.stderr)
 
+    if unfiltered:
+        # No run report, so there is no evidence any of these were processed. A bare hash would
+        # claim otherwise: snapshot_fetch.diff_snapshots reads a missing `processed` as True
+        # ("old format entries are implicitly processed"), and only a hash change ever resets it,
+        # so the issues would be excluded from selection permanently and silently. Recording them
+        # unprocessed surfaces them as NEW on the first incremental fetch, where check_resume can
+        # still skip the ones that already have a passing review.
+        snapshot_issues = {
+            key: {"hash": content_hash, "processed": False}
+            for key, content_hash in snapshot_issues.items()
+        }
+
     # Step 5: Write snapshot
     if args.dry_run:
-        print(f"\nDry run — would write snapshot with {len(snapshot_issues)} issue hashes")
+        scope = (
+            "every fetched issue, marked unprocessed (no run-report filter)"
+            if unfiltered
+            else "issues from the run report"
+        )
+        print(f"\nDry run — would write snapshot with {len(snapshot_issues)} hashes: {scope}")
         return
 
     snapshot_dir = (

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -38,6 +38,7 @@ from artifact_utils import (  # noqa: E402
     scan_task_files,
     update_frontmatter,
 )
+from generate_run_report import TYPE_CONFIG as REPORT_TYPE_CONFIG  # noqa: E402
 from generate_run_report import _parse_run_id  # noqa: E402
 from jira_utils import (  # noqa: E402
     add_comment,
@@ -166,6 +167,17 @@ def _find_review(artifacts_dir, item_id, cfg):
     """Find review file path for an item, or None."""
     path = os.path.join(artifacts_dir, cfg["reviews_dir"], f"{item_id}-review.md")
     return path if os.path.isfile(path) else None
+
+
+def report_companion_path(artifacts_dir, run_id, work_type, suffix):
+    """Path for a run report companion file, beside the YAML it belongs to.
+
+    generate_run_report owns the report filename, prefix included. Re-deriving that prefix here
+    would be a second copy of a per-type constant, so the companion resolves it from the same
+    config the writer uses.
+    """
+    prefix = REPORT_TYPE_CONFIG[work_type]["output_prefix"]
+    return os.path.join(artifacts_dir, "auto-fix-runs", f"{prefix}{run_id}{suffix}")
 
 
 def _post_needs_attention_comment(server, user, token, entry, results, dry_run, cfg):
@@ -900,10 +912,7 @@ def main():
         else:
             print(f"Warning: YAML report generation failed: {result.stderr}", file=sys.stderr)
 
-        report_prefix = "initiative-run-" if args.type == "initiative" else ""
-        html_output = os.path.join(
-            args.artifacts_dir, "auto-fix-runs", f"{report_prefix}{run_id}-report.html"
-        )
+        html_output = report_companion_path(args.artifacts_dir, run_id, args.type, "-report.html")
         html_cmd = [
             sys.executable,
             os.path.join(script_dir, "generate_review_pdf.py"),

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -1045,6 +1045,86 @@ class TestBootstrapIntegration:
         assert "--include-all" in r.stderr
         assert not os.path.exists(os.path.join(art_dir, "auto-fix-runs"))
 
+    def test_corrupt_report_fails_loudly(self, tmp_path, mock_jira):
+        """A report that exists but cannot be parsed is not treated as absent."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Issue one."}
+        results = _make_results_dir(tmp_path, ["20260401-120000"], latest="20260401-120000")
+        report_dir = os.path.join(results, "20260401-120000", "auto-fix-runs")
+        os.makedirs(report_dir, exist_ok=True)
+        with open(os.path.join(report_dir, "20260401-120000.yaml"), "w") as f:
+            f.write("per_rfe: [ {id: RHAIRFE-1")
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+
+        r = subprocess.run(
+            [
+                sys.executable,
+                SCRIPT,
+                "--results-dir",
+                results,
+                "--artifacts-dir",
+                art_dir,
+                "project = RHAIRFE",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert r.returncode == 1
+        assert "unreadable" in r.stderr
+        assert "--include-all" in r.stderr
+        assert "Traceback" not in r.stderr
+        assert not os.path.exists(os.path.join(art_dir, "auto-fix-runs"))
+
+    def test_include_all_overrides_a_corrupt_report(self, tmp_path, mock_jira):
+        """The recovery override applies to corruption too, and stays fail-safe."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Issue one."}
+        results = _make_results_dir(tmp_path, ["20260401-120000"], latest="20260401-120000")
+        report_dir = os.path.join(results, "20260401-120000", "auto-fix-runs")
+        os.makedirs(report_dir, exist_ok=True)
+        with open(os.path.join(report_dir, "20260401-120000.yaml"), "w") as f:
+            f.write("per_rfe: [ {id: RHAIRFE-1")
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+
+        r = subprocess.run(
+            [
+                sys.executable,
+                SCRIPT,
+                "--results-dir",
+                results,
+                "--artifacts-dir",
+                art_dir,
+                "--include-all",
+                "project = RHAIRFE",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert r.returncode == 0, r.stderr
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        snapshots = [f for f in os.listdir(snapshot_dir) if f.startswith("issue-snapshot-")]
+        with open(os.path.join(snapshot_dir, snapshots[0])) as f:
+            snap = yaml.safe_load(f)
+        assert all(e["processed"] is False for e in snap["issues"].values())
+
     def test_include_all_overrides_the_refusal(self, tmp_path, mock_jira):
         """The escape hatch must exist: bootstrap is the tool you reach for in a bad state."""
         url, server = mock_jira
@@ -1085,6 +1165,58 @@ class TestBootstrapIntegration:
         with open(os.path.join(snapshot_dir, snapshots[0])) as f:
             snap = yaml.safe_load(f)
         assert all(e["processed"] is False for e in snap["issues"].values())
+
+
+class TestLoadRunReportRejectsCorruptFiles:
+    """Present-but-unreadable is not absence.
+
+    Absence has a documented include-all fallback; a corrupt report says nothing about what the
+    run processed. Normalizing these to (None, None) would either mislabel the failure as a
+    partial clone or silently include everything — the conflation this reader was just taught
+    to avoid. None of the 278 published reports have these shapes; this is defence.
+    """
+
+    def _write_report(self, tmp_path, body, run_name="20260401-120000"):
+        results = str(tmp_path / "results")
+        report_dir = os.path.join(results, run_name, "auto-fix-runs")
+        os.makedirs(report_dir)
+        with open(os.path.join(report_dir, f"{run_name}.yaml"), "w") as f:
+            f.write(body)
+        return results, run_name
+
+    def test_malformed_yaml_raises(self, tmp_path):
+        results, run = self._write_report(tmp_path, "per_rfe: [ {id: RHAIRFE-1")
+
+        with pytest.raises(ValueError, match="unreadable"):
+            _load_run_report(results, run)
+
+    def test_non_mapping_raises(self, tmp_path):
+        results, run = self._write_report(tmp_path, "- just\n- a\n- list\n")
+
+        with pytest.raises(ValueError, match="not a mapping"):
+            _load_run_report(results, run)
+
+    def test_empty_file_raises(self, tmp_path):
+        """yaml.safe_load('') is None — a present-but-empty file is corrupt, not absent."""
+        results, run = self._write_report(tmp_path, "")
+
+        with pytest.raises(ValueError, match="not a mapping"):
+            _load_run_report(results, run)
+
+    def test_entries_without_id_raise(self, tmp_path):
+        results, run = self._write_report(tmp_path, "per_rfe:\n  - recommendation: submit\n")
+
+        with pytest.raises(ValueError, match="malformed per_rfe entries"):
+            _load_run_report(results, run)
+
+    def test_missing_file_is_still_none(self, tmp_path):
+        """Absence keeps its meaning — only corruption raises."""
+        results = str(tmp_path / "results")
+        os.makedirs(os.path.join(results, "20260401-120000"))
+
+        ids, report = _load_run_report(results, "20260401-120000")
+
+        assert ids is None and report is None
 
 
 class TestLoadRunReportConfig:

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -351,7 +351,10 @@ class TestBootstrapIntegration:
         )
         assert r.returncode == 0, r.stderr
         assert "Dry run" in r.stdout
-        assert "2 issue hashes" in r.stdout
+        assert "2 hashes" in r.stdout
+        # The count alone cannot tell an operator whether the run-report filter applied, which is
+        # the difference between a correct snapshot and a silently over-inclusive one.
+        assert "issues from the run report" in r.stdout
 
         # No files written
         snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
@@ -1003,6 +1006,85 @@ class TestBootstrapIntegration:
             snap = yaml.safe_load(f)
 
         assert len(snap["issues"]) == 2
+        # Fail-safe: bootstrap has no run-report evidence these were processed, so it must not
+        # write a bare hash — snapshot_fetch reads a missing `processed` as True and nothing
+        # ever demotes such an entry.
+        assert all(e == {"hash": e["hash"], "processed": False} for e in snap["issues"].values())
+
+    def test_partial_results_dir_is_refused(self, tmp_path, mock_jira):
+        """Snapshots but no run report means a partial clone — do not silently include all."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Issue one."}
+        results = _make_results_dir(tmp_path, ["20260401-120000"], latest="20260401-120000")
+        snap_dir = os.path.join(results, "20260401-120000", "auto-fix-runs")
+        os.makedirs(snap_dir, exist_ok=True)
+        with open(os.path.join(snap_dir, "issue-snapshot-20260401-120000.yaml"), "w") as f:
+            yaml.dump({"issues": {}}, f)
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+        cmd = [
+            sys.executable,
+            SCRIPT,
+            "--results-dir",
+            results,
+            "--artifacts-dir",
+            art_dir,
+            "project = RHAIRFE",
+        ]
+
+        r = subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+        assert r.returncode == 1
+        assert "looks partial" in r.stderr
+        assert "--include-all" in r.stderr
+        assert not os.path.exists(os.path.join(art_dir, "auto-fix-runs"))
+
+    def test_include_all_overrides_the_refusal(self, tmp_path, mock_jira):
+        """The escape hatch must exist: bootstrap is the tool you reach for in a bad state."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Issue one."}
+        results = _make_results_dir(tmp_path, ["20260401-120000"], latest="20260401-120000")
+        snap_dir = os.path.join(results, "20260401-120000", "auto-fix-runs")
+        os.makedirs(snap_dir, exist_ok=True)
+        with open(os.path.join(snap_dir, "issue-snapshot-20260401-120000.yaml"), "w") as f:
+            yaml.dump({"issues": {}}, f)
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+        env = {
+            **os.environ,
+            "JIRA_SERVER": url,
+            "JIRA_USER": "test@example.com",
+            "JIRA_TOKEN": "test-token",
+        }
+
+        r = subprocess.run(
+            [
+                sys.executable,
+                SCRIPT,
+                "--results-dir",
+                results,
+                "--artifacts-dir",
+                art_dir,
+                "--include-all",
+                "project = RHAIRFE",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert r.returncode == 0, r.stderr
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        snapshots = [f for f in os.listdir(snapshot_dir) if f.startswith("issue-snapshot-")]
+        with open(os.path.join(snapshot_dir, snapshots[0])) as f:
+            snap = yaml.safe_load(f)
+        assert all(e["processed"] is False for e in snap["issues"].values())
 
 
 class TestLoadRunReportConfig:

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -1209,6 +1209,25 @@ class TestLoadRunReportRejectsCorruptFiles:
         with pytest.raises(ValueError, match="malformed per_rfe entries"):
             _load_run_report(results, run)
 
+    def test_missing_item_key_raises(self, tmp_path):
+        """A mapping without the configured key is the drift shape, not an empty run.
+
+        An empty LIST keeps the documented fallback (zero-count runs are legitimate since
+        bc2f553); a missing KEY means writer and reader disagree about the schema.
+        """
+        results, run = self._write_report(tmp_path, "results:\n  passed: 3\n")
+
+        with pytest.raises(ValueError, match="has no per_rfe item list"):
+            _load_run_report(results, run)
+
+    def test_empty_item_list_is_still_none(self, tmp_path):
+        """Key present, list empty — the legitimate zero-count shape keeps its meaning."""
+        results, run = self._write_report(tmp_path, "per_rfe: []\n")
+
+        ids, report = _load_run_report(results, run)
+
+        assert ids is None and report is None
+
     def test_missing_file_is_still_none(self, tmp_path):
         """Absence keeps its meaning — only corruption raises."""
         results = str(tmp_path / "results")

--- a/tests/test_report_roundtrip.py
+++ b/tests/test_report_roundtrip.py
@@ -7,12 +7,16 @@ list by TYPE_CONFIG[type]["item_key"]. bootstrap_snapshot._load_run_report reads
 BOOTSTRAP_CONFIG[type]["item_key"]. Two uncoupled constant pairs, in two modules, with nothing
 tying them together.
 
-When either pair drifts the reader takes its "no run report" path: it warns to stderr, skips the
-ID filter, includes every fetched issue, and exits 0. Because bootstrap writes bare-string snapshot
-entries and snapshot_fetch.diff_snapshots reads a missing `processed` field as True, the wrongly
-admitted issues are recorded as processed-and-unchanged and are then excluded from selection by
-every later incremental fetch. Nothing demotes them (only a hash change resets `processed`), so the
-damage is silent and permanent. Measured on live data: a real run report filters 2277 issues to 11.
+When either pair drifts the reader takes its "no run report" path. Before this guard existed that
+was catastrophic and silent: bootstrap wrote bare-string entries, snapshot_fetch.diff_snapshots
+reads a missing `processed` field as True, and only a hash change ever resets it — so every
+wrongly admitted issue was recorded processed-and-unchanged and excluded from selection forever.
+Measured on live data, a real run report filters 2277 issues to 11.
+
+Bootstrap now backstops that path (refusing a visibly partial results dir, and writing fallback
+entries as {hash, processed: false} so over-included issues resurface as NEW), which converts the
+damage from permanent to noisy: a full re-triage of the backlog and hours of needless changelog
+lookups. This guard is the first line — it makes the drift a test failure instead of a bad run.
 
 Equality asserts between the two constant dicts would not catch this — the path pair is a separate
 pair, and for type rfe both prefixes are "" so an rfe-only check is structurally blind to prefix

--- a/tests/test_report_roundtrip.py
+++ b/tests/test_report_roundtrip.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""The run report writer and the snapshot reader must agree, for every type.
+
+generate_run_report.py writes artifacts/auto-fix-runs/<output_prefix><run>.yaml and keys the entry
+list by TYPE_CONFIG[type]["item_key"]. bootstrap_snapshot._load_run_report reads back
+<results>/<run>/auto-fix-runs/<report_prefix><run>.yaml and pulls
+BOOTSTRAP_CONFIG[type]["item_key"]. Two uncoupled constant pairs, in two modules, with nothing
+tying them together.
+
+When either pair drifts the reader takes its "no run report" path: it warns to stderr, skips the
+ID filter, includes every fetched issue, and exits 0. Because bootstrap writes bare-string snapshot
+entries and snapshot_fetch.diff_snapshots reads a missing `processed` field as True, the wrongly
+admitted issues are recorded as processed-and-unchanged and are then excluded from selection by
+every later incremental fetch. Nothing demotes them (only a hash change resets `processed`), so the
+damage is silent and permanent. Measured on live data: a real run report filters 2277 issues to 11.
+
+Equality asserts between the two constant dicts would not catch this — the path pair is a separate
+pair, and for type rfe both prefixes are "" so an rfe-only check is structurally blind to prefix
+drift. These tests round-trip a real report through the real CLI instead.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import bootstrap_snapshot
+from generate_run_report import TYPE_CONFIG
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "generate_run_report.py")
+RUN = "20260818-120000"
+
+FIXTURES = {
+    "rfe": {
+        "tasks_dir": "rfe-tasks",
+        "reviews_dir": "rfe-reviews",
+        "ids": ["RHAIRFE-1234", "RHAIRFE-5678"],
+        "task": (
+            "---\nrfe_id: {id}\ntitle: Test\npriority: Major\nstatus: Ready\n---\n\n"
+            "## Problem\nx.\n"
+        ),
+        "review": (
+            "---\nrfe_id: {id}\nscore: 9\npass: true\nrecommendation: submit\n"
+            "feasibility: feasible\nauto_revised: false\nneeds_attention: false\n"
+            "scores:\n  what: 2\n  why: 2\n  open_to_how: 2\n  not_a_task: 2\n  right_sized: 1\n"
+            "---\n\n## Feedback\nok.\n"
+        ),
+    },
+    "initiative": {
+        "tasks_dir": "initiatives",
+        "reviews_dir": "initiative-reviews",
+        "ids": ["RHOAIENG-1234", "RHOAIENG-5678"],
+        "task": (
+            "---\ninitiative_id: {id}\ntitle: Test\npriority: Major\nstatus: Ready\n---\n\n"
+            "## Objective\nx.\n"
+        ),
+        "review": (
+            "---\ninitiative_id: {id}\nscore: 9\npass: true\nrecommendation: submit\n"
+            "feasibility: feasible\nauto_revised: false\nneeds_attention: false\n"
+            "alignment: strong\n"
+            "scores:\n  what: 2\n  why: 2\n  scope: 2\n  open_to_how: 2\n  right_sized: 1\n"
+            "---\n\n## Feedback\nok.\n"
+        ),
+    },
+}
+
+
+def _write(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def _write_report(tmp_path, work_type, results_dir, run=RUN):
+    """Run the real CLI for `work_type`, then place its output where the reader looks for it.
+
+    Copies the whole auto-fix-runs directory rather than a computed filename, so the writer's own
+    path formula is what ends up on disk — a test that reconstructed the name would just restate
+    the bug.
+    """
+    fx = FIXTURES[work_type]
+    artifacts = tmp_path / f"artifacts-{work_type}"
+    for item_id in fx["ids"]:
+        _write(f"{artifacts}/{fx['tasks_dir']}/{item_id}.md", fx["task"].format(id=item_id))
+        _write(
+            f"{artifacts}/{fx['reviews_dir']}/{item_id}-review.md", fx["review"].format(id=item_id)
+        )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            SCRIPT,
+            "--type",
+            work_type,
+            "--start-time",
+            run,
+            "--artifacts-dir",
+            str(artifacts),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    src = artifacts / "auto-fix-runs"
+    dest = os.path.join(results_dir, run, "auto-fix-runs")
+    os.makedirs(dest, exist_ok=True)
+    for name in os.listdir(src):
+        with open(src / name) as f:
+            body = f.read()
+        _write(os.path.join(dest, name), body)
+    return set(fx["ids"])
+
+
+class TestWriterReaderAgree:
+    def test_config_key_sets_match(self):
+        """A type added to one side only would silently take the include-all fallback."""
+        assert set(TYPE_CONFIG) == set(bootstrap_snapshot.BOOTSTRAP_CONFIG)
+
+    @pytest.mark.parametrize("work_type", sorted(FIXTURES))
+    def test_reader_finds_what_the_writer_wrote(self, tmp_path, work_type):
+        """Round-trip through the real CLI: drift in either the path or the key pair fails here."""
+        results_dir = str(tmp_path / "results")
+        expected = _write_report(tmp_path, work_type, results_dir)
+
+        ids, report = bootstrap_snapshot._load_run_report(
+            results_dir, RUN, config=bootstrap_snapshot.BOOTSTRAP_CONFIG[work_type]
+        )
+
+        assert ids == expected, (
+            f"{work_type}: reader did not find the writer's report. Check that "
+            f"TYPE_CONFIG['{work_type}']['output_prefix'] matches "
+            f"BOOTSTRAP_CONFIG['{work_type}']['report_prefix'], and that the item_key pair agrees."
+        )
+        assert report is not None
+
+    def test_reader_does_not_cross_wire_types(self, tmp_path):
+        """An initiative bootstrap must not resolve ids out of an rfe-only run directory.
+
+        Guards the failure a permissive key lookup would introduce: reading the wrong type's list
+        filters the snapshot to a disjoint ID set, which empties it rather than widening it.
+        """
+        results_dir = str(tmp_path / "results")
+        _write_report(tmp_path, "rfe", results_dir)
+
+        ids, report = bootstrap_snapshot._load_run_report(
+            results_dir, RUN, config=bootstrap_snapshot.BOOTSTRAP_CONFIG["initiative"]
+        )
+
+        assert ids is None
+        assert report is None

--- a/tests/test_report_roundtrip.py
+++ b/tests/test_report_roundtrip.py
@@ -137,6 +137,30 @@ class TestWriterReaderAgree:
         )
         assert report is not None
 
+    @pytest.mark.parametrize("work_type", sorted(FIXTURES))
+    def test_html_companion_lands_beside_the_yaml(self, tmp_path, work_type):
+        """submit.py builds the HTML companion path itself, outside the round-trip above.
+
+        Compares against the filename the writer actually produced rather than against the
+        config both sides read — comparing the config to itself would pass no matter what
+        submit.py does with it.
+        """
+        import submit
+
+        artifacts = tmp_path / f"artifacts-{work_type}"
+        results_dir = str(tmp_path / "results")
+        _write_report(tmp_path, work_type, results_dir)
+        written = [n for n in os.listdir(artifacts / "auto-fix-runs") if n.endswith(".yaml")]
+        assert len(written) == 1, written
+
+        html = submit.report_companion_path(str(artifacts), RUN, work_type, "-report.html")
+
+        assert os.path.dirname(html) == str(artifacts / "auto-fix-runs")
+        assert os.path.basename(html) == written[0].replace(".yaml", "-report.html"), (
+            f"{work_type}: the HTML companion would not land beside the YAML the writer produced. "
+            f"submit.py must resolve the prefix from TYPE_CONFIG, not re-derive it."
+        )
+
     def test_reader_does_not_cross_wire_types(self, tmp_path):
         """An initiative bootstrap must not resolve ids out of an rfe-only run directory.
 


### PR DESCRIPTION
## The failure

`bootstrap_snapshot._load_run_report` filters a Jira fetch down to the issues the previous run actually processed. When it cannot read the run report it falls through to "no run report — including all issues", warns to stderr, and exits 0.

That fallback is not benign. bootstrap writes bare-string snapshot entries, and `snapshot_fetch.diff_snapshots:252-253` reads a bare entry as `processed = True` (*"old format entries are implicitly processed"*). So every wrongly admitted issue is recorded processed-and-unchanged, excluded from selection by every later incremental fetch, and never demoted — invariant 7 permits resetting `processed` only on a hash change. Recovery is manual.

Measured against live data: the newest published report filters **2277 issues down to 11**. The fallback silently makes that 2277 → 2277, burying ~2266 issues permanently. `--dry-run` doesn't catch it; it prints a plausible larger number.

And the fallback is reachable **today, with no drift at all**: `clone_results_repo.py:75-83` sparse-checks out `/latest` and `/*/auto-fix-runs/issue-snapshot-*.yaml`, which never materializes `<run>.yaml`. Any bootstrap against a clone made by this repo's own tooling already takes it.

## Three changes

**Record the fallback honestly.** With no run report there is no evidence any of these issues were processed, so entries are now written `{hash, processed: false}`. They surface as NEW on the first incremental fetch, where `check_resume` still skips any that already have a passing review. Filtered runs are unchanged.

**Refuse a visibly partial results directory.** Issue snapshots present but no readable run report means a partial clone, not a run that never wrote one. Bootstrap exits 1 naming the cause and the remedy. Since it is a recovery tool and had no override, `--include-all` is added and named in the error.

**Say which mode the dry run is in.** The count alone cannot distinguish a correct snapshot from an over-inclusive one, which made the operator's one guard rail blind to exactly this regression.

## Plus a real guard against the drift that would re-open it

`generate_run_report` writes `auto-fix-runs/<output_prefix><run>.yaml` keyed by `TYPE_CONFIG[type]["item_key"]`; the reader uses `BOOTSTRAP_CONFIG[type]["report_prefix"]` and its own `item_key`. **Two uncoupled constant pairs in two modules**, and drift in either is silent.

An equality assert between the dicts would not catch it — the prefixes are a second, separate pair, and for type `rfe` both are `""`, so an rfe-only check is structurally blind. `tests/test_report_roundtrip.py` round-trips a real report through the real CLI instead, parametrized over every type, plus a key-set parity check and a negative cross-type case.

Mutation-tested; the guard fails on all five drift modes:

```
baseline:            4 passed
writer prefix drift: 1 failed
reader prefix drift: 1 failed
writer item_key:     1 failed
reader item_key:     1 failed
type on one side:    1 failed
```

It also fails on the *intended* `per_item` rename (RHAIFIRST-567) — deliberately, so that rename cannot land writer-only.

## Invariants

`docs/snapshot-incremental-fetch.md:398-441` reviewed against this change: **none violated**. Invariant 8 ("only `submit.py` sets `processed: true`") was already in tension via the bare-string write; this restores it for the fallback path.

Note what is deliberately *not* changed: `clone_results_repo.py`'s sparse set stays as is — `tests/test_clone_results_repo.py::test_run_report_not_materialized` pins that exclusion intentionally, so the safety goal is met on the bootstrap side instead.

## Verification

763 tests pass on this branch off `main`; ruff clean. Independent of #156 and of the report-root-metadata PR — verified by cherry-picking onto a probe branch off `origin/main`.

RHAIFIRST-563, part of RHAIFIRST-553.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `--include-all` option to process all fetched issues, including those not listed in a run report.
  - Dry-run output now indicates whether processing is filtered by a report or includes all results.
  - Generated HTML reports now consistently appear alongside their corresponding report files.

- **Bug Fixes**
  - Bootstrap safely stops for missing, incomplete, corrupt, or malformed reports by default.
  - `--include-all` enables recovery from invalid or partial reports, marking entries as unprocessed for follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->