### PR TITLE
Write the run report before aborting on a split failure

### DIFF
--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -169,6 +169,97 @@ def _find_review(artifacts_dir, item_id, cfg):
     return path if os.path.isfile(path) else None
 
 
+def _generate_reports(args):
+    """Regenerate the run report YAML and its HTML companion."""
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    ts = args.report_timestamp
+    run_id = _parse_run_id(ts)
+
+    print("\nGenerating reports...")
+
+    yaml_cmd = [
+        sys.executable,
+        os.path.join(script_dir, "generate_run_report.py"),
+        "--start-time",
+        ts,
+        "--artifacts-dir",
+        args.artifacts_dir,
+    ]
+    if args.type == "initiative":
+        yaml_cmd.extend(["--type", "initiative"])
+    result = subprocess.run(yaml_cmd, capture_output=True, text=True)
+    if result.returncode == 0:
+        print(f"  YAML report: {result.stdout.strip()}")
+    else:
+        print(f"Warning: YAML report generation failed: {result.stderr}", file=sys.stderr)
+
+    html_output = report_companion_path(args.artifacts_dir, run_id, args.type, "-report.html")
+    html_cmd = [
+        sys.executable,
+        os.path.join(script_dir, "generate_review_pdf.py"),
+        "--revised-only",
+        "--artifacts-dir",
+        args.artifacts_dir,
+        "--output",
+        html_output,
+    ]
+    if args.type == "initiative":
+        html_cmd.extend(["--type", "initiative"])
+    result = subprocess.run(html_cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Warning: HTML report generation failed: {result.stderr}", file=sys.stderr)
+
+
+def _record_split_failure(server, user, token, parent_key, reason, error, args, cfg, parent_data):
+    """Record a split that did not complete: review frontmatter, then Jira comment and label.
+
+    The Jira half is best-effort on purpose. The point of recording is to survive a failure, and
+    under the failures most worth recording — an expired token, an unreachable instance — these
+    same calls raise. An unguarded write here would replace the diagnosis with a traceback.
+    """
+    review_path = _find_review(args.artifacts_dir, parent_key, cfg)
+    if review_path:
+        update_frontmatter(
+            review_path,
+            {"error": error, "needs_attention": True, "needs_attention_reason": reason},
+            cfg["review_schema"],
+        )
+
+    entry = {
+        cfg["id_field"]: parent_key,
+        "attn_reason": reason,
+        "original_labels": parent_data.get("original_labels") or [],
+    }
+    try:
+        _post_needs_attention_comment(
+            server, user, token, entry, {parent_key: parent_key}, args.dry_run, cfg
+        )
+        if not args.dry_run:
+            add_labels(server, user, token, parent_key, [f"{cfg['label_prefix']}-needs-attention"])
+    except Exception as e:
+        print(
+            f"  Warning: could not flag {parent_key} in Jira ({e}). Recorded locally.",
+            file=sys.stderr,
+        )
+
+
+def _finish(args, type_label, submit_errors):
+    """Summarise failures, regenerate the reports, then exit. Never returns.
+
+    Every terminating path routes through here. A path that skipped it took the run report with
+    it, so successes already committed to Jira ended up recorded nowhere at all.
+    """
+    if submit_errors:
+        print(f"\n{len(submit_errors)} {type_label}(s) failed during submit:", file=sys.stderr)
+        for eid, emsg in submit_errors:
+            print(f"  {eid}: {emsg}", file=sys.stderr)
+
+    if args.generate_report:
+        _generate_reports(args)
+
+    sys.exit(1 if submit_errors else 0)
+
+
 def report_companion_path(artifacts_dir, run_id, work_type, suffix):
     """Path for a run report companion file, beside the YAML it belongs to.
 
@@ -293,6 +384,10 @@ def main():
             pk = _parent_of.get(pk)
         return False
 
+    # Hoisted above the split loop: both loops record into it, and every exit
+    # path reports it.
+    submit_errors = []
+
     if split_parents:
         print(f"Phase 1: Submitting {len(split_parents)} split parent(s)\n")
         script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -312,81 +407,69 @@ def main():
                 cmd.append("--dry-run")
             print(f"--- {parent_key} ---")
             result = subprocess.run(cmd)
+            # NB: argparse also exits 2, so a malformed argv above would be misread as the
+            # leaf cap and skipped rather than failing loudly.
             if result.returncode == 2:
                 print(f"  {parent_key}: Split refused — too many children")
-                review_path = _find_review(args.artifacts_dir, parent_key, cfg)
-                attn_reason = (
+                _record_split_failure(
+                    server,
+                    user,
+                    token,
+                    parent_key,
                     f"Automatic splitting produced too many child {type_label}s. "
                     "The decomposition needs human review to determine "
-                    "the right granularity."
+                    "the right granularity.",
+                    "split_refused: too many leaf children",
+                    args,
+                    cfg,
+                    split_parent_data[parent_key],
                 )
-                if review_path:
-                    update_frontmatter(
-                        review_path,
-                        {
-                            "error": "split_refused: too many leaf children",
-                            "needs_attention": True,
-                            "needs_attention_reason": attn_reason,
-                        },
-                        cfg["review_schema"],
-                    )
-
-                parent_labels = split_parent_data[parent_key].get("original_labels") or []
-                refusal_entry = {
-                    id_field: parent_key,
-                    "attn_reason": attn_reason,
-                    "original_labels": parent_labels,
-                }
-                refusal_results = {parent_key: parent_key}
-                _post_needs_attention_comment(
-                    server, user, token, refusal_entry, refusal_results, args.dry_run, cfg
-                )
-
-                if not args.dry_run:
-                    needs_attn_label = f"{cfg['label_prefix']}-needs-attention"
-                    add_labels(server, user, token, parent_key, [needs_attn_label])
                 continue
             elif result.returncode == 3:
                 print(f"  {parent_key}: Split refused — Jira conflict")
-                review_path = _find_review(args.artifacts_dir, parent_key, cfg)
-                attn_reason = (
+                _record_split_failure(
+                    server,
+                    user,
+                    token,
+                    parent_key,
                     f"Parent {type_label} description was modified in Jira since "
                     "fetch. Split submission skipped to avoid "
-                    "overwriting human edits."
+                    "overwriting human edits.",
+                    "split_refused: jira conflict",
+                    args,
+                    cfg,
+                    split_parent_data[parent_key],
                 )
-                if review_path:
-                    update_frontmatter(
-                        review_path,
-                        {
-                            "error": "split_refused: jira conflict",
-                            "needs_attention": True,
-                            "needs_attention_reason": attn_reason,
-                        },
-                        cfg["review_schema"],
-                    )
-
-                parent_labels = split_parent_data[parent_key].get("original_labels") or []
-                refusal_entry = {
-                    id_field: parent_key,
-                    "attn_reason": attn_reason,
-                    "original_labels": parent_labels,
-                }
-                refusal_results = {parent_key: parent_key}
-                _post_needs_attention_comment(
-                    server, user, token, refusal_entry, refusal_results, args.dry_run, cfg
-                )
-
-                if not args.dry_run:
-                    needs_attn_label = f"{cfg['label_prefix']}-needs-attention"
-                    add_labels(server, user, token, parent_key, [needs_attn_label])
                 continue
             elif result.returncode != 0:
+                # Unlike the refusals above, this one may be PARTIALLY APPLIED — split_submit
+                # writes to Jira across three phases, so children and links may already exist.
+                # Still an abort: continuing past an unclassified failure needs the systemic-vs-
+                # per-parent distinction the exit codes cannot currently express. But the report
+                # is written first, because the parents that succeeded earlier in this loop are
+                # real in Jira and this is the only place they are recorded.
                 print(
                     f"Error: split_submit.py failed for {parent_key} "
                     f"(exit code {result.returncode})",
                     file=sys.stderr,
                 )
-                sys.exit(result.returncode)
+                _record_split_failure(
+                    server,
+                    user,
+                    token,
+                    parent_key,
+                    f"Split submission failed partway (exit {result.returncode}). Jira may be "
+                    f"partially updated — check {parent_key} for child {type_label}s that were "
+                    "already created, and for unlinked children, before retrying.",
+                    f"split_submit_failed: exit {result.returncode}",
+                    args,
+                    cfg,
+                    split_parent_data[parent_key],
+                )
+                submit_errors.append(
+                    (parent_key, f"split_submit exit {result.returncode} (may be partial)")
+                )
+                _finish(args, type_label, submit_errors)
             print()
 
     # Record split-child hashes in the snapshot
@@ -444,7 +527,9 @@ def main():
                 print(f"Done. Index rebuilt at {args.artifacts_dir}/rfes.md")
             else:
                 print(f"Done. {len(split_parents)} split(s) processed.")
-            return
+            # A split-only batch reaches here on the happy path too, so returning early meant a
+            # run whose every input was a split never produced a report at all.
+            _finish(args, type_label, submit_errors)
         print(f"Error: No submittable {type_label}s found.", file=sys.stderr)
         sys.exit(1)
 
@@ -693,7 +778,6 @@ def main():
     # Execute
     results = {}
     submitted_hashes = {}
-    submit_errors = []
     mark_processed_ids = []
     for entry in plan:
         item_id = entry[id_field]
@@ -888,48 +972,7 @@ def main():
         for eid, emsg in submit_errors:
             print(f"  {eid}: {emsg}", file=sys.stderr)
 
-    # Generate reports if requested
-    if args.generate_report:
-        script_dir = os.path.dirname(os.path.abspath(__file__))
-        ts = args.report_timestamp
-        run_id = _parse_run_id(ts)
-
-        print("\nGenerating reports...")
-
-        yaml_cmd = [
-            sys.executable,
-            os.path.join(script_dir, "generate_run_report.py"),
-            "--start-time",
-            ts,
-            "--artifacts-dir",
-            args.artifacts_dir,
-        ]
-        if args.type == "initiative":
-            yaml_cmd.extend(["--type", "initiative"])
-        result = subprocess.run(yaml_cmd, capture_output=True, text=True)
-        if result.returncode == 0:
-            print(f"  YAML report: {result.stdout.strip()}")
-        else:
-            print(f"Warning: YAML report generation failed: {result.stderr}", file=sys.stderr)
-
-        html_output = report_companion_path(args.artifacts_dir, run_id, args.type, "-report.html")
-        html_cmd = [
-            sys.executable,
-            os.path.join(script_dir, "generate_review_pdf.py"),
-            "--revised-only",
-            "--artifacts-dir",
-            args.artifacts_dir,
-            "--output",
-            html_output,
-        ]
-        if args.type == "initiative":
-            html_cmd.extend(["--type", "initiative"])
-        result = subprocess.run(html_cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            print(f"Warning: HTML report generation failed: {result.stderr}", file=sys.stderr)
-
-    if submit_errors:
-        sys.exit(1)
+    _finish(args, type_label, submit_errors)
 
 
 if __name__ == "__main__":

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -213,17 +213,24 @@ def _generate_reports(args):
 def _record_split_failure(server, user, token, parent_key, reason, error, args, cfg, parent_data):
     """Record a split that did not complete: review frontmatter, then Jira comment and label.
 
-    The Jira half is best-effort on purpose. The point of recording is to survive a failure, and
-    under the failures most worth recording — an expired token, an unreachable instance — these
-    same calls raise. An unguarded write here would replace the diagnosis with a traceback.
+    Both halves are best-effort on purpose. The point of recording is to survive a failure, and
+    an unguarded write here would replace the diagnosis with a traceback — the Jira calls raise
+    under the failures most worth recording (expired token, unreachable instance), and the local
+    write raises on a corrupt or read-only review file.
     """
     review_path = _find_review(args.artifacts_dir, parent_key, cfg)
     if review_path:
-        update_frontmatter(
-            review_path,
-            {"error": error, "needs_attention": True, "needs_attention_reason": reason},
-            cfg["review_schema"],
-        )
+        try:
+            update_frontmatter(
+                review_path,
+                {"error": error, "needs_attention": True, "needs_attention_reason": reason},
+                cfg["review_schema"],
+            )
+        except Exception as e:
+            print(
+                f"  Warning: could not record the failure on {parent_key}'s review ({e}).",
+                file=sys.stderr,
+            )
 
     entry = {
         cfg["id_field"]: parent_key,
@@ -966,11 +973,6 @@ def main():
         print(f"Done. Index rebuilt at {args.artifacts_dir}/rfes.md")
     else:
         print(f"\nDone. {len(results)} {type_label.lower()}(s) processed.")
-
-    if submit_errors:
-        print(f"\n{len(submit_errors)} {type_label}(s) failed during submit:", file=sys.stderr)
-        for eid, emsg in submit_errors:
-            print(f"  {eid}: {emsg}", file=sys.stderr)
 
     _finish(args, type_label, submit_errors)
 

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -834,3 +834,131 @@ class TestApprovedTransition:
         stdout, stderr, rc = _run_submit(art_dir)
         assert rc == 0, stderr
         assert "Would transition to Approved" not in stdout
+
+
+class TestSplitFailureIsRecorded:
+    """A split that crashes must not take the run report down with it.
+
+    split_submit writes to Jira across three phases, so by the time an unclassified failure
+    surfaces, earlier parents in the same loop may already be fully split in Jira. Aborting before
+    the report was regenerated left those successes recorded nowhere — observed 2026-07-21/22,
+    where 11 of 18 parents were genuinely split and the job logged "No changes to commit".
+    """
+
+    PARENT_TASK = (
+        "---\nrfe_id: RHAIRFE-1000\ntitle: Parent RFE\n"
+        "priority: Major\nstatus: Archived\n---\n\nParent content.\n"
+    )
+    CHILD_TASK = (
+        "---\nrfe_id: RFE-001\ntitle: Child RFE\n"
+        "priority: Major\nstatus: Ready\nparent_key: RHAIRFE-1000\n---\n\nChild content.\n"
+    )
+    REVIEW_TPL = (
+        "---\nrfe_id: {rid}\nscore: 9\npass: true\n"
+        "recommendation: submit\nfeasibility: feasible\n"
+        "auto_revised: false\nneeds_attention: false\n"
+        "scores:\n  what: 2\n  why: 2\n  open_to_how: 2\n"
+        "  not_a_task: 2\n  right_sized: 1\n---\n\nLooks good.\n"
+    )
+
+    def _split_only_batch(self, art_dir):
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
+        _write(
+            f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md",
+            self.REVIEW_TPL.format(rid="RHAIRFE-1000"),
+        )
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md", self.CHILD_TASK)
+        _write(f"{art_dir}/rfe-reviews/RFE-001-review.md", self.REVIEW_TPL.format(rid="RFE-001"))
+
+    def _report_paths(self, art_dir, ts="20260818-120000"):
+        return (
+            f"{art_dir}/auto-fix-runs/{ts}.yaml",
+            f"{art_dir}/auto-fix-runs/{ts}-report.html",
+        )
+
+    def test_split_only_batch_still_writes_a_report(self, art_dir):
+        """The early return used to skip report generation entirely on this shape.
+
+        Uses the leaf-cap refusal to reach it: exit 2 is decided before split_submit makes any
+        Jira call, so this exercises the split-only path without a live instance. Afterwards
+        nothing is regular-submittable (the children all have a Jira ancestor), which is exactly
+        the branch that used to `return` before the report block.
+        """
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
+        _write(
+            f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md",
+            self.REVIEW_TPL.format(rid="RHAIRFE-1000"),
+        )
+        for i in range(1, 8):  # 7 leaves > MAX_LEAF_CHILDREN
+            _write(
+                f"{art_dir}/rfe-tasks/RFE-{i:03d}.md",
+                "---\nrfe_id: RFE-%03d\ntitle: Child %d\npriority: Major\n"
+                "status: Ready\nparent_key: RHAIRFE-1000\n---\n\nChild.\n" % (i, i),
+            )
+        yaml_path, _ = self._report_paths(art_dir)
+
+        stdout, stderr, rc = _run_submit(
+            art_dir, ["--generate-report", "--report-timestamp", "20260818-120000"]
+        )
+
+        assert rc == 0, stdout + stderr
+        assert "Split refused" in stdout
+        assert os.path.exists(yaml_path), (
+            "a batch whose every input was a split produced no run report"
+        )
+
+    def test_generic_failure_records_and_still_reports(self, art_dir, monkeypatch, tmp_path):
+        """Exit code 1 from split_submit: record it, write the report, then exit 1."""
+        self._split_only_batch(art_dir)
+        yaml_path, _ = self._report_paths(art_dir)
+
+        # Stand in for split_submit.py with something that fails the way a Jira 404 does.
+        stub = tmp_path / "split_submit.py"
+        stub.write_text("import sys\nsys.stderr.write('boom\\n')\nsys.exit(1)\n")
+        scripts_copy = tmp_path / "scripts"
+        scripts_copy.mkdir()
+        for name in os.listdir(os.path.dirname(SCRIPT)):
+            if name.endswith(".py") and name != "split_submit.py":
+                src = os.path.join(os.path.dirname(SCRIPT), name)
+                if os.path.isfile(src):
+                    with open(src) as f:
+                        (scripts_copy / name).write_text(f.read())
+        (scripts_copy / "split_submit.py").write_text(stub.read_text())
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": "https://fake.atlassian.net",
+            "JIRA_USER": "fake@example.com",
+            "JIRA_TOKEN": "fake-token",
+        }
+        result = subprocess.run(
+            [
+                "python3",
+                str(scripts_copy / "submit.py"),
+                "--dry-run",
+                "--artifacts-dir",
+                art_dir,
+                "--generate-report",
+                "--report-timestamp",
+                "20260818-120000",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "Traceback" not in result.stderr, result.stderr
+
+        import yaml
+
+        with open(f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md") as f:
+            content = f.read()
+        fm = yaml.safe_load(content[3 : content.index("---", 3)])
+        assert fm["error"] == "split_submit_failed: exit 1"
+        assert fm["needs_attention"] is True
+        assert "partially updated" in fm["needs_attention_reason"]
+
+        assert os.path.exists(yaml_path), (
+            "the failure took the run report with it — the successes before it are unrecorded"
+        )

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -907,6 +907,33 @@ class TestSplitFailureIsRecorded:
             "a batch whose every input was a split produced no run report"
         )
 
+    def test_corrupt_review_file_does_not_take_the_run_down(self, art_dir):
+        """Recording is best-effort on the local half too.
+
+        If the review file cannot be updated (corrupt frontmatter here; read-only or
+        schema-invalid in the wild), the refusal branch must warn and carry on to the report,
+        not replace the diagnosis with a traceback.
+        """
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
+        # A review file whose frontmatter cannot be parsed, let alone updated.
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md", "---\n: not yaml [\n---\n")
+        for i in range(1, 8):  # 7 leaves > MAX_LEAF_CHILDREN -> refusal branch
+            _write(
+                f"{art_dir}/rfe-tasks/RFE-{i:03d}.md",
+                "---\nrfe_id: RFE-%03d\ntitle: Child %d\npriority: Major\n"
+                "status: Ready\nparent_key: RHAIRFE-1000\n---\n\nChild.\n" % (i, i),
+            )
+
+        stdout, stderr, rc = _run_submit(
+            art_dir, ["--generate-report", "--report-timestamp", "20260818-120000"]
+        )
+
+        assert rc == 0, stdout + stderr
+        # The handled path, not a crash. (stderr may still QUOTE a traceback: submit.py wraps
+        # the HTML generator's own, pre-existing crash on corrupt reviews in a warning.)
+        assert "could not record the failure" in stderr
+        assert os.path.exists(f"{art_dir}/auto-fix-runs/20260818-120000.yaml")
+
     def test_generic_failure_records_and_still_reports(self, art_dir, monkeypatch, tmp_path):
         """Exit code 1 from split_submit: record it, write the report, then exit 1."""
         self._split_only_batch(art_dir)


### PR DESCRIPTION
> **Stacked on #157** (base `fix/snapshot-reader-hardening`) — `_generate_reports` uses `report_companion_path`, which #157 introduces. Rebase onto `main` once #157 merges. Only the last commit is new.

## The failure

`split_submit` writes to Jira across three phases. By the time an unclassified failure surfaces, parents processed earlier in the same loop may already be fully split. `submit.py` aborted on the spot, and report regeneration lives at the end of `main()` — so those successes were recorded nowhere.

Observed 2026-07-21/22: an `HTTP 404` in `phase2_create_link`, the job logging `No changes to commit, skipping push`, and **11 of 18 parents genuinely split in Jira with no trace in any report**.

## Why the abort stays

The obvious fix — record it and continue — is not safe yet, and an analysis of it turned up three blockers:

- **Everything collapses to exit 1.** `api_call_with_retry` retries 429/5xx/`URLError` but raises 401/403/400/404 immediately, so a revoked token and one over-long child title are indistinguishable. A blind `continue` applies per-parent policy to systemic failures: 18 parents × ~3 requests × 21s of retry backoff, and 18 bogus needs-attention flags.
- **The recording branch itself calls Jira, unguarded.** Under the very failures worth recording, the ported branch would throw at parent #1 — a traceback replacing today's clean error, and still no report.
- **Non-fatal makes a latent duplication bug live.** `phase2_create_link` commits `create_issue` before the link and the confirmation comment, and `discover_state` can only find a child via one of those two. A death in that window mints a ticket no future run can see; since the parent stays `processed: false`, the nightly would retry it and duplicate children every night. (Measured: 60 children created 2026-07-20→24, **zero** currently orphaned — the hazard is real by inspection but has not fired.)

So this PR keeps the abort and fixes the actual complaint: the record survives. Continuing is tracked separately, gated on the classification work that makes it safe.

## Changes

- Every terminating path routes through `_finish()`, which reports failures, regenerates the reports, and sets the exit code.
- The generic-failure branch now records like the two refusal branches: review frontmatter, a Jira comment, the needs-attention label. Its error string is `split_submit_failed: exit N` rather than `split_refused:`, and its reason warns the split may be **partially applied** — unlike the refusals, which are decided before any Jira write.
- That recording is extracted into one helper and its Jira calls are wrapped. They were unguarded in the existing exit-2/exit-3 branches too, so this fixes a live latent traceback.
- `submit_errors` hoisted above the split loop; it was defined ~300 lines below it.

## Also fixes a live bug found alongside

`if not submittable:` → `return`, before the errors dump, the report block and the exit code. **A batch whose every input was a split produced no report even when every split succeeded** — the exact shape of the 18-parent run above.

## Verification

767 tests pass, ruff clean. Two new tests, both mutation-checked — reverting either fix fails its own test and only that one:

```
revert early-return fix   -> test_split_only_batch_still_writes_a_report  FAILED
restore the hard abort    -> test_generic_failure_records_and_still_reports FAILED
```

The split-only test reaches the early-return branch via the leaf-cap refusal, since exit 2 is decided before `split_submit` makes any Jira call — no live instance needed.

RHAIFIRST-565, part of RHAIFIRST-553.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Split-only submissions now generate reports even when processing is refused or encounters an error.
  - Failed split processing is recorded for review with an attention indicator.
  - Errors are accumulated and reported consistently.
  - Failed executions now exit cleanly with an error status instead of displaying a traceback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->