### PR TITLE
Move skill under execution and declare judge score ranges in eval configs

### DIFF
--- a/eval-initiative.yaml
+++ b/eval-initiative.yaml
@@ -462,11 +462,6 @@ judges:
   - name: pairwise
     description: Blind A/B comparison of Initiative pipeline output quality across runs
     prompt_file: eval/config/initiative-pairwise-judge.md
-    # The pairwise judge returns A/B/tie verdicts, not a numeric score —
-    # score.py routes it past the numeric path by name, so this range is
-    # never enforced. Declared only to satisfy the loader's numeric-judge
-    # check, which cannot know that.
-    score_range: [1, 5]
 
 thresholds:
   files_exist:

--- a/eval-initiative.yaml
+++ b/eval-initiative.yaml
@@ -1,10 +1,10 @@
 name: initiative-speedrun
 description: End-to-end Initiative pipeline — create, review, auto-fix, split, and submit Initiatives
-skill: initiative-speedrun
 
 # Execution — how the skill processes test cases (runner-agnostic)
 execution:
   mode: batch
+  skill: initiative-speedrun
   arguments: --headless --dry-run --input batch.yaml
   timeout: 8100          # 2 hours 15 minutes
   max_budget_usd: 100.0  # Per-invocation cost cap
@@ -355,6 +355,7 @@ judges:
     description: |
       Assess the quality of produced Initiative task files against the
       rubric criteria and whether the pipeline's own scores are well-calibrated.
+    score_range: [1, 5]
     prompt: |
       You are an independent evaluator assessing the quality of an automated
       Initiative creation pipeline.
@@ -400,6 +401,7 @@ judges:
     description: |
       Assess whether auto-revisions improved the Initiative without losing content.
       Compares original (artifacts/initiative-originals/) vs revised (artifacts/initiatives/).
+    score_range: [1, 5]
     prompt: |
       You are an independent evaluator assessing the quality of automated
       Initiative revisions. The pipeline may have auto-revised some Initiatives
@@ -460,6 +462,11 @@ judges:
   - name: pairwise
     description: Blind A/B comparison of Initiative pipeline output quality across runs
     prompt_file: eval/config/initiative-pairwise-judge.md
+    # The pairwise judge returns A/B/tie verdicts, not a numeric score —
+    # score.py routes it past the numeric path by name, so this range is
+    # never enforced. Declared only to satisfy the loader's numeric-judge
+    # check, which cannot know that.
+    score_range: [1, 5]
 
 thresholds:
   files_exist:

--- a/eval.yaml
+++ b/eval.yaml
@@ -436,11 +436,6 @@ judges:
   - name: pairwise
     description: Blind A/B comparison of RFE pipeline output quality across runs
     prompt_file: eval/config/pairwise-judge.md
-    # The pairwise judge returns A/B/tie verdicts, not a numeric score —
-    # score.py routes it past the numeric path by name, so this range is
-    # never enforced. Declared only to satisfy the loader's numeric-judge
-    # check, which cannot know that.
-    score_range: [1, 5]
 
 thresholds:
   files_exist:

--- a/eval.yaml
+++ b/eval.yaml
@@ -1,10 +1,10 @@
 name: rfe-speedrun
 description: End-to-end RFE pipeline — create, review, auto-fix, split, and submit RFEs
-skill: rfe.speedrun
 
 # Execution — how the skill processes test cases (runner-agnostic)
 execution:
   mode: batch
+  skill: rfe.speedrun
   arguments: --headless --dry-run --input batch.yaml
   timeout: 7200          # 2 hours — opus with 20 cases + splits needs ~60 min
   max_budget_usd: 100.0  # Per-invocation cost cap
@@ -350,6 +350,7 @@ judges:
     description: |
       Assess the quality of produced RFE task files against the 5 rubric
       criteria and whether the pipeline's own scores are well-calibrated.
+    score_range: [1, 5]
     prompt: |
       You are an independent evaluator assessing the quality of an automated
       RFE (Request for Enhancement) creation pipeline.
@@ -384,6 +385,7 @@ judges:
     description: |
       Assess whether auto-revisions improved the RFE without losing content.
       Compares original (artifacts/rfe-originals/) vs revised (artifacts/rfe-tasks/).
+    score_range: [1, 5]
     prompt: |
       You are an independent evaluator assessing the quality of automated
       RFE revisions. The pipeline may have auto-revised some RFEs to improve
@@ -434,6 +436,11 @@ judges:
   - name: pairwise
     description: Blind A/B comparison of RFE pipeline output quality across runs
     prompt_file: eval/config/pairwise-judge.md
+    # The pairwise judge returns A/B/tie verdicts, not a numeric score —
+    # score.py routes it past the numeric path by name, so this range is
+    # never enforced. Declared only to satisfy the loader's numeric-judge
+    # check, which cannot know that.
+    score_range: [1, 5]
 
 thresholds:
   files_exist:


### PR DESCRIPTION
Every load of `eval.yaml` / `eval-initiative.yaml` by the eval harness emits four warnings:

```
DeprecationWarning: Top-level 'skill:' in eval.yaml is deprecated; move it under execution.skill
UserWarning: Judge 'rfe_quality': numeric judge has no 'score_range', so it is scored on the unenforced [1, 5] default
UserWarning: Judge 'revision_quality': numeric judge has no 'score_range', ...
```

(`eval-initiative.yaml` emits the same set with `initiative_quality` in place of `rfe_quality`.)

## Changes

- **`skill:` moved under `execution:`** in both configs. The loader already auto-normalized the top-level form, so behavior is identical — this just adopts the canonical home before the fallback is removed.
- **`score_range: [1, 5]` declared on the true numeric judges** (`rfe_quality`, `initiative_quality`, `revision_quality`). Their prompts already say "score 1-5"; the declaration matches. One behavioral effect, and it is the point of the warning: a declared range is *enforced*, so a judge returning e.g. 7 is now rejected instead of silently accepted onto the unenforced default scale.

## Verification

Loaded both configs through `agent_eval.config.EvalConfig.from_yaml` with all warnings captured: 4 warnings per file on `main`; with this change, 0 per file against a harness carrying opendatahub-io/agent-eval-harness#202, and only the residual `pairwise` false positive against a pre-#202 harness. `execution.skill` resolves to `rfe.speedrun` / `initiative-speedrun` as before, and the declared ranges parse as `[1.0, 5.0]`.
