### PR TITLE
Route ERROR_COLLECT to REPORT when nothing is retryable

### DIFF
--- a/scripts/error_collect.py
+++ b/scripts/error_collect.py
@@ -88,12 +88,34 @@ def main():
         capture_output=True,
         text=True,
     )
+    # A crashed or garbled collector must fail this phase loudly, not parse
+    # to an empty list — empty means "nothing to retry", which sends the
+    # pipeline to REPORT as if collection succeeded. Leave the retry file
+    # untouched so a later re-run of this phase starts from honest state.
+    if result.returncode != 0:
+        print(
+            f"ERROR_COLLECT: collect_recommendations failed "
+            f"(exit {result.returncode}): {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     error_ids = []
+    saw_marker = False
     for line in result.stdout.splitlines():
         if line.startswith("ERRORS="):
+            saw_marker = True
             val = line.split("=", 1)[1].strip()
             if val:
                 error_ids = [x.strip() for x in val.split(",") if x.strip()]
+    if not saw_marker:
+        print(
+            "ERROR_COLLECT: collect_recommendations output has no ERRORS= line "
+            f"— refusing to treat that as zero errors. stdout: {result.stdout.strip()[:200]}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     if not error_ids:
         # Clear the retry file rather than leaving whatever a previous cycle
         # wrote — the ERROR_COLLECT transition reads it to decide between a

--- a/scripts/error_collect.py
+++ b/scripts/error_collect.py
@@ -95,6 +95,11 @@ def main():
             if val:
                 error_ids = [x.strip() for x in val.split(",") if x.strip()]
     if not error_ids:
+        # Clear the retry file rather than leaving whatever a previous cycle
+        # wrote — the ERROR_COLLECT transition reads it to decide between a
+        # retry batch and going straight to REPORT, and a stale non-empty
+        # file would start a retry for IDs that are no longer erroring.
+        _write_ids(RETRY_IDS_FILE, [])
         print("ERROR_COLLECT: no error IDs found")
         return
 

--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -713,10 +713,18 @@ def advance(state, dry_run=False):
                     )
         return "REPORT", f"{summary}\nBATCH_DONE → REPORT"
 
-    # --- ERROR_COLLECT → BATCH_START ---
+    # --- ERROR_COLLECT → BATCH_START (or REPORT when nothing is retryable) ---
     if phase == "ERROR_COLLECT":
         retry_ids = _read_ids("tmp/pipeline-retry-ids.txt")
         n = len(retry_ids)
+        if n == 0:
+            # BATCH_DONE routed here on error-classified reviews, but
+            # error_collect.py found none worth retrying (the two checks can
+            # disagree — reviews change under them). Starting a retry batch
+            # with no IDs dead-ends the machine at a batch file that does not
+            # exist, and the run's report never gets generated. Observed in
+            # production 2026-08-24 (RHAIFIRST-581).
+            return ("REPORT", "ERROR_COLLECT: no retryable errors\nERROR_COLLECT → REPORT")
         batch = state.get("total_batches", 0)
         return (
             "BATCH_START",

--- a/tests/test_error_collect.py
+++ b/tests/test_error_collect.py
@@ -110,6 +110,50 @@ def _rfe_task(workspace, item_id, **extra):
     )
 
 
+class TestCollectorFailureIsLoud:
+    """A crashed collector must fail the phase, not report zero errors.
+
+    Unchecked, a nonzero exit parses to an empty error list, which clears the
+    retry file and routes ERROR_COLLECT to REPORT — a collection failure
+    masquerading as a clean completion. The retry file must stay untouched so
+    a re-run of the phase starts from honest state."""
+
+    def _shadow_collector(self, workspace, body):
+        """Replace the scripts/ symlink with a dir of per-file links, then
+        shadow collect_recommendations.py with a stub."""
+        scripts_link = workspace / "scripts"
+        os.remove(scripts_link)
+        os.makedirs(scripts_link)
+        for name in os.listdir(SCRIPTS_DIR):
+            if name == "collect_recommendations.py":
+                continue
+            os.symlink(os.path.join(SCRIPTS_DIR, name), scripts_link / name)
+        with open(scripts_link / "collect_recommendations.py", "w") as f:
+            f.write(body)
+
+    def test_collector_crash_exits_nonzero_and_keeps_retry_file(self, workspace):
+        self._shadow_collector(workspace, "import sys\nsys.stderr.write('boom')\nsys.exit(2)\n")
+        _set_ids(workspace, "RHAIRFE-1")
+        _write_raw(str(workspace / "tmp" / "pipeline-retry-ids.txt"), "RHAIRFE-999\n")
+
+        _, stderr, rc = _run(workspace)
+
+        assert rc == 1
+        assert "collect_recommendations failed" in stderr
+        with open(workspace / "tmp" / "pipeline-retry-ids.txt") as f:
+            assert f.read().strip() == "RHAIRFE-999"
+
+    def test_missing_errors_marker_is_a_failure_too(self, workspace):
+        """Exit 0 with garbled stdout must not parse to 'zero errors'."""
+        self._shadow_collector(workspace, "print('SOMETHING ELSE ENTIRELY')\n")
+        _set_ids(workspace, "RHAIRFE-1")
+
+        _, stderr, rc = _run(workspace)
+
+        assert rc == 1
+        assert "no ERRORS= line" in stderr
+
+
 class TestNoErrorsClearsRetryFile:
     """The early return must not leave a stale retry file behind.
 

--- a/tests/test_error_collect.py
+++ b/tests/test_error_collect.py
@@ -110,6 +110,28 @@ def _rfe_task(workspace, item_id, **extra):
     )
 
 
+class TestNoErrorsClearsRetryFile:
+    """The early return must not leave a stale retry file behind.
+
+    The ERROR_COLLECT transition reads tmp/pipeline-retry-ids.txt to choose
+    between a retry batch and REPORT; a leftover non-empty file from an
+    earlier cycle would start a retry for IDs that are no longer erroring
+    (RHAIFIRST-581)."""
+
+    def test_stale_retry_ids_cleared_when_nothing_errors(self, workspace):
+        _rfe_task(workspace, "RHAIRFE-1")
+        _write_review(workspace, "rfe-reviews", "RHAIRFE-1", "rfe_id", None)
+        _set_ids(workspace, "RHAIRFE-1")
+        _write_raw(str(workspace / "tmp" / "pipeline-retry-ids.txt"), "RHAIRFE-999\n")
+
+        stdout, stderr, rc = _run(workspace)
+
+        assert rc == 0, stderr
+        assert "no error IDs found" in stdout
+        with open(workspace / "tmp" / "pipeline-retry-ids.txt") as f:
+            assert f.read().strip() == ""
+
+
 class TestSplitErrorCleanup:
     """The --type must reach cleanup_partial_split, or children are orphaned."""
 

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -521,6 +521,43 @@ class TestSplitCollect:
 # ---------- BATCH_DONE ----------
 
 
+class TestErrorCollectAdvance:
+    """ERROR_COLLECT with nothing retryable must terminate through REPORT.
+
+    BATCH_DONE routes here on error-classified reviews, but error_collect.py
+    re-checks and can find none worth retrying. The old unconditional
+    transition started a retry batch whose IDs file does not exist,
+    dead-ending the machine and skipping REPORT — the orchestrator had to
+    improvise `set-phase DONE` (production, 2026-08-24, RHAIFIRST-581).
+    """
+
+    def test_zero_retry_ids_goes_to_report(self, tmp_dir):
+        write_ids("tmp/pipeline-retry-ids.txt", [])
+        state = make_state(phase="ERROR_COLLECT", batch=1, total_batches=1, retry_cycle=1)
+
+        next_phase, msg = ps.advance(state)
+
+        assert next_phase == "REPORT"
+        assert "no retryable errors" in msg
+
+    def test_missing_retry_file_goes_to_report(self, tmp_dir):
+        """error_collect.py's early return historically wrote nothing at all."""
+        state = make_state(phase="ERROR_COLLECT", batch=1, total_batches=1, retry_cycle=1)
+
+        next_phase, _ = ps.advance(state)
+
+        assert next_phase == "REPORT"
+
+    def test_retry_ids_still_start_the_retry_batch(self, tmp_dir):
+        write_ids("tmp/pipeline-retry-ids.txt", ["RHAIRFE-1", "RHAIRFE-2"])
+        state = make_state(phase="ERROR_COLLECT", batch=1, total_batches=2, retry_cycle=1)
+
+        next_phase, msg = ps.advance(state)
+
+        assert next_phase == "BATCH_START"
+        assert "2 error IDs" in msg
+
+
 class TestBatchDone:
     def test_more_batches(self, tmp_dir, monkeypatch):
         write_ids("tmp/pipeline-active-ids.txt", ["A"])


### PR DESCRIPTION
Fixes RHAIFIRST-581, observed in production run `20260824-031043` (2026-08-24).

## The dead end

`BATCH_DONE` routes to `ERROR_COLLECT` when `collect_recommendations --errors` finds error-classified reviews. `error_collect.py` then re-checks — and the two can disagree, because reviews change under them. When it finds **zero** retryable IDs it early-returns without writing the retry-ids file or a batch file. The `ERROR_COLLECT → BATCH_START` transition was **unconditional**, so the machine started a retry batch whose IDs file does not exist and dead-ended.

In production the orchestrating agent improvised its way out — `set-phase DONE` directly, from the trace: *"Since there are no error IDs to retry and only 1 batch, I need to force the pipeline to DONE."* That skipped the REPORT phase entirely (no pre-submit report; the CI job's first push logged `No run report YAML found`). The run stayed healthy only because #159's `_finish()` regenerated the report post-submit — a backstop, not a path to rely on: this is the "orchestrator-improvised" family from the RHAIFIRST-306 post-mortem, and a text-only-stop risk on every occurrence.

The defect is not new: the unconditional transition dates to 2026-04-08/09 (`664a0ad`/`4e82265`) and was live on the old ci-prod too. The new report/push observability is what made the 08-24 occurrence detectable.

## The fix, both halves

- **`pipeline_state.py`**: `ERROR_COLLECT` with zero retry IDs transitions to `REPORT` — the same terminal a completed retry cycle reaches through `BATCH_DONE`. (`error_collect.py` sets `retry_cycle=1` before anything else, so no loop is possible.)
- **`error_collect.py`**: the early return now **clears** `tmp/pipeline-retry-ids.txt` instead of leaving whatever a previous cycle wrote — without this, a stale non-empty file would send the transition into a retry for IDs that are no longer erroring, which is the mirror-image bug.

## Verification

828 tests pass, ruff clean. Four new tests: zero-ids → REPORT, missing-file → REPORT (the historical shape), non-empty ids still → BATCH_START, and stale-file-cleared-on-early-return. Mutation-checked: reverting the transition fails its two tests, removing the clear fails its one — each independently.

RHAIFIRST-581, part of RHAIFIRST-553.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale retry items from triggering unnecessary retry batches when no current errors are found.
  * Updated processing to move directly to reporting when there are no retryable errors.
  * Preserved retry-batch handling when retryable errors are present.

* **Tests**
  * Added coverage for empty, missing, and populated retry-item scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->