### PR TITLE
ci-prod: generate the review diff with difflib, not the diff binary

### DIFF
--- a/scripts/generate_review_pdf.py
+++ b/scripts/generate_review_pdf.py
@@ -5,7 +5,6 @@ from collections import Counter
 import json
 import os
 import re
-import subprocess
 import sys
 import yaml
 
@@ -59,19 +58,20 @@ def generate_diff(rfe_id, tasks_dir, originals_dir):
         if len(parts) >= 3:
             revised_content = parts[2].lstrip('\n')
 
-    import tempfile
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as tmp:
-        tmp.write(revised_content)
-        tmp_path = tmp.name
+    with open(orig) as f:
+        orig_lines = f.readlines()
+    revised_lines = revised_content.splitlines(keepends=True)
 
-    try:
-        result = subprocess.run(
-            ['diff', '-u', orig, tmp_path],
-            capture_output=True, text=True
-        )
-        return result.stdout
-    finally:
-        os.unlink(tmp_path)
+    # difflib needs a trailing newline on the last line or it emits "\ No newline"
+    # markers mid-diff; normalize both sides the way diff -u effectively did.
+    if orig_lines and not orig_lines[-1].endswith('\n'):
+        orig_lines[-1] += '\n'
+    if revised_lines and not revised_lines[-1].endswith('\n'):
+        revised_lines[-1] += '\n'
+
+    import difflib
+    diff = difflib.unified_diff(orig_lines, revised_lines, fromfile=orig, tofile=revised)
+    return ''.join(diff)
 
 def html_escape(text):
     return text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;').replace("'", '&#x27;')


### PR DESCRIPTION
Targeted backport of the core fix from #145 (RHAIFIRST-313) to `ci-prod`.

## Why the bug is still live in production

#145 replaced `generate_review_pdf.py`'s `subprocess.run(['diff', ...])` with `difflib` — but it merged to `main`, and the autofixer CI clones this repo at `ci-prod` (`CLAUDE_REPO_BRANCH: "ci-prod"`). The openshell image has no `diff` binary, so every production run still hits:

```
FileNotFoundError: [Errno 2] No such file or directory: 'diff'
```

Seen in [job 16022657385](https://gitlab.com/redhat/rhel-ai/agentic-ci/rfe-autofixer/-/jobs/16022657385) (2026-08-21). The job stays green because `submit.py` wraps HTML generation in a warning — the impact is that **no production run publishes its HTML companion report**; the YAML report is unaffected.

## Why a backport rather than a cherry-pick

`ci-prod` is 103 commits behind `main`; a direct cherry-pick of #145's commits conflicts because `main`'s `generate_diff` has since grown hardening (`_safe_artifact_path`, `_open_nofollow`, size caps) entangled with main-only code. This ports only the load-bearing change into ci-prod's existing function shape: read both files, strip frontmatter as before, and produce the unified diff with `difflib.unified_diff` — no temp file, no subprocess, no external binary. The dead `subprocess` import is removed.

Trailing newlines are normalized on both sides so difflib doesn't emit mid-diff `\ No newline` markers — matching what `diff -u` effectively produced.

## Verification

- Functional check against a synthetic original/revised pair: changed case emits a correct unified diff, unchanged case returns `""` (same as `diff -u`).
- ci-prod test suite: 463 passed, 1 failed — the failure (`test_dry_run_skips_split_child_hashes`) pre-exists on unmodified `ci-prod` and is untouched by this change.