### PR TITLE
Stop curl reading files, and the input reaching the shell

### DIFF
--- a/.github/workflows/rfe-creator-eval.yml
+++ b/.github/workflows/rfe-creator-eval.yml
@@ -47,8 +47,14 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
+          # Through env, not `${{ }}` in the script: a workflow_dispatch input is
+          # expanded into the shell before bash sees it, and `type: number` is a
+          # UI hint rather than a constraint the API enforces. The step below
+          # already reads its values this way.
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
-          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${{ inputs.pr_number }}")
+          PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
           echo "sha=$(echo "$PR_JSON" | jq -r '.head.sha')" >> "$GITHUB_OUTPUT"
           echo "ref=$(echo "$PR_JSON" | jq -r '.head.ref')" >> "$GITHUB_OUTPUT"
 
@@ -65,12 +71,12 @@ jobs:
         run: |
           curl --fail-with-body \
             --request POST \
-            --form "token=${GITLAB_TRIGGER_TOKEN}" \
-            --form "ref=main" \
-            --form "variables[GITHUB_PR_NUMBER]=${PR_NUMBER}" \
-            --form "variables[GITHUB_SHA]=${PR_SHA}" \
-            --form "variables[GITHUB_HEAD_REF]=${PR_REF}" \
-            --form "variables[GITHUB_REPO]=${REPO}" \
-            --form "variables[EVAL_CONFIG]=${EVAL_CONFIG}" \
-            --form "variables[QUICK_MODE]=${QUICK_MODE}" \
+            --form-string "token=${GITLAB_TRIGGER_TOKEN}" \
+            --form-string "ref=main" \
+            --form-string "variables[GITHUB_PR_NUMBER]=${PR_NUMBER}" \
+            --form-string "variables[GITHUB_SHA]=${PR_SHA}" \
+            --form-string "variables[GITHUB_HEAD_REF]=${PR_REF}" \
+            --form-string "variables[GITHUB_REPO]=${REPO}" \
+            --form-string "variables[EVAL_CONFIG]=${EVAL_CONFIG}" \
+            --form-string "variables[QUICK_MODE]=${QUICK_MODE}" \
             "${GITLAB_TRIGGER_URL}"


### PR DESCRIPTION
Ports two fixes found reviewing the same workflow in
opendatahub-io/strat-creator#57. That copy is a PR; this one is already on `main`.

## 1. `curl --form` can be made to upload a file

`--form` treats a value beginning with `@` as a local file to upload.
`variables[GITHUB_HEAD_REF]` carries the PR's branch name, which anyone who can
open a PR controls — and `@/etc/passwd` is a valid git branch name:

```
$ git check-ref-format --branch "@/etc/passwd"
@/etc/passwd
```

Only a bare `@` as the *whole* refname is disallowed, not as a path component. So
the runner can be made to send a local file to GitLab. Demonstrated with a local
listener:

```
--form        "variables[REF]=@victim.txt"  →  filename="victim.txt" + file contents
--form-string "control=@victim.txt"         →  the literal string
```

`--form-string` disables `@`, `<` and `;type=` parsing outright. Every field here
is a literal string, so all eight change, including `token=`.

## 2. The dispatch input reached the shell through `${{ }}`

`${{ inputs.pr_number }}` is expanded before bash runs, so `type: number` does not
constrain it — that is a UI hint, not something the dispatch API enforces. It goes
through `env` now, which is what the *next* step already did.

Worth being clear on severity: `workflow_dispatch` needs write access, so anyone
who could exploit this could also edit the workflow. It is cheap and it makes the
first step consistent with the second.

## Verification

YAML parses, no `${{ }}` remains inside any `run:` block, and the step env
resolves as intended. No behavior change to the trigger itself.
