### PR TITLE
feat(codex): add .codex-plugin/plugin.json for Codex support

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "rfe-creator",
+  "version": "0.1.0",
+  "description": "Skills for creating, reviewing, and submitting RFEs to the RHAIRFE Jira project. Provides an automated pipeline from initial creation through review, splitting, and submission, plus strategy refinement skills.",
+  "skills": "./.claude/skills/"
+}


### PR DESCRIPTION
## Summary

Adds a `.codex-plugin/plugin.json` manifest so this plugin's skills are discoverable when it is installed via **OpenAI Codex** (in addition to Claude Code).

Codex discovers a plugin's skills from its own manifest's `skills` path. Without this file, installing `rfe-creator` through the [opendatahub-io skills-registry](https://github.com/opendatahub-io/skills-registry) Codex marketplace loads **zero skills**. The manifest points at the existing `./.claude/skills/` directory, so nothing about the Claude Code setup changes.

It uses `.codex-plugin/` (not `.claude-plugin/plugin.json`) deliberately: Claude Code ignores `.codex-plugin/`, so this is safe for both harnesses and avoids the `strict: false` + `plugin.json` conflict.

```json
{
  "name": "rfe-creator",
  "version": "0.1.0",
  "description": "Skills for creating, reviewing, and submitting RFEs to the RHAIRFE Jira project. Provides an automated pipeline from initial creation through review, splitting, and submission, plus strategy refinement skills.",
  "skills": "./.claude/skills/"
}
```

### Related
- Codex marketplace support in the registry: opendatahub-io/skills-registry#112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `rfe-creator` plugin with initial version metadata.
  * Configured the plugin to use its RFE-focused skills directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->