### PR TITLE
Say what a run report is: schema version, type, and submit stage

### DIFF
--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -52,6 +52,17 @@ TYPE_CONFIG = {
 
 SCORE_FIELDS = TYPE_CONFIG["rfe"]["score_fields"]
 
+# Bumped only on a breaking change to the report shape. Absent means a report
+# written before versioning existed — consumers must treat those as legacy.
+REPORT_SCHEMA_VERSION = 1
+
+# Whether the per-entry values are final. The pipeline's REPORT phase runs
+# before submit, so the report it writes is a snapshot: nothing has been
+# created in Jira yet and no refusal has been recorded. submit.py regenerates
+# it afterwards. Defaults to pre_submit so a caller that forgets to say
+# understates its authority rather than overstating it.
+REPORT_STAGES = ("pre_submit", "final")
+
 # submit.py writes this marker into review frontmatter when split_submit refuses
 # a split outright — too many leaf children (exit 2) or a Jira conflict (exit 3).
 # Nothing was created in Jira, so the parent is blocked, not split.
@@ -90,6 +101,7 @@ def build_report(
     retry_success_ids=None,
     artifacts_dir=None,
     entry_type="rfe",
+    report_stage="pre_submit",
 ):
     if artifacts_dir is None:
         artifacts_dir = DEFAULT_ARTIFACTS_DIR
@@ -198,6 +210,9 @@ def build_report(
         results["retry_successes"] = len(retry_success_ids)
 
     report = {
+        "report_schema_version": REPORT_SCHEMA_VERSION,
+        "type": entry_type,
+        "report_stage": report_stage,
         "run_id": _parse_run_id(start_time),
         "started": start_time,
         "completed": now,
@@ -239,6 +254,16 @@ def main():
         default="rfe",
         help="Entry type (default: rfe)",
     )
+    parser.add_argument(
+        "--report-stage",
+        choices=REPORT_STAGES,
+        default="pre_submit",
+        help=(
+            "Whether per-entry values are final. The pipeline's REPORT phase runs "
+            "before submit, so it writes pre_submit; submit.py regenerates with "
+            "final (default: pre_submit)"
+        ),
+    )
     parser.add_argument("ids", nargs="*", help="IDs (default: scan review files)")
     args = parser.parse_args()
 
@@ -269,6 +294,7 @@ def main():
         retry_success_ids=retry_ok,
         artifacts_dir=artifacts_dir,
         entry_type=args.type,
+        report_stage=args.report_stage,
     )
 
     out_dir = os.path.join(artifacts_dir, "auto-fix-runs")

--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -103,6 +103,10 @@ def build_report(
     entry_type="rfe",
     report_stage="pre_submit",
 ):
+    if report_stage not in REPORT_STAGES:
+        # argparse guards the CLI; this guards programmatic callers. Consumers switch on this
+        # field, so an unknown value must fail at write time, not at the reader.
+        raise ValueError(f"unsupported report stage: {report_stage!r} (expected {REPORT_STAGES})")
     if artifacts_dir is None:
         artifacts_dir = DEFAULT_ARTIFACTS_DIR
     if retried_ids is None:

--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -393,6 +393,8 @@ def _build_phase_config(pipeline_type):
                 f"python3 scripts/generate_run_report.py --type {pipeline_type}"
                 " --start-time {start_time}"
                 " --batch-size {batch_size}"
+                # This phase runs before submit — nothing is in Jira yet.
+                " --report-stage pre_submit"
             ),
         },
     }

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -184,6 +184,9 @@ def _generate_reports(args):
         ts,
         "--artifacts-dir",
         args.artifacts_dir,
+        # Regenerated after submit, so per-entry values are authoritative.
+        "--report-stage",
+        "final",
     ]
     if args.type == "initiative":
         yaml_cmd.extend(["--type", "initiative"])

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -560,6 +560,13 @@ class TestReportRootMetadata:
 
         assert report["type"] == "initiative"
 
+    def test_build_report_rejects_an_unknown_stage(self, art_dir):
+        """argparse only guards the CLI; a programmatic caller must fail at write time too."""
+        self._one_rfe(art_dir)
+
+        with pytest.raises(ValueError, match="unsupported report stage"):
+            build_report(["RHAIRFE-1234"], "2026-08-18T09:00:00Z", report_stage="submitted")
+
     def test_cli_rejects_an_unknown_stage(self, tmp_path):
         os.makedirs(tmp_path / "artifacts" / "rfe-reviews")
         result = subprocess.run(

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -505,3 +505,115 @@ class TestRefusedSplitIsBlockedNotSplit:
         report = build_report(["RHAIRFE-2429"], "2026-08-15T03:09:45Z", 5, [], [])
 
         assert report["per_rfe"][0]["needs_attention"] is True
+
+
+class TestReportRootMetadata:
+    """Root fields that let a consumer know what it is reading."""
+
+    def _one_rfe(self, art_dir):
+        _write(
+            f"{art_dir}/rfe-tasks/RHAIRFE-1234.md",
+            TASK_TEMPLATE.format(rfe_id="RHAIRFE-1234", extra=""),
+        )
+        _write(
+            f"{art_dir}/rfe-reviews/RHAIRFE-1234-review.md",
+            REVIEW_TEMPLATE.format(
+                rfe_id="RHAIRFE-1234",
+                score=9,
+                pass_val="true",
+                recommendation="submit",
+                right_sized=2,
+            ),
+        )
+
+    def test_schema_version_and_type_are_emitted(self, art_dir):
+        self._one_rfe(art_dir)
+
+        report = build_report(["RHAIRFE-1234"], "2026-08-18T09:00:00Z")
+
+        assert report["report_schema_version"] == 1
+        assert report["type"] == "rfe"
+
+    def test_stage_defaults_to_pre_submit(self, art_dir):
+        """A caller that forgets must understate authority, never overstate it."""
+        self._one_rfe(art_dir)
+
+        report = build_report(["RHAIRFE-1234"], "2026-08-18T09:00:00Z")
+
+        assert report["report_stage"] == "pre_submit"
+
+    def test_stage_is_final_when_asked(self, art_dir):
+        self._one_rfe(art_dir)
+
+        report = build_report(["RHAIRFE-1234"], "2026-08-18T09:00:00Z", report_stage="final")
+
+        assert report["report_stage"] == "final"
+
+    def test_type_follows_entry_type(self, tmp_path, monkeypatch):
+        for d in ["initiatives", "initiative-reviews"]:
+            os.makedirs(tmp_path / "artifacts" / d)
+        art = str(tmp_path / "artifacts")
+
+        report = build_report(
+            [], "2026-08-18T09:00:00Z", artifacts_dir=art, entry_type="initiative"
+        )
+
+        assert report["type"] == "initiative"
+
+    def test_cli_rejects_an_unknown_stage(self, tmp_path):
+        os.makedirs(tmp_path / "artifacts" / "rfe-reviews")
+        result = subprocess.run(
+            [
+                sys.executable,
+                os.path.join(os.path.dirname(__file__), "..", "scripts", "generate_run_report.py"),
+                "--start-time",
+                "20260818-090000",
+                "--artifacts-dir",
+                str(tmp_path / "artifacts"),
+                "--report-stage",
+                "definitely-not-a-stage",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "invalid choice" in result.stderr
+
+    def test_cli_writes_the_stage_it_was_given(self, tmp_path):
+        art = str(tmp_path / "artifacts")
+        os.makedirs(f"{art}/rfe-tasks")
+        os.makedirs(f"{art}/rfe-reviews")
+        _write(
+            f"{art}/rfe-tasks/RHAIRFE-1234.md",
+            TASK_TEMPLATE.format(rfe_id="RHAIRFE-1234", extra=""),
+        )
+        _write(
+            f"{art}/rfe-reviews/RHAIRFE-1234-review.md",
+            REVIEW_TEMPLATE.format(
+                rfe_id="RHAIRFE-1234",
+                score=9,
+                pass_val="true",
+                recommendation="submit",
+                right_sized=2,
+            ),
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                os.path.join(os.path.dirname(__file__), "..", "scripts", "generate_run_report.py"),
+                "--start-time",
+                "20260818-090000",
+                "--artifacts-dir",
+                art,
+                "--report-stage",
+                "final",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        with open(result.stdout.strip()) as f:
+            written = yaml.safe_load(f)
+        assert written["report_stage"] == "final"
+        assert written["report_schema_version"] == 1
+        assert written["type"] == "rfe"


### PR DESCRIPTION
> **Stacked on #156** (base `fix/report-blocked-splits`, not `main`) — both commits touch `generate_run_report.py`. Rebase onto `main` once #156 merges. Only the second commit is new here.

## The problem

Nothing in a published run report says whether its per-entry values are final.

The pipeline's `REPORT` phase runs **before** submit, so the report it writes predates every Jira write — no keys assigned, no refusal recorded. `submit.py` regenerates it afterwards. Both are published under the same filename with nothing to tell them apart, which is why a stale report and a genuinely blocked split read identically. 36 runs never received their post-submit push, so their published report is permanently pre-submit and indistinguishable from a completed one.

## The change

Root now carries:

```yaml
report_schema_version: 1
type: rfe
report_stage: final              # pre_submit | final
```

`report_stage` comes from the two call sites that already exist — `pipeline_state.py:390` passes `pre_submit`, `submit.py` passes `final`. The default is `pre_submit`, so a caller that forgets **understates** the report's authority rather than overstating it; that is the direction that fails safe.

`report_schema_version` is absent on all 278 reports published so far, which is the signal for a legacy file. It bumps only on a breaking change.

`type` matches the `type:` field `work-item-types-unified.md` §5:256 adds to the base schemas, rather than inventing a parallel `work_type`.

## Not included, deliberately

Renaming the `per_rfe` / `per_initiative` list key to a stable `per_item`. An impact analysis found that is a coordinated multi-repo migration rather than a rename: three eval configs plus 20 frozen `eval/harbor-tasks/*/steps/submit/tests/eval.yaml` copies *assert* on the current key (proven by executing them), 2208 legacy report YAMLs under `eval/runs/` are re-scored as a matter of routine, and `agent-eval-harness-model-compare` clones this repo at unpinned `main` and runs its `eval.yaml` verbatim. Tracked separately as RHAIFIRST-567 and sequenced with work-item-types PR-1.

That is also why `report_schema_version` matters now: when the key does change it must bump to 2, or version 1 would denote two incompatible shapes.

## Verification

Full suite green; ruff clean. Six new tests, including that the CLI rejects an unknown stage and that the default is `pre_submit`.

End-to-end against a real published run (`20260815-030945`, whose split was refused):

```yaml
report_schema_version: 1
type: rfe
report_stage: final
results: {passed: 9, failed: 0, split: 1, blocked: 1, errors: 0, ...}
```

RHAIFIRST-563, part of RHAIFIRST-553.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added report schema version metadata to generated reports.
  * Added report-stage metadata, supporting `pre_submit` and `final` stages.
  * Reports now default to the pre-submission stage and can be explicitly generated as final.
  * Submission workflows regenerate reports with authoritative final-stage values.
  * Invalid report stages are rejected by the command-line interface.

* **Tests**
  * Added coverage for report metadata, stage defaults, valid stages, and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->