### PR TITLE
Scope architecture-review overlays by release and component

### DIFF
--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -26,9 +26,16 @@ Architecture review skipped — no architecture context available.
 
 ## Architecture Context Overlays
 
-Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` in full and keep the ones with `status: active` in their frontmatter — this skill filters on status alone, so a frontmatter-only pre-pass saves nothing, and the correction lives in the body's `## Fact` and `## Impact on Strategies` sections anyway. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
+Check for overlay files with the Glob tool: `.context/architecture-context/overlays/*.md`. Read each match except `README.md` and keep the ones with `status: active` in their frontmatter. Frontmatter can run to 40 lines and keeps growing, so pass `limit: 60` to Read for this filtering pass rather than loading whole files. Use Glob and Read for this, never a Bash glob or `for` loop — shell globs and loops are not on the headless Bash allowlist, so a loop costs a denied turn and then falls back to Read anyway. These overlays are human-authored corrections to the generated architecture docs — version bumps, maturity changes, dependency shifts.
 
-When reviewing a strategy's architecture claims, check whether any active overlay corrects or updates the information the strategy references. If a strategy uses outdated information that an overlay corrects (e.g., references KFP SDK 2.15 when an overlay says 2.16), flag it as a finding. Overlays take precedence over the generated architecture docs when they conflict.
+Filter for relevant overlays:
+1. **Status**: `status` must be `active` (ignore `superseded`)
+2. **Release**: `release` list must contain the target RHOAI release or `"all"`
+3. **Component match**: `affects` list must intersect with the components the strategy touches. Overlays with `affects: [platform]` match all strategies.
+
+For each matched overlay, read its `## Fact` and `## Impact on Strategies` sections. Use these to correct or supplement the architecture docs when reviewing architecture claims. Overlays take precedence over the generated architecture docs when they conflict.
+
+When reviewing a strategy's architecture claims, check whether any matched overlay corrects or updates the information the strategy references. If a strategy uses outdated information that an overlay corrects (e.g., references KFP SDK 2.15 when an overlay says 2.16), flag it as a finding.
 
 When overlays are applied, print which ones were used:
 
@@ -36,6 +43,8 @@ When overlays are applied, print which ones were used:
 Overlays applied:
 - 0001: KFP SDK updated to 2.16 in RHOAI 3.4
 ```
+
+If no overlays directory exists or no overlays match, proceed without them.
 
 ## What to Assess
 


### PR DESCRIPTION
## Description

Follow-up to #152, addressing the CodeRabbit finding on it (`architecture-review/SKILL.md:29`, [thread](https://github.com/opendatahub-io/rfe-creator/pull/152#discussion_r3843457475)): architecture-review applied every `status: active` overlay, while the three sibling skills (feasibility-review, rfe-feasibility-review, initiative-feasibility-review) also require the `release` list to contain the target RHOAI release and the `affects` list to intersect the components touched. The gap is pre-existing — it dates to the section's introduction (972dc1c), not to #152 — but an active overlay scoped to another release or an unrelated component could override the facts this review grounds its findings in and produce a false architecture finding.

The fix ports feasibility-review's filter block verbatim (it is already strategy-flavored: "components the strategy touches", "`affects: [platform]` match all strategies"), plus its matched-overlay body read and no-match fallback. Two things make this the right moment:

- #152 made architecture-review read `LATEST_VERSION`, so the target release is now available to filter on.
- With a real three-criterion filter, the frontmatter pre-pass (`limit: 60`) pays for itself again — #152 had dropped it here because a status-only filter kept everything (all 20 current overlays are active), making the pre-pass a pure double-read. Restored, all four overlay-carrying skills now share the same structure: filter cheap, then read matched bodies.

Behavior change: overlays for other releases or unrelated components are no longer applied by this review. Duplicate "overlays take precedence" sentence consolidated into the matched-overlay paragraph.

## How Has This Been Tested?

`uv run pytest tests/` — 757 passed. `skillsaw .claude/skills` — 0 errors, 0 warnings. Prose-only change; no Python touched. CodeRabbit verified the diff against its original finding and withdrew it from #152 in favor of this PR.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Architecture reviews now focus on relevant, active overlays for the selected release and components.
  * Reviews can proceed even when no overlay directory or matching overlays are available.
  * Applicable overlay guidance is prioritized when evaluating potentially outdated claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->