### PR TITLE
Carry tracker_ref, role and provenance on every run report entry

### DIFF
--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -871,6 +871,14 @@ def rename_to_jira_key(artifacts_dir, rfe_id, jira_key):
         rfe_id: e.g. "RFE-001"
         jira_key: e.g. "RHAIRFE-1600"
     """
+    # Both ids become path components below. rfe_id comes from validated
+    # frontmatter, but jira_key arrives from a Jira API response — reject
+    # anything that is not the documented shape before touching the fs.
+    if not re.fullmatch(r"RFE-\d+", rfe_id):
+        raise ValueError(f"rename_to_jira_key: invalid local id {rfe_id!r}")
+    if not re.fullmatch(r"RHAIRFE-\d+", jira_key):
+        raise ValueError(f"rename_to_jira_key: invalid Jira key {jira_key!r}")
+
     tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
     reviews_dir = os.path.join(artifacts_dir, "rfe-reviews")
 
@@ -923,6 +931,11 @@ def rename_initiative_to_jira_key(artifacts_dir, initiative_id, jira_key):
     Renames the task file, companion files, and review file.
     Updates initiative_id in frontmatter to the new Jira key.
     """
+    if not re.fullmatch(r"INIT-\d+", initiative_id):
+        raise ValueError(f"rename_initiative_to_jira_key: invalid local id {initiative_id!r}")
+    if not re.fullmatch(r"RHOAIENG-\d+", jira_key):
+        raise ValueError(f"rename_initiative_to_jira_key: invalid Jira key {jira_key!r}")
+
     initiatives_dir = os.path.join(artifacts_dir, "initiatives")
     reviews_dir = os.path.join(artifacts_dir, "initiative-reviews")
 

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -64,6 +64,15 @@ SCHEMAS = {
             "required": True,
             "pattern": r"^(RFE-\d+|RHAIRFE-\d+)$",
         },
+        # Pre-submission id, persisted at rename time. Renaming overwrites
+        # rfe_id with the Jira key, and this is the only durable record of
+        # which local draft a submitted item came from.
+        "local_id": {
+            "type": "string",
+            "required": False,
+            "pattern": r"^RFE-\d+$",
+            "default": None,
+        },
         "title": {
             "type": "string",
             "required": True,
@@ -101,6 +110,15 @@ SCHEMAS = {
             "type": "string",
             "required": True,
             "pattern": r"^(RFE-\d+|RHAIRFE-\d+)$",
+        },
+        # Pre-submission id, persisted at rename time. Renaming overwrites
+        # rfe_id with the Jira key, and this is the only durable record of
+        # which local draft a submitted item came from.
+        "local_id": {
+            "type": "string",
+            "required": False,
+            "pattern": r"^RFE-\d+$",
+            "default": None,
         },
         "score": {
             "type": "int",
@@ -175,6 +193,12 @@ SCHEMAS = {
             "required": True,
             "pattern": r"^(INIT-\d+|RHOAIENG-\d+)$",
         },
+        "local_id": {
+            "type": "string",
+            "required": False,
+            "pattern": r"^INIT-\d+$",
+            "default": None,
+        },
         "title": {
             "type": "string",
             "required": True,
@@ -206,6 +230,12 @@ SCHEMAS = {
             "type": "string",
             "required": True,
             "pattern": r"^(INIT-\d+|RHOAIENG-\d+)$",
+        },
+        "local_id": {
+            "type": "string",
+            "required": False,
+            "pattern": r"^INIT-\d+$",
+            "default": None,
         },
         "score": {
             "type": "int",
@@ -869,7 +899,9 @@ def rename_to_jira_key(artifacts_dir, rfe_id, jira_key):
             # Update frontmatter on main task file
             if new_name == f"{jira_key}.md":
                 update_frontmatter(
-                    new_path, {"rfe_id": jira_key, "status": "Submitted"}, "rfe-task"
+                    new_path,
+                    {"rfe_id": jira_key, "status": "Submitted", "local_id": rfe_id},
+                    "rfe-task",
                 )
 
     # Rename review file
@@ -881,7 +913,7 @@ def rename_to_jira_key(artifacts_dir, rfe_id, jira_key):
                 os.rename(old_path, new_path)
 
                 # Update frontmatter
-                update_frontmatter(new_path, {"rfe_id": jira_key}, "rfe-review")
+                update_frontmatter(new_path, {"rfe_id": jira_key, "local_id": rfe_id}, "rfe-review")
                 break
 
 
@@ -922,7 +954,7 @@ def rename_initiative_to_jira_key(artifacts_dir, initiative_id, jira_key):
             if new_name == f"{jira_key}.md":
                 update_frontmatter(
                     new_path,
-                    {"initiative_id": jira_key, "status": "Submitted"},
+                    {"initiative_id": jira_key, "status": "Submitted", "local_id": initiative_id},
                     "initiative-task",
                 )
 
@@ -931,7 +963,11 @@ def rename_initiative_to_jira_key(artifacts_dir, initiative_id, jira_key):
         if os.path.isfile(old_review):
             new_review = os.path.join(reviews_dir, f"{jira_key}-review.md")
             os.rename(old_review, new_review)
-            update_frontmatter(new_review, {"initiative_id": jira_key}, "initiative-review")
+            update_frontmatter(
+                new_review,
+                {"initiative_id": jira_key, "local_id": initiative_id},
+                "initiative-review",
+            )
 
 
 # ─── Index Rebuilding ───────────────────────────────────────────────────────────

--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -73,29 +73,34 @@ REPORT_STAGES = ("pre_submit", "final")
 SPLIT_REFUSED_PREFIX = "split_refused:"
 
 
-def split_children_map(artifacts_dir, config):
+def split_children_map(artifacts_dir, config, tasks=None):
     """Map parent ID -> child IDs for split children found in the task dir.
 
     A child declares its parent with `parent_key`. On the initiative side that
     same field also carries the RHAISTRAT Outcome link, which is a strategy
     rollup, not a split — so only same-family parents count.
 
-    `config` is a TYPE_CONFIG entry.
+    `config` is a TYPE_CONFIG entry. `tasks` lets a caller that already
+    scanned the tree reuse the rows instead of walking it again.
     """
+    if tasks is None:
+        tasks = config["scan_tasks"](artifacts_dir)
     children_map = {}
-    for _, task_data in config["scan_tasks"](artifacts_dir):
+    for _, task_data in tasks:
         parent = task_data.get("parent_key")
         if parent and parent.startswith(config["child_parent_prefixes"]):
             children_map.setdefault(parent, []).append(task_data[config["id_field"]])
     return children_map
 
 
-def _task_status_map(artifacts_dir, config):
+def _task_status_map(tasks, config):
     """Map item id -> task frontmatter status, for role classification."""
-    return {
-        task_data[config["id_field"]]: task_data.get("status")
-        for _, task_data in config["scan_tasks"](artifacts_dir)
-    }
+    return {task_data[config["id_field"]]: task_data.get("status") for _, task_data in tasks}
+
+
+def _usable_score(value):
+    """An integer that is not a bool — the only shape the aggregates accept."""
+    return isinstance(value, int) and not isinstance(value, bool)
 
 
 def _parse_run_id(start_time):
@@ -132,8 +137,9 @@ def build_report(
     reviews_dir = os.path.join(artifacts_dir, config["reviews_dir"])
 
     # Expand ID list to include split children discovered from task files
-    children_map = split_children_map(artifacts_dir, config)
-    status_map = _task_status_map(artifacts_dir, config)
+    tasks = list(config["scan_tasks"](artifacts_dir))
+    children_map = split_children_map(artifacts_dir, config, tasks=tasks)
+    status_map = _task_status_map(tasks, config)
     all_children = [c for kids in children_map.values() for c in kids]
     expanded_ids = list(ids) + [c for c in all_children if c not in ids]
 
@@ -175,8 +181,24 @@ def build_report(
             # feed a phantom value into every average. Note error stubs are
             # written schema-complete with score=0, so they pass and count as
             # failed — which is their design.
-            if not isinstance(data.get("score"), int) or isinstance(data.get("score"), bool):
+            if not _usable_score(data.get("score")):
                 raise ValueError(f"review has no usable score (got {data.get('score')!r})")
+            # Every other numeric the aggregates consume gets the same rule: a
+            # single malformed value would otherwise reach avg()'s sum() and
+            # abort the WHOLE report over one corrupt review, instead of that
+            # review becoming an error entry.
+            if data.get("before_score") is not None and not _usable_score(data["before_score"]):
+                raise ValueError(f"review has unusable before_score ({data['before_score']!r})")
+            for field_name in ("scores", "before_scores"):
+                members = data.get(field_name)
+                if isinstance(members, dict):
+                    bad = {
+                        k: v
+                        for k, v in members.items()
+                        if k in score_fields and not _usable_score(v)
+                    }
+                    if bad:
+                        raise ValueError(f"review has unusable {field_name} members: {bad!r}")
         except Exception as e:
             per_item.append({"id": item_id, "tracker_ref": tracker_ref, "error": str(e)})
             counts["errors"] += 1

--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -164,8 +164,11 @@ def build_report(
             continue
         try:
             data, _ = read_frontmatter(review_path)
-            if not isinstance(data, dict):
-                raise ValueError("review frontmatter is empty or not a mapping")
+            # read_frontmatter normalizes missing/empty/non-mapping frontmatter
+            # to {} — which would sail through as a normal entry with score 0
+            # and recommendation 'revise', silently dragging the averages.
+            if not isinstance(data, dict) or not data:
+                raise ValueError("review frontmatter is missing, empty or not a mapping")
         except Exception as e:
             per_item.append({"id": item_id, "tracker_ref": tracker_ref, "error": str(e)})
             counts["errors"] += 1

--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -31,6 +31,8 @@ TYPE_CONFIG = {
         "id_field": "rfe_id",
         # parent_key values that mean "split from"; see split_children_map.
         "child_parent_prefixes": ("RFE-", "RHAIRFE-"),
+        "tracker_prefix": "RHAIRFE-",
+        "local_prefix": "RFE-",
     },
     "initiative": {
         "score_fields": [
@@ -47,6 +49,8 @@ TYPE_CONFIG = {
         "scan_tasks": scan_initiative_task_files,
         "id_field": "initiative_id",
         "child_parent_prefixes": ("INIT-", "RHOAIENG-"),
+        "tracker_prefix": "RHOAIENG-",
+        "local_prefix": "INIT-",
     },
 }
 
@@ -86,6 +90,14 @@ def split_children_map(artifacts_dir, config):
     return children_map
 
 
+def _task_status_map(artifacts_dir, config):
+    """Map item id -> task frontmatter status, for role classification."""
+    return {
+        task_data[config["id_field"]]: task_data.get("status")
+        for _, task_data in config["scan_tasks"](artifacts_dir)
+    }
+
+
 def _parse_run_id(start_time):
     """Derive run_id from a timestamp. Accepts YYYYMMDD-HHMMSS or ISO format."""
     if re.match(r"^\d{8}-\d{6}$", start_time):
@@ -121,6 +133,7 @@ def build_report(
 
     # Expand ID list to include split children discovered from task files
     children_map = split_children_map(artifacts_dir, config)
+    status_map = _task_status_map(artifacts_dir, config)
     all_children = [c for kids in children_map.values() for c in kids]
     expanded_ids = list(ids) + [c for c in all_children if c not in ids]
 
@@ -137,18 +150,49 @@ def build_report(
             review_path = os.path.join(reviews_dir, f"{item_id}-review.md")
             if not os.path.exists(review_path):
                 review_path = None
+        # Error entries carry tracker_ref too — it derives from the id alone,
+        # and without it these are the only rows a consumer would still have
+        # to prefix-sniff.
+        is_tracker_id = item_id.startswith(config["tracker_prefix"])
+        tracker_ref = item_id if is_tracker_id else None
+
         if not review_path:
-            per_item.append({"id": item_id, "error": "review file not found"})
+            per_item.append(
+                {"id": item_id, "tracker_ref": tracker_ref, "error": "review file not found"}
+            )
             counts["errors"] += 1
             continue
         try:
             data, _ = read_frontmatter(review_path)
+            if not isinstance(data, dict):
+                raise ValueError("review frontmatter is empty or not a mapping")
         except Exception as e:
-            per_item.append({"id": item_id, "error": str(e)})
+            per_item.append({"id": item_id, "tracker_ref": tracker_ref, "error": str(e)})
             counts["errors"] += 1
             continue
 
         entry = {"id": item_id}
+
+        # The canonical remote reference (work-item-types-unified.md §5): the id
+        # itself once submitted, null while none exists. Consumers must never
+        # infer "is this a real ticket" from the id prefix again.
+        entry["tracker_ref"] = tracker_ref
+
+        # A local-id node that was split again is a structural stepping stone —
+        # archived, never submitted, its children re-parented at submit time by
+        # split_submit._collect_leaves. Everything else is a leaf. Absent means
+        # the task file was not found, so the role could not be determined.
+        task_status = status_map.get(item_id)
+        if task_status is not None:
+            is_local_id = item_id.startswith(config["local_prefix"])
+            entry["role"] = "intermediary" if is_local_id and task_status == "Archived" else "leaf"
+
+        # Provenance: the pre-submission id, persisted by the rename. Only
+        # meaningful once the entry id has become the Jira key.
+        local_id = data.get("local_id")
+        if local_id and local_id != item_id:
+            entry["local_id"] = local_id
+
         rec = data.get("recommendation", "revise")
         entry["recommendation"] = rec
         entry["auto_revised"] = data.get("auto_revised", False)

--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -169,6 +169,14 @@ def build_report(
             # and recommendation 'revise', silently dragging the averages.
             if not isinstance(data, dict) or not data:
                 raise ValueError("review frontmatter is missing, empty or not a mapping")
+            # Deliberately narrower than full schema validation: an aggregator
+            # has to tolerate field drift across review vintages (historical
+            # re-scoring), but a review whose score is not an integer would
+            # feed a phantom value into every average. Note error stubs are
+            # written schema-complete with score=0, so they pass and count as
+            # failed — which is their design.
+            if not isinstance(data.get("score"), int) or isinstance(data.get("score"), bool):
+                raise ValueError(f"review has no usable score (got {data.get('score')!r})")
         except Exception as e:
             per_item.append({"id": item_id, "tracker_ref": tracker_ref, "error": str(e)})
             counts["errors"] += 1
@@ -219,14 +227,16 @@ def build_report(
         else:
             entry["revision_cycles"] = 0
 
-        scores = data.get("scores") or {}
-        for f in score_fields:
-            if f in scores:
-                after_totals[f].append(scores[f])
-        before_scores = data.get("before_scores") or {}
-        for f in score_fields:
-            if f in before_scores:
-                before_totals[f].append(before_scores[f])
+        scores = data.get("scores")
+        if isinstance(scores, dict):
+            for f in score_fields:
+                if f in scores:
+                    after_totals[f].append(scores[f])
+        before_scores = data.get("before_scores")
+        if isinstance(before_scores, dict):
+            for f in score_fields:
+                if f in before_scores:
+                    before_totals[f].append(before_scores[f])
 
         kids = children_map.get(item_id)
         if kids:

--- a/tests/test_artifact_utils.py
+++ b/tests/test_artifact_utils.py
@@ -16,6 +16,7 @@ from artifact_utils import (
     read_frontmatter,
     read_frontmatter_validated,
     rename_initiative_to_jira_key,
+    rename_to_jira_key,
     update_frontmatter,
     validate,
     write_frontmatter,
@@ -405,6 +406,81 @@ class TestInitiativeFrontmatter:
         data, _ = read_frontmatter("init-review.md")
         assert data["auto_revised"] is True
         assert data["initiative_id"] == "INIT-001"
+
+
+class TestRenamePersistsLocalId:
+    """Renaming to the Jira key must not destroy the pre-submission identity.
+
+    rfe_id/initiative_id is overwritten with the key, so before this the
+    RFE-001 -> RHAIRFE-3082 mapping survived only as a git rename in the
+    results repo's history — unreadable from any single commit. The run
+    report's provenance field reads local_id back from these files.
+    """
+
+    def _setup_rfe(self):
+        os.makedirs("artifacts/rfe-tasks")
+        os.makedirs("artifacts/rfe-reviews")
+        write_frontmatter(
+            "artifacts/rfe-tasks/RFE-001.md",
+            {"rfe_id": "RFE-001", "title": "T", "priority": "Major", "status": "Ready"},
+            "rfe-task",
+        )
+        write_frontmatter(
+            "artifacts/rfe-reviews/RFE-001-review.md",
+            {**VALID_REVIEW_FM, "rfe_id": "RFE-001"},
+            "rfe-review",
+        )
+
+    def test_rfe_task_and_review_carry_local_id(self, tmp_dir):
+        self._setup_rfe()
+
+        rename_to_jira_key("artifacts", "RFE-001", "RHAIRFE-3082")
+
+        task, _ = read_frontmatter("artifacts/rfe-tasks/RHAIRFE-3082.md")
+        review, _ = read_frontmatter("artifacts/rfe-reviews/RHAIRFE-3082-review.md")
+        assert task["rfe_id"] == "RHAIRFE-3082"
+        assert task["local_id"] == "RFE-001"
+        assert review["local_id"] == "RFE-001"
+
+    def test_renamed_files_still_validate(self, tmp_dir):
+        """local_id must be legal under the schemas or every later
+        update_frontmatter on a renamed file would raise."""
+        self._setup_rfe()
+
+        rename_to_jira_key("artifacts", "RFE-001", "RHAIRFE-3082")
+
+        data, _ = read_frontmatter_validated("artifacts/rfe-tasks/RHAIRFE-3082.md", "rfe-task")
+        assert data["local_id"] == "RFE-001"
+        # and a subsequent update keeps working
+        update_frontmatter(
+            "artifacts/rfe-tasks/RHAIRFE-3082.md", {"status": "Submitted"}, "rfe-task"
+        )
+
+    def test_initiative_rename_carries_local_id(self, tmp_dir):
+        os.makedirs("artifacts/initiatives")
+        os.makedirs("artifacts/initiative-reviews")
+        write_frontmatter(
+            "artifacts/initiatives/INIT-001.md",
+            VALID_INITIATIVE_TASK_FM.copy(),
+            "initiative-task",
+        )
+
+        rename_initiative_to_jira_key("artifacts", "INIT-001", "RHOAIENG-1234")
+
+        data, _ = read_frontmatter("artifacts/initiatives/RHOAIENG-1234.md")
+        assert data["local_id"] == "INIT-001"
+
+    def test_local_id_pattern_rejects_jira_keys(self):
+        """The field means "pre-submission id" — a Jira key in it is a bug."""
+        data = {
+            "rfe_id": "RHAIRFE-3082",
+            "title": "T",
+            "priority": "Major",
+            "status": "Submitted",
+            "local_id": "RHAIRFE-3082",
+        }
+        errors = validate(data, "rfe-task")
+        assert any("local_id" in e for e in errors)
 
 
 class TestRenameInitiativeToJiraKey:

--- a/tests/test_artifact_utils.py
+++ b/tests/test_artifact_utils.py
@@ -483,6 +483,29 @@ class TestRenamePersistsLocalId:
         assert any("local_id" in e for e in errors)
 
 
+class TestRenameRejectsMalformedIds:
+    """Both ids become path components; jira_key arrives from a Jira API
+    response, so shapes outside the documented grammar are rejected before
+    any file operation (path-traversal guard)."""
+
+    def test_traversal_in_jira_key_rejected(self, tmp_dir):
+        os.makedirs("artifacts/rfe-tasks")
+        with pytest.raises(ValueError, match="invalid Jira key"):
+            rename_to_jira_key("artifacts", "RFE-001", "../../etc/passwd")
+
+    def test_traversal_in_local_id_rejected(self, tmp_dir):
+        os.makedirs("artifacts/rfe-tasks")
+        with pytest.raises(ValueError, match="invalid local id"):
+            rename_to_jira_key("artifacts", "../RFE-001", "RHAIRFE-1600")
+
+    def test_initiative_guards(self, tmp_dir):
+        os.makedirs("artifacts/initiatives")
+        with pytest.raises(ValueError, match="invalid Jira key"):
+            rename_initiative_to_jira_key("artifacts", "INIT-001", "RHOAIENG-1/../2")
+        with pytest.raises(ValueError, match="invalid local id"):
+            rename_initiative_to_jira_key("artifacts", "INIT-001x", "RHOAIENG-1234")
+
+
 class TestRenameInitiativeToJiraKey:
     """Companion files must be renamed as companions, not as the task file.
 

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -625,6 +625,41 @@ class TestEntryProvenanceFields:
         assert report["after_scores_avg"]["total"] == 0.0
         assert report["results"]["errors"] == 1
 
+    def test_malformed_nested_score_is_an_error_entry_not_a_crash(self, art_dir):
+        """One corrupt review must become an error entry — not abort the whole
+        report via sum() raising TypeError in avg()."""
+        self._task(art_dir, "RHAIRFE-80", status="Ready")
+        _write(
+            f"{art_dir}/rfe-reviews/RHAIRFE-80-review.md",
+            "---\nrfe_id: RHAIRFE-80\nscore: 8\npass: true\nrecommendation: submit\n"
+            "feasibility: feasible\nauto_revised: false\nneeds_attention: false\n"
+            "scores:\n  what: bad\n  why: 2\n---\n\nok.\n",
+        )
+        # A healthy sibling proves the report itself survives.
+        self._task(art_dir, "RHAIRFE-81", status="Ready")
+        self._review(art_dir, "RHAIRFE-81")
+
+        report = build_report(["RHAIRFE-80", "RHAIRFE-81"], "2026-08-24T12:00:00Z")
+        by_id = {e["id"]: e for e in report["per_rfe"]}
+
+        assert "unusable scores members" in by_id["RHAIRFE-80"]["error"]
+        assert by_id["RHAIRFE-81"]["after_score"] == 9
+        assert report["after_scores_avg"]["total"] == 9.0
+
+    def test_malformed_before_score_is_an_error_entry(self, art_dir):
+        self._task(art_dir, "RHAIRFE-82", status="Ready")
+        _write(
+            f"{art_dir}/rfe-reviews/RHAIRFE-82-review.md",
+            "---\nrfe_id: RHAIRFE-82\nscore: 8\npass: true\nrecommendation: submit\n"
+            "feasibility: feasible\nauto_revised: false\nneeds_attention: false\n"
+            "before_score: seven\n---\n\nok.\n",
+        )
+
+        report = build_report(["RHAIRFE-82"], "2026-08-24T12:00:00Z")
+
+        assert "unusable before_score" in report["per_rfe"][0]["error"]
+        assert report["results"]["errors"] == 1
+
     def test_non_dict_scores_do_not_crash_or_pollute(self, art_dir):
         self._task(art_dir, "RHAIRFE-78", status="Ready")
         _write(

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -606,6 +606,39 @@ class TestEntryProvenanceFields:
         assert report["results"]["errors"] == 1
         assert report["after_scores_avg"]["total"] == 0.0  # nothing scored, not a 0-score entry
 
+    def test_review_without_a_score_is_an_error_entry(self, art_dir):
+        """Non-empty but score-less frontmatter must not feed a phantom 0 into
+        the averages. Full schema validation is deliberately NOT used here —
+        the aggregator tolerates field drift across review vintages; only the
+        values it consumes are checked."""
+        self._task(art_dir, "RHAIRFE-77", status="Ready")
+        _write(
+            f"{art_dir}/rfe-reviews/RHAIRFE-77-review.md",
+            "---\nrfe_id: RHAIRFE-77\nrecommendation: submit\n---\n\nok.\n",
+        )
+
+        report = build_report(["RHAIRFE-77"], "2026-08-21T12:00:00Z")
+        entry = report["per_rfe"][0]
+
+        assert "error" in entry and "no usable score" in entry["error"]
+        assert entry["tracker_ref"] == "RHAIRFE-77"
+        assert report["after_scores_avg"]["total"] == 0.0
+        assert report["results"]["errors"] == 1
+
+    def test_non_dict_scores_do_not_crash_or_pollute(self, art_dir):
+        self._task(art_dir, "RHAIRFE-78", status="Ready")
+        _write(
+            f"{art_dir}/rfe-reviews/RHAIRFE-78-review.md",
+            "---\nrfe_id: RHAIRFE-78\nscore: 9\npass: true\nrecommendation: submit\n"
+            "feasibility: feasible\nauto_revised: false\nneeds_attention: false\n"
+            "scores: what happened here\n---\n\nok.\n",
+        )
+
+        report = build_report(["RHAIRFE-78"], "2026-08-21T12:00:00Z")
+
+        assert report["per_rfe"][0]["after_score"] == 9
+        assert report["after_scores_avg"]["what"] == 0.0
+
     def test_missing_task_file_omits_role(self, art_dir):
         """Absent means not determined — never guessed."""
         self._review(art_dir, "RHAIRFE-1234")

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -590,6 +590,22 @@ class TestEntryProvenanceFields:
         assert entry["role"] == "leaf"
         assert entry["tracker_ref"] == "RHAIRFE-1000"
 
+    def test_empty_frontmatter_review_is_an_error_entry(self, art_dir):
+        """read_frontmatter normalizes empty/non-mapping frontmatter to {} —
+        without a guard that review becomes a normal entry with score 0,
+        silently dragging the averages. Seen in the published corpus
+        (20260727-031043/RHAIRFE-2911-review.md)."""
+        self._task(art_dir, "RHAIRFE-2911", status="Ready")
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-2911-review.md", "---\n---\n\n## Feedback\n")
+
+        report = build_report(["RHAIRFE-2911"], "2026-08-21T12:00:00Z")
+        entry = report["per_rfe"][0]
+
+        assert "error" in entry
+        assert entry["tracker_ref"] == "RHAIRFE-2911"
+        assert report["results"]["errors"] == 1
+        assert report["after_scores_avg"]["total"] == 0.0  # nothing scored, not a 0-score entry
+
     def test_missing_task_file_omits_role(self, art_dir):
         """Absent means not determined — never guessed."""
         self._review(art_dir, "RHAIRFE-1234")

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -507,6 +507,100 @@ class TestRefusedSplitIsBlockedNotSplit:
         assert report["per_rfe"][0]["needs_attention"] is True
 
 
+class TestEntryProvenanceFields:
+    """tracker_ref, role and local_id — the three-mode classification per entry.
+
+    | mode          | role         | tracker_ref  |
+    |---------------|--------------|--------------|
+    | intermediary  | intermediary | null         |
+    | blocked leaf  | leaf         | null         |
+    | submitted     | leaf         | the Jira key |
+    """
+
+    def _task(self, art_dir, rfe_id, status="Ready", parent=None, extra_fm=""):
+        parent_line = f"parent_key: {parent}\n" if parent else ""
+        _write(
+            f"{art_dir}/rfe-tasks/{rfe_id}.md",
+            f"---\nrfe_id: {rfe_id}\ntitle: T\npriority: Major\n"
+            f"status: {status}\n{parent_line}{extra_fm}---\n\nBody.\n",
+        )
+
+    def _review(self, art_dir, rfe_id, extra_fm=""):
+        _write(
+            f"{art_dir}/rfe-reviews/{rfe_id}-review.md",
+            f"---\nrfe_id: {rfe_id}\nscore: 9\npass: true\nrecommendation: submit\n"
+            f"feasibility: feasible\nauto_revised: false\nneeds_attention: false\n{extra_fm}"
+            "scores:\n  what: 2\n  why: 2\n  open_to_how: 2\n  not_a_task: 2\n  right_sized: 2\n"
+            "---\n\nok.\n",
+        )
+
+    def test_submitted_entry_carries_tracker_ref_and_provenance(self, art_dir):
+        """Post-rename: id is the Jira key, local_id preserves where it came from."""
+        self._task(art_dir, "RHAIRFE-3082", status="Submitted", extra_fm="local_id: RFE-001\n")
+        self._review(art_dir, "RHAIRFE-3082", extra_fm="local_id: RFE-001\n")
+
+        report = build_report(["RHAIRFE-3082"], "2026-08-21T12:00:00Z")
+        entry = report["per_rfe"][0]
+
+        assert entry["tracker_ref"] == "RHAIRFE-3082"
+        assert entry["role"] == "leaf"
+        assert entry["local_id"] == "RFE-001"
+
+    def test_unsubmitted_local_entry_is_a_leaf_without_a_ticket(self, art_dir):
+        """Mode 1 shape: a Draft child whose split was refused."""
+        self._task(art_dir, "RFE-001", status="Draft", parent="RHAIRFE-1000")
+        self._review(art_dir, "RFE-001")
+        self._task(art_dir, "RHAIRFE-1000", status="Archived")
+        self._review(art_dir, "RHAIRFE-1000")
+
+        report = build_report(["RHAIRFE-1000"], "2026-08-21T12:00:00Z")
+        by_id = {e["id"]: e for e in report["per_rfe"]}
+
+        assert by_id["RFE-001"]["tracker_ref"] is None
+        assert by_id["RFE-001"]["role"] == "leaf"
+        assert "local_id" not in by_id["RFE-001"]
+
+    def test_archived_local_node_is_an_intermediary(self, art_dir):
+        """Mode 2: re-split stepping stone — never was and never will be a ticket."""
+        self._task(art_dir, "RHAIRFE-1000", status="Archived")
+        self._review(art_dir, "RHAIRFE-1000")
+        self._task(art_dir, "RFE-004", status="Archived", parent="RHAIRFE-1000")
+        self._review(art_dir, "RFE-004")
+        self._task(art_dir, "RFE-007", status="Ready", parent="RFE-004")
+        self._review(art_dir, "RFE-007")
+
+        report = build_report(["RHAIRFE-1000"], "2026-08-21T12:00:00Z")
+        by_id = {e["id"]: e for e in report["per_rfe"]}
+
+        assert by_id["RFE-004"]["role"] == "intermediary"
+        assert by_id["RFE-004"]["tracker_ref"] is None
+
+    def test_archived_jira_parent_is_not_an_intermediary(self, art_dir):
+        """The real split parent is also Archived — but it IS a ticket.
+
+        Classifying on Archived alone would mislabel exactly the row consumers
+        care about most; the rule requires a local id as well.
+        """
+        self._task(art_dir, "RHAIRFE-1000", status="Archived")
+        self._review(art_dir, "RHAIRFE-1000")
+
+        report = build_report(["RHAIRFE-1000"], "2026-08-21T12:00:00Z")
+        entry = report["per_rfe"][0]
+
+        assert entry["role"] == "leaf"
+        assert entry["tracker_ref"] == "RHAIRFE-1000"
+
+    def test_missing_task_file_omits_role(self, art_dir):
+        """Absent means not determined — never guessed."""
+        self._review(art_dir, "RHAIRFE-1234")
+
+        report = build_report(["RHAIRFE-1234"], "2026-08-21T12:00:00Z")
+        entry = report["per_rfe"][0]
+
+        assert "role" not in entry
+        assert entry["tracker_ref"] == "RHAIRFE-1234"
+
+
 class TestReportRootMetadata:
     """Root fields that let a consumer know what it is reading."""
 


### PR DESCRIPTION
Implements RHAIFIRST-564 — the last schema piece of RHAIFIRST-553. With this, the three failure modes are readable directly from any `report_stage: final` report:

| | `role` | `tracker_ref` | meaning |
|---|---|---|---|
| structural intermediary | `intermediary` | `null` | re-split stepping stone — flatten away |
| blocked leaf | `leaf` | `null` | no ticket exists; `blocked_reason` says why |
| submitted | `leaf` | the Jira key | real ticket |

## The three fields, all additive (`report_schema_version` stays 1; absent = not determined)

**`tracker_ref`** — the canonical remote reference: the id once submitted, `null` while no ticket exists. Named per `work-item-types-unified.md` §5 (`tracker_ref`, deliberately not `key`/`jira_key` — see RHAIFIRST-553's compatibility section). Also emitted on **error entries**: it derives from the id alone, and without it those were the only rows a consumer would still have to prefix-sniff.

**`role: leaf | intermediary`** — an archived *local-id* node is a re-split stepping stone that `split_submit._collect_leaves` walks past by design. The local-id half of the rule is load-bearing: the real split parent is **also** `Archived` but *is* a ticket, and classifying on `Archived` alone would mislabel exactly the row consumers care about most (there's a dedicated negative test for it).

**`local_id`** — the pre-submission id. `rename_to_jira_key` overwrites `rfe_id` with the Jira key, so until now the `RFE-001 → RHAIRFE-3082` mapping survived *only* as a git rename in the results repo's history — unreadable from any single commit. Both rename functions now persist it into task and review frontmatter (all four schemas gain the optional field, `parent_key`-style: pattern-validated, default `null`), and the report copies it through when it differs from the entry id.

## Verification

- 833 tests pass; ruff clean. New: 5 report-classification tests (including the Archived-Jira-parent negative and missing-task-file → role omitted) and 4 rename-persistence tests (including that renamed files still validate, so later `update_frontmatter` calls don't start raising).
- **Corpus backfill over all 286 published run directories** in `rfe-autofixer-results`, ground truth keyed by task frontmatter: **225/225** archived-local nodes classify `intermediary` (225 is the full population; the 214 previously cited was the has-children subset), zero Jira-keyed entries misclassified, every entry carries `tracker_ref` with the correct value.
- Mutation-tested: dropping the local-id half of the role rule, hardwiring `tracker_ref` to the id, and forgetting `local_id` at rename each fail exactly their own test.
- Also hardened in passing: a review file with empty/non-mapping frontmatter now becomes a proper error entry instead of an `AttributeError` (found via a real corpus file, `20260727-031043/RHAIRFE-2911-review.md`).

RHAIFIRST-564, part of RHAIFIRST-553.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserved original local IDs when RFE and initiative tasks or reviews are renamed with tracker keys.
  * Added tracker references and local ID provenance to run reports.
  * Improved report classification for submitted, unsubmitted, archived, and intermediary entries.

* **Bug Fixes**
  * Prevented tracker keys and malformed IDs from being used as local IDs.
  * Improved handling of missing or invalid artifact metadata in reports.
  * Excluded invalid scores from report averages and prevented malformed data from interrupting report generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->