### PR TITLE
Judge architecture grounding from subagent transcripts, not prose

### DIFF
--- a/eval-initiative.yaml
+++ b/eval-initiative.yaml
@@ -317,15 +317,20 @@ judges:
 
   - name: architecture_context_used
     description: |
-      Verify that every feasibility review used architecture context.
+      Verify that every feasibility review was grounded in architecture
+      context. Primary evidence is behavioral: the subagent transcript that
+      wrote each feasibility file must show a successful Read/Grep/Glob of
+      .context/architecture-context — unless the review declares the
+      context not relevant, which Initiatives may legitimately do. Prose
+      matching is only a fallback for runs without transcript capture.
     check: |
-      import re
+      import glob, json, os, re
       files = outputs.get("files", {})
       feasibility = {k: v for k, v in files.items()
                      if k.endswith("-feasibility.md")}
       if not feasibility:
           return (False, "No feasibility files found")
-      errors = []
+      docs_dir = re.compile(r"\.context/architecture-context(?![\w.\-])")
       no_ctx_pattern = re.compile(
           r'architecture context was not available|no architecture context was available',
           re.IGNORECASE
@@ -334,16 +339,75 @@ judges:
           r'architecture context (was |is )?(not |un)relevant|no relevant architecture context|outside the scope of.*architecture context',
           re.IGNORECASE
       )
-      used = 0
+      run_dir = os.path.dirname(os.path.dirname(outputs.get("case_dir") or ""))
+      transcripts = sorted(glob.glob(os.path.join(run_dir, "subagents", "*.jsonl")))
+      basenames = {os.path.basename(f): f for f in feasibility}
+      # writer_hits[basename] = doc reads of the transcript(s) that wrote it
+      writer_hits = {}
+      for path in transcripts:
+          try:
+              with open(path, encoding="utf-8", errors="replace") as fh:
+                  raw = fh.read()
+          except OSError:
+              continue
+          mentioned = [b for b in basenames if b in raw]
+          if not mentioned:
+              continue
+          wrote = set()
+          hits = 0
+          pending = {}
+          for line in raw.splitlines():
+              try:
+                  ev = json.loads(line)
+              except ValueError:
+                  continue
+              msg = ev.get("message") if isinstance(ev, dict) else None
+              if not isinstance(msg, dict):
+                  continue
+              for b in msg.get("content") or []:
+                  if not isinstance(b, dict):
+                      continue
+                  if b.get("type") == "tool_use":
+                      tool_input = str(b.get("input", {}))
+                      if b.get("name") in ("Write", "Edit"):
+                          for base in mentioned:
+                              if base in tool_input:
+                                  wrote.add(base)
+                      if (b.get("name") in ("Read", "Grep", "Glob")
+                              and docs_dir.search(tool_input)):
+                          pending[b.get("id")] = True
+                  elif (b.get("type") == "tool_result"
+                          and b.get("tool_use_id") in pending):
+                      pending.pop(b.get("tool_use_id"))
+                      if b.get("is_error"):
+                          continue
+                      content = b.get("content")
+                      text = content if isinstance(content, str) else json.dumps(content)
+                      if len(text) >= 200:
+                          hits += 1
+          for base in wrote:
+              writer_hits[base] = max(writer_hits.get(base, 0), hits)
+      errors = []
+      evidenced = 0
       not_relevant = 0
       for fname, content in sorted(feasibility.items()):
-          if no_ctx_pattern.search(content) and not not_relevant_pattern.search(content):
-              errors.append(f"{fname}: architecture context not used")
-          elif not_relevant_pattern.search(content):
+          base = os.path.basename(fname)
+          declared_irrelevant = bool(not_relevant_pattern.search(content))
+          if base in writer_hits:
+              if writer_hits[base] > 0:
+                  evidenced += 1
+              elif declared_irrelevant:
+                  not_relevant += 1
+              else:
+                  errors.append(f"{fname}: writer subagent never read "
+                                ".context/architecture-context")
+          elif declared_irrelevant:
               not_relevant += 1
+          elif no_ctx_pattern.search(content):
+              errors.append(f"{fname}: architecture context not used")
           else:
-              used += 1
-      msg = f"{used} used architecture context"
+              evidenced += 1
+      msg = f"{evidenced} grounded"
       if not_relevant:
           msg += f", {not_relevant} not relevant (ok)"
       return (len(errors) == 0,

--- a/eval-initiative.yaml
+++ b/eval-initiative.yaml
@@ -339,8 +339,16 @@ judges:
           r'architecture context (was |is )?(not |un)relevant|no relevant architecture context|outside the scope of.*architecture context',
           re.IGNORECASE
       )
-      run_dir = os.path.dirname(os.path.dirname(outputs.get("case_dir") or ""))
-      transcripts = sorted(glob.glob(os.path.join(run_dir, "subagents", "*.jsonl")))
+      # Transcripts live at the run root in batch mode; per-case mode and
+      # batch runs with traces.events route (copies of) them into
+      # cases/<id>/subagents/. Search both, dedupe by filename (routing
+      # copies, so the same transcript can appear in both places).
+      case_dir = outputs.get("case_dir") or ""
+      run_dir = os.path.dirname(os.path.dirname(case_dir))
+      transcripts = list({os.path.basename(p): p for p in sorted(
+          glob.glob(os.path.join(case_dir, "subagents", "*.jsonl"))
+          + glob.glob(os.path.join(run_dir, "subagents", "*.jsonl"))
+      )}.values())
       basenames = {os.path.basename(f): f for f in feasibility}
       # writer_hits[basename] = doc reads of the transcript(s) that wrote it
       writer_hits = {}
@@ -389,6 +397,7 @@ judges:
               writer_hits[base] = max(writer_hits.get(base, 0), hits)
       errors = []
       evidenced = 0
+      assumed = 0
       not_relevant = 0
       for fname, content in sorted(feasibility.items()):
           base = os.path.basename(fname)
@@ -406,8 +415,10 @@ judges:
           elif no_ctx_pattern.search(content):
               errors.append(f"{fname}: architecture context not used")
           else:
-              evidenced += 1
-      msg = f"{evidenced} grounded"
+              assumed += 1
+      msg = f"{evidenced} grounded via transcript evidence"
+      if assumed:
+          msg += f", {assumed} assumed via prose fallback (no transcript)"
       if not_relevant:
           msg += f", {not_relevant} not relevant (ok)"
       return (len(errors) == 0,

--- a/eval.yaml
+++ b/eval.yaml
@@ -342,8 +342,16 @@ judges:
           r'architecture context was not available|no architecture context was available',
           re.IGNORECASE
       )
-      run_dir = os.path.dirname(os.path.dirname(outputs.get("case_dir") or ""))
-      transcripts = sorted(glob.glob(os.path.join(run_dir, "subagents", "*.jsonl")))
+      # Transcripts live at the run root in batch mode; per-case mode and
+      # batch runs with traces.events route (copies of) them into
+      # cases/<id>/subagents/. Search both, dedupe by filename (routing
+      # copies, so the same transcript can appear in both places).
+      case_dir = outputs.get("case_dir") or ""
+      run_dir = os.path.dirname(os.path.dirname(case_dir))
+      transcripts = list({os.path.basename(p): p for p in sorted(
+          glob.glob(os.path.join(case_dir, "subagents", "*.jsonl"))
+          + glob.glob(os.path.join(run_dir, "subagents", "*.jsonl"))
+      )}.values())
       basenames = {os.path.basename(f): f for f in feasibility}
       # writer_hits[basename] = doc reads of the transcript(s) that wrote it
       writer_hits = {}
@@ -392,6 +400,7 @@ judges:
               writer_hits[base] = max(writer_hits.get(base, 0), hits)
       errors = []
       evidenced = 0
+      assumed = 0
       for fname, content in sorted(feasibility.items()):
           base = os.path.basename(fname)
           if base in writer_hits:
@@ -402,10 +411,12 @@ judges:
                                 ".context/architecture-context")
           elif no_ctx_pattern.search(content):
               errors.append(f"{fname}: architecture context not used")
-      return (len(errors) == 0,
-              "; ".join(errors) if errors
-              else f"{len(feasibility)} feasibility reviews grounded "
-                   f"({evidenced} via transcript evidence)")
+          else:
+              assumed += 1
+      msg = f"{evidenced} grounded via transcript evidence"
+      if assumed:
+          msg += f", {assumed} assumed via prose fallback (no transcript)"
+      return (len(errors) == 0, "; ".join(errors) if errors else msg)
 
   # --- LLM judges ---
 

--- a/eval.yaml
+++ b/eval.yaml
@@ -322,27 +322,90 @@ judges:
 
   - name: architecture_context_used
     description: |
-      Verify that every feasibility review used architecture context.
-      The LATEST_VERSION file and PLATFORM.md must have been read,
-      and no feasibility file should contain "architecture context was
-      not available".
+      Verify that every feasibility review was grounded in architecture
+      context. Primary evidence is behavioral: the subagent transcript that
+      wrote each feasibility file must show a successful Read/Grep/Glob of
+      .context/architecture-context. Prose matching ("architecture context
+      was not available") is only a fallback for runs without transcript
+      capture — it both false-positives (an agent borrowing the phrase for
+      an unrelated note, e.g. a missing comments file) and false-negatives
+      (an agent that silently skipped the docs).
     check: |
-      import re
+      import glob, json, os, re
       files = outputs.get("files", {})
       feasibility = {k: v for k, v in files.items()
                      if k.endswith("-feasibility.md")}
       if not feasibility:
           return (False, "No feasibility files found")
-      errors = []
+      docs_dir = re.compile(r"\.context/architecture-context(?![\w.\-])")
       no_ctx_pattern = re.compile(
           r'architecture context was not available|no architecture context was available',
           re.IGNORECASE
       )
+      run_dir = os.path.dirname(os.path.dirname(outputs.get("case_dir") or ""))
+      transcripts = sorted(glob.glob(os.path.join(run_dir, "subagents", "*.jsonl")))
+      basenames = {os.path.basename(f): f for f in feasibility}
+      # writer_hits[basename] = doc reads of the transcript(s) that wrote it
+      writer_hits = {}
+      for path in transcripts:
+          try:
+              with open(path, encoding="utf-8", errors="replace") as fh:
+                  raw = fh.read()
+          except OSError:
+              continue
+          mentioned = [b for b in basenames if b in raw]
+          if not mentioned:
+              continue
+          wrote = set()
+          hits = 0
+          pending = {}
+          for line in raw.splitlines():
+              try:
+                  ev = json.loads(line)
+              except ValueError:
+                  continue
+              msg = ev.get("message") if isinstance(ev, dict) else None
+              if not isinstance(msg, dict):
+                  continue
+              for b in msg.get("content") or []:
+                  if not isinstance(b, dict):
+                      continue
+                  if b.get("type") == "tool_use":
+                      tool_input = str(b.get("input", {}))
+                      if b.get("name") in ("Write", "Edit"):
+                          for base in mentioned:
+                              if base in tool_input:
+                                  wrote.add(base)
+                      if (b.get("name") in ("Read", "Grep", "Glob")
+                              and docs_dir.search(tool_input)):
+                          pending[b.get("id")] = True
+                  elif (b.get("type") == "tool_result"
+                          and b.get("tool_use_id") in pending):
+                      pending.pop(b.get("tool_use_id"))
+                      if b.get("is_error"):
+                          continue
+                      content = b.get("content")
+                      text = content if isinstance(content, str) else json.dumps(content)
+                      if len(text) >= 200:
+                          hits += 1
+          for base in wrote:
+              writer_hits[base] = max(writer_hits.get(base, 0), hits)
+      errors = []
+      evidenced = 0
       for fname, content in sorted(feasibility.items()):
-          if no_ctx_pattern.search(content):
+          base = os.path.basename(fname)
+          if base in writer_hits:
+              if writer_hits[base] > 0:
+                  evidenced += 1
+              else:
+                  errors.append(f"{fname}: writer subagent never read "
+                                ".context/architecture-context")
+          elif no_ctx_pattern.search(content):
               errors.append(f"{fname}: architecture context not used")
       return (len(errors) == 0,
-              "; ".join(errors) if errors else f"{len(feasibility)} feasibility reviews used architecture context")
+              "; ".join(errors) if errors
+              else f"{len(feasibility)} feasibility reviews grounded "
+                   f"({evidenced} via transcript evidence)")
 
   # --- LLM judges ---
 


### PR DESCRIPTION
## Problem

`architecture_context_used` failed today's full eval run ([PR #163 comment](https://github.com/opendatahub-io/rfe-creator/pull/163#issuecomment-5397471708), 19/20 vs a 1.0 threshold) on a false positive: case-018's feasibility review applied three overlays and cited component internals in depth, but also wrote

> Architecture context was not available for comments file (no comments file found).

— a benign note about a missing `-comments.md` companion (expected for a new RFE), phrased with the escape-hatch wording the check's regex hunts for. Prose matching is weak in both directions: it fails an agent that *says* the wrong sentence, and passes an agent that silently never opened the docs.

## Change

Following the upgrade strat-creator made to its judge of the same name ([eval.yaml](https://github.com/opendatahub-io/strat-creator/blob/main/eval/eval.yaml)), the check now judges **behavior instead of prose**: for each feasibility file, it locates the subagent transcript that wrote it (`subagents/*.jsonl`, captured by the harness) and requires at least one successful `Read`/`Grep`/`Glob` under `.context/architecture-context` (directory-boundary-anchored, ≥200 chars returned — both guards taken from strat-creator's calibration). The prose heuristic survives only as the fallback for runs without transcript capture, byte-for-byte unchanged, so local capture-less runs keep today's behavior.

The initiative variant gets the same upgrade and keeps its "not relevant (ok)" carve-out — an Initiative whose review legitimately declares architecture context irrelevant is not required to show doc reads.

Not adopted: strat-creator's native `agent:` judge (`architecture_score`). That is a grounded 0–2 *scorer* at ~$4/case — the right tool for validating architecture claims, but overkill for this binary did-it-read-the-docs gate, which the transcripts answer for free.

## Verification (replayed on the stored `2026-08-24-opus-4-6` run, 20 cases)

- New check: **20/20 pass, every case via transcript evidence** — case-018 passes because its writer transcript shows 8 successful architecture-context reads.
- Mutation 1 — docs pattern disabled: all 20 fail with "writer subagent never read", so the evidence path genuinely gates.
- Mutation 2 — transcripts removed: exactly case-018 fails via the prose fallback, reproducing today's behavior byte-for-byte.
- Both check bodies extracted from the YAML and exec'd through the harness's wrapper convention; both configs parse with `EvalConfig.from_yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved architecture-context validation by verifying evidence from feasibility reviews.
  * Reviews are now checked for meaningful use of available architecture information rather than relying solely on written claims.
  * Explicitly irrelevant reviews can be recognized and reported separately.
  * Added clearer reporting for reviews with missing or insufficient supporting evidence.
  * Retained compatibility with runs where detailed review activity is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->