### PR TITLE
Walk back past empty run reports, and surface unreviewed items

### DIFF
--- a/docs/snapshot-incremental-fetch.md
+++ b/docs/snapshot-incremental-fetch.md
@@ -390,6 +390,10 @@ The bootstrap snapshot accounts for:
   zero-count run), bootstrap walks back to the newest run that
   processed anything and reconstructs state as of that run — the
   empty run's newer timestamp would hide edits made between the two.
+  When every report in history is empty, bootstrap snapshots every
+  fetched issue marked unprocessed, without requiring `--include-all`:
+  the reports were read and state exactly that nothing was processed,
+  which is evidence, not absence.
   If no run report is found at all, all fetched issues are included
   as a fallback, marked unprocessed. A `report_stage: pre_submit`
   report is used but warned about: it predates that run's Jira

--- a/docs/snapshot-incremental-fetch.md
+++ b/docs/snapshot-incremental-fetch.md
@@ -382,10 +382,18 @@ has prior CI run history, before the first incremental fetch.
 
 The bootstrap snapshot accounts for:
 - **Run-report filtering**: Only issues listed in the latest run
-  report's `per_rfe` list are included in the snapshot. Issues that
-  were open but not processed by the previous run remain absent,
-  correctly surfacing as NEW on the first incremental fetch. If no
-  run report is found, all fetched issues are included as a fallback.
+  report's `per_rfe` list are included in the snapshot — excluding
+  error entries, which record that the run could NOT dispose of the
+  item. Issues that were open but not processed by the previous run
+  remain absent, correctly surfacing as NEW on the first incremental
+  fetch. If the latest report has an EMPTY item list (a legitimate
+  zero-count run), bootstrap walks back to the newest run that
+  processed anything and reconstructs state as of that run — the
+  empty run's newer timestamp would hide edits made between the two.
+  If no run report is found at all, all fetched issues are included
+  as a fallback, marked unprocessed. A `report_stage: pre_submit`
+  report is used but warned about: it predates that run's Jira
+  writes, so split children may appear under local ids.
 - Historical descriptions at the run time (for externally modified issues)
 - Current descriptions for auto-revised issues (our own submissions)
 - Exclusion of issues that were out of scope (Done) at run time

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -113,7 +113,10 @@ def _load_run_report(results_dir, run_name, config=None):
             continue
         try:
             ids.add(entry["id"])
-        except KeyError as e:
+        except (KeyError, TypeError) as e:
+            # TypeError included: an unhashable id ({} / []) must follow the
+            # same malformed-report path as a missing one, not escape as a
+            # traceback past main's ValueError handling.
             raise ValueError(f"run report {path} has malformed {item_key} entries: {e}") from e
     return ids, report
 
@@ -129,7 +132,13 @@ def _older_run_names(results_dir, run_name):
     for name in sorted(os.listdir(results_dir), reverse=True):
         if name.startswith(".") or name in ("latest", "test-data"):
             continue
-        if not os.path.isdir(os.path.join(results_dir, name)):
+        path = os.path.join(results_dir, name)
+        # isdir follows symlinks: a planted timestamp-named symlink would
+        # otherwise route the walk-back into a report OUTSIDE results_dir
+        # and let it rewrite the processed-ID filter (CWE-59). `latest` is
+        # the one symlink this layout legitimately contains, and it is
+        # already excluded by name above.
+        if os.path.islink(path) or not os.path.isdir(path):
             continue
         try:
             datetime.strptime(name, "%Y%m%d-%H%M%S")

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -92,8 +92,19 @@ def _load_run_report(results_dir, run_name, config=None):
         # writer and this reader disagree about the schema, and pretending the report is absent
         # would hide exactly that.
         raise ValueError(f"run report {path} has no {item_key} item list")
+    items = report.get(item_key)
+    if not isinstance(items, list):
+        # A null or mapping-typed item list is the same writer/reader schema
+        # disagreement as a missing key — not a zero-count run. The old
+        # comprehension caught the null case as TypeError inside its try;
+        # the explicit loop must not regress it to a bare traceback, and {}
+        # must not masquerade as a legitimate empty LIST.
+        raise ValueError(
+            f"run report {path} has a non-list {item_key} value "
+            f"({type(items).__name__})"
+        )
     ids = set()
-    for entry in report.get(item_key, []):
+    for entry in items:
         if not isinstance(entry, dict):
             raise ValueError(
                 f"run report {path} has malformed {item_key} entries: "

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -100,8 +100,7 @@ def _load_run_report(results_dir, run_name, config=None):
         # the explicit loop must not regress it to a bare traceback, and {}
         # must not masquerade as a legitimate empty LIST.
         raise ValueError(
-            f"run report {path} has a non-list {item_key} value "
-            f"({type(items).__name__})"
+            f"run report {path} has a non-list {item_key} value ({type(items).__name__})"
         )
     ids = set()
     for entry in items:

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -55,7 +55,17 @@ BOOTSTRAP_CONFIG = {
 def _load_run_report(results_dir, run_name, config=None):
     """Load processed IDs and report from the run's item list.
 
-    Returns (set_of_ids, report_dict), or (None, None) if no report file exists.
+    Returns (set_of_ids, report_dict) — the set may be EMPTY for a legitimate
+    zero-count run — or (None, None) if no report file exists. Absence and
+    emptiness are different signals: an absent report has the documented
+    include-all fallback, while an empty one is positive evidence the run
+    processed nothing, so the caller walks back to an older run instead
+    (RHAIFIRST-569).
+
+    Error entries do not count as processed: the run recorded them precisely
+    because it could NOT dispose of them (no readable review), so counting
+    them here would freeze them out of every future fetch — the
+    RHAIRFE-3201 shape, reachable through bootstrap (RHAIFIRST-582).
 
     Raises ValueError when the file exists but cannot be understood — unreadable, malformed YAML,
     not a mapping, or entries without an id. That is a different situation from absence: absence
@@ -78,17 +88,37 @@ def _load_run_report(results_dir, run_name, config=None):
         raise ValueError(f"run report {path} is not a mapping (got {type(report).__name__})")
     if item_key not in report:
         # The drift shape: a report written under a different item key. An empty LIST is a
-        # legitimate zero-count run and keeps the documented fallback; a missing KEY means the
+        # legitimate zero-count run (the caller walks back); a missing KEY means the
         # writer and this reader disagree about the schema, and pretending the report is absent
         # would hide exactly that.
         raise ValueError(f"run report {path} has no {item_key} item list")
     try:
-        ids = {e["id"] for e in report.get(item_key, [])}
+        ids = {e["id"] for e in report.get(item_key, []) if "error" not in e}
     except (TypeError, KeyError) as e:
         raise ValueError(f"run report {path} has malformed {item_key} entries: {e}") from e
-    if not ids:
-        return None, None
     return ids, report
+
+
+def _older_run_names(results_dir, run_name):
+    """Run directory names strictly older than run_name, newest first.
+
+    Same eligibility rules as find_latest_run_timestamp; the strict name
+    comparison also excludes replay directories newer than the `latest`
+    symlink target (pushed with --no-update-latest).
+    """
+    names = []
+    for name in sorted(os.listdir(results_dir), reverse=True):
+        if name.startswith(".") or name in ("latest", "test-data"):
+            continue
+        if not os.path.isdir(os.path.join(results_dir, name)):
+            continue
+        try:
+            datetime.strptime(name, "%Y%m%d-%H%M%S")
+        except ValueError:
+            continue
+        if name < run_name:
+            names.append(name)
+    return names
 
 
 def _run_dir_has_snapshots(results_dir, run_name):
@@ -389,12 +419,54 @@ def main():
     print(f"Fetched {len(current)} issues from Jira", file=sys.stderr)
 
     # Filter to issues that were actually processed in the run
+    run_report = None
     try:
-        # The report half of the tuple is unused here — main() only needs the ID filter.
-        processed_ids, _ = _load_run_report(args.results_dir, run_name, config=boot_config)
+        processed_ids, run_report = _load_run_report(args.results_dir, run_name, config=boot_config)
+        # An empty item list is a legitimate zero-count run (a valid outcome
+        # since bc2f553), not missing evidence: falling through to include-all
+        # would re-surface the whole backlog that earlier runs already
+        # processed. Walk back to the most recent run that processed anything
+        # and reconstruct state as of THAT run — using the empty run's newer
+        # timestamp instead would hash issues at post-edit state, hiding any
+        # edit made between the two runs from change detection (RHAIFIRST-569).
+        if processed_ids is not None and not processed_ids:
+            for older_name in _older_run_names(args.results_dir, run_name):
+                older_ids, older_report = _load_run_report(
+                    args.results_dir, older_name, config=boot_config
+                )
+                if older_ids is None:
+                    print(
+                        f"Warning: {older_name} has no run report — skipped in walk-back",
+                        file=sys.stderr,
+                    )
+                    continue
+                if not older_ids:
+                    continue
+                print(
+                    f"Run {run_name} processed nothing — walking back to {older_name}",
+                    file=sys.stderr,
+                )
+                run_name = older_name
+                run_dt = datetime.strptime(older_name, "%Y%m%d-%H%M%S").replace(tzinfo=timezone.utc)
+                processed_ids, run_report = older_ids, older_report
+                break
+            else:
+                # Every report in history says "processed nothing" — that is
+                # positive evidence, not absence, so neither the --include-all
+                # gate nor the partial-clone guard applies (run_report stays
+                # set to mark that a report WAS read): snapshotting everything
+                # as unprocessed states exactly what the reports state.
+                print(
+                    "Warning: no run with a non-empty item list found — "
+                    "including all issues as unprocessed",
+                    file=sys.stderr,
+                )
+                processed_ids = None
     except ValueError as e:
         # Present but not understood is not the same as absent: absence has a documented
         # fallback, a corrupt report does not. Only an explicit --include-all proceeds.
+        # The same strictness applies to a corrupt report met during walk-back — the
+        # chain of evidence stops at the first report that cannot be read.
         if not args.include_all:
             print(
                 f"Error: {e}. Pass --include-all to snapshot every fetched issue "
@@ -406,7 +478,11 @@ def main():
         processed_ids = None
     unfiltered = processed_ids is None
     if unfiltered:
-        if not args.include_all and _run_dir_has_snapshots(args.results_dir, run_name):
+        if (
+            not args.include_all
+            and run_report is None
+            and _run_dir_has_snapshots(args.results_dir, run_name)
+        ):
             print(
                 f"Error: {run_name} has issue snapshots but no readable run report — "
                 f"the results directory looks partial (clone_results_repo.py omits run "
@@ -415,11 +491,24 @@ def main():
                 file=sys.stderr,
             )
             sys.exit(1)
-        print("Warning: no run report — including all issues", file=sys.stderr)
+        if run_report is None:
+            print("Warning: no run report — including all issues", file=sys.stderr)
     else:
         before = len(current)
         current = {k: v for k, v in current.items() if k in processed_ids}
         print(f"Filtered to {len(current)}/{before} issues from run report", file=sys.stderr)
+
+    if run_report is not None and run_report.get("report_stage") == "pre_submit":
+        # One line, absence of the field is silent: pre-versioned reports say
+        # nothing about their stage. A pre_submit tip predates that run's Jira
+        # writes, so split children may appear under local ids and be missing
+        # from this snapshot; they will surface as NEW on the next fetch.
+        print(
+            f"Warning: run report {run_name} is report_stage: pre_submit — it predates "
+            f"that run's Jira writes; split children may appear under local ids and "
+            f"be missing from this snapshot",
+            file=sys.stderr,
+        )
 
     # Step 3: Find which issues were updated since the run
     run_jql_ts = run_dt.strftime("%Y-%m-%d %H:%M")

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -92,10 +92,19 @@ def _load_run_report(results_dir, run_name, config=None):
         # writer and this reader disagree about the schema, and pretending the report is absent
         # would hide exactly that.
         raise ValueError(f"run report {path} has no {item_key} item list")
-    try:
-        ids = {e["id"] for e in report.get(item_key, []) if "error" not in e}
-    except (TypeError, KeyError) as e:
-        raise ValueError(f"run report {path} has malformed {item_key} entries: {e}") from e
+    ids = set()
+    for entry in report.get(item_key, []):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"run report {path} has malformed {item_key} entries: "
+                f"expected a mapping, got {type(entry).__name__}"
+            )
+        if "error" in entry:
+            continue
+        try:
+            ids.add(entry["id"])
+        except KeyError as e:
+            raise ValueError(f"run report {path} has malformed {item_key} entries: {e}") from e
     return ids, report
 
 
@@ -406,6 +415,13 @@ def main():
         print("Error: no valid run directories found", file=sys.stderr)
         sys.exit(1)
     print(f"Last run: {run_name} ({run_dt.isoformat()})", file=sys.stderr)
+    # The snapshot FILE is always named after the tip run, even when the
+    # walk-back reconstructs from an older one: find_previous_snapshot picks
+    # the reverse-lexically newest name, so a file named after the older run
+    # would be shadowed forever by any stale snapshot a pre-walk-back
+    # bootstrap left under the tip name — and a re-run must overwrite that
+    # file in place. bootstrapped_from records the run actually used.
+    tip_name = run_name
 
     # Step 2: Fetch all current issues with hard filters
     ignore_label = snap_config["ignore_label"]
@@ -435,6 +451,30 @@ def main():
                     args.results_dir, older_name, config=boot_config
                 )
                 if older_ids is None:
+                    if _run_dir_has_snapshots(args.results_dir, older_name):
+                        # Same shape the tip-level guard refuses: snapshots
+                        # prove a real pipeline run whose report is invisible
+                        # (partial clone, or an aborted run that submitted
+                        # before it could publish). Its work is unknown, so
+                        # "include everything as unprocessed" would re-select
+                        # a backlog that run may already have disposed of.
+                        if not args.include_all:
+                            print(
+                                f"Error: walk-back reached {older_name}, which has issue "
+                                f"snapshots but no readable run report — the results "
+                                f"directory looks partial. Point --results-dir at a full "
+                                f"clone, or pass --include-all to snapshot every fetched "
+                                f"issue as unprocessed.",
+                                file=sys.stderr,
+                            )
+                            sys.exit(1)
+                        print(
+                            f"Warning: {older_name} has snapshots but no run report — "
+                            f"--include-all set, including all issues",
+                            file=sys.stderr,
+                        )
+                        processed_ids = None
+                        break
                     print(
                         f"Warning: {older_name} has no run report — skipped in walk-back",
                         file=sys.stderr,
@@ -604,7 +644,7 @@ def main():
         "issues": snapshot_issues,
     }
     snapshot_prefix = snap_config["snapshot_prefix"]
-    snapshot_path = os.path.join(snapshot_dir, f"{snapshot_prefix}{run_name}.yaml")
+    snapshot_path = os.path.join(snapshot_dir, f"{snapshot_prefix}{tip_name}.yaml")
     with open(snapshot_path, "w", encoding="utf-8") as f:
         yaml.dump(snapshot, f, default_flow_style=False, sort_keys=False)
     print(f"Wrote snapshot: {snapshot_path}")

--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -142,6 +142,14 @@ def build_report(
     status_map = _task_status_map(tasks, config)
     all_children = [c for kids in children_map.values() for c in kids]
     expanded_ids = list(ids) + [c for c in all_children if c not in ids]
+    # ...and every task file the run left behind. The CLI's default population
+    # scans the REVIEWS directory, so an item whose review was never written —
+    # or was cleared for a reassess cycle that never ran — simply vanished
+    # from the report while its task file sat in the run: RHAIRFE-3201 was
+    # marked processed yet absent from all 77 entries (RHAIFIRST-582). Tasks
+    # without a review land in the review-file-not-found error path below.
+    known = set(expanded_ids)
+    expanded_ids += [tid for tid in status_map if tid not in known]
 
     per_item = []
     before_totals = {f: [] for f in score_fields}

--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -11,6 +11,7 @@ import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from artifact_utils import (
+    _is_companion_file,
     find_review_file,
     read_frontmatter,
     resolve_ids,
@@ -24,6 +25,7 @@ TYPE_CONFIG = {
     "rfe": {
         "score_fields": ["what", "why", "open_to_how", "not_a_task", "right_sized"],
         "reviews_dir": "rfe-reviews",
+        "tasks_dir": "rfe-tasks",
         "item_key": "per_rfe",
         "output_prefix": "",
         "extra_entry_fields": ["needs_attention"],
@@ -43,6 +45,7 @@ TYPE_CONFIG = {
             "right_sized",
         ],
         "reviews_dir": "initiative-reviews",
+        "tasks_dir": "initiatives",
         "item_key": "per_initiative",
         "output_prefix": "initiative-run-",
         "extra_entry_fields": ["alignment", "feasibility", "needs_attention"],
@@ -91,6 +94,28 @@ def split_children_map(artifacts_dir, config, tasks=None):
         if parent and parent.startswith(config["child_parent_prefixes"]):
             children_map.setdefault(parent, []).append(task_data[config["id_field"]])
     return children_map
+
+
+def _ids_from_filenames(artifacts_dir, config):
+    """Ids recoverable from task FILENAMES ({ID}.md).
+
+    The frontmatter scan silently skips a task file torn mid-write (the
+    orchestrator died while writing it), which would make the item vanish
+    from the report exactly like a missing review does — the filename is
+    the one part of a torn task that survives (RHAIFIRST-582).
+    """
+    tasks_dir = os.path.join(artifacts_dir, config["tasks_dir"])
+    if not os.path.isdir(tasks_dir):
+        return []
+    prefixes = (config["local_prefix"], config["tracker_prefix"])
+    ids = []
+    for filename in os.listdir(tasks_dir):
+        if not filename.endswith(".md") or _is_companion_file(filename):
+            continue
+        tid = filename[:-3]
+        if tid.startswith(prefixes):
+            ids.append(tid)
+    return ids
 
 
 def _task_status_map(tasks, config):
@@ -150,6 +175,13 @@ def build_report(
     # without a review land in the review-file-not-found error path below.
     known = set(expanded_ids)
     expanded_ids += [tid for tid in status_map if tid not in known]
+    known.update(status_map)
+    # A task file torn mid-write (orchestrator killed) fails the frontmatter
+    # scan and would vanish the same way — recover the id from the filename,
+    # which is {ID}.md for every task the pipeline writes.
+    expanded_ids += sorted(
+        tid for tid in _ids_from_filenames(artifacts_dir, config) if tid not in known
+    )
 
     per_item = []
     before_totals = {f: [] for f in score_fields}

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -588,9 +588,36 @@ def main():
             except (ValidationError, Exception) as e:
                 print(f"Warning: cannot read review for {item_id}: {e}", file=sys.stderr)
 
-        rec = "submit"
-        if review_data:
-            rec = review_data.get("recommendation", "submit")
+        if review_data is None:
+            # No readable review means this item never finished the pipeline —
+            # interrupted mid-review, or its review was cleared for a reassess
+            # cycle that never ran. Submitting would push content no review
+            # approved, and marking it processed would freeze it out of every
+            # future run at an unchanged hash (RHAIRFE-3201, RHAIFIRST-582).
+            # Leave it untouched and unprocessed: the next fetch selects it as
+            # NEW, and check_resume finds no passing review to skip it on.
+            plan.append(
+                {
+                    id_field: item_id,
+                    "title": title,
+                    "is_existing": is_existing,
+                    "priority": priority,
+                    "size": size,
+                    "action": "SKIP",
+                    "labels": [],
+                    "remove_labels": [],
+                    "skip_reason": "no readable review — left unprocessed for the next run",
+                    "task_path": task_path,
+                    "attn_reason": None,
+                    "original_labels": task_data.get("original_labels") or [],
+                    "auto_approve": False,
+                    "jira_status": None,
+                    "leave_unprocessed": True,
+                }
+            )
+            continue
+
+        rec = review_data.get("recommendation", "submit")
 
         original_labels = task_data.get("original_labels") or []
         attn_reason = None
@@ -792,7 +819,11 @@ def main():
     for entry in plan:
         item_id = entry[id_field]
         if entry["skip_reason"]:
-            if "Jira conflict" not in entry["skip_reason"]:
+            # A conflict or an unreviewed item is not disposed of — marking it
+            # processed would exclude it from every future fetch (invariant 7:
+            # only a hash change resets the flag). Everything else skipped
+            # here was a decision (e.g. rejected) and counts as disposal.
+            if "Jira conflict" not in entry["skip_reason"] and not entry.get("leave_unprocessed"):
                 mark_processed_ids.append(item_id)
             print(f"  {item_id}: Skipping — {entry['skip_reason']}")
             continue

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -588,14 +588,20 @@ def main():
             except (ValidationError, Exception) as e:
                 print(f"Warning: cannot read review for {item_id}: {e}", file=sys.stderr)
 
-        if review_data is None:
-            # No readable review means this item never finished the pipeline —
-            # interrupted mid-review, or its review was cleared for a reassess
-            # cycle that never ran. Submitting would push content no review
-            # approved, and marking it processed would freeze it out of every
-            # future run at an unchanged hash (RHAIRFE-3201, RHAIFIRST-582).
-            # Leave it untouched and unprocessed: the next fetch selects it as
-            # NEW, and check_resume finds no passing review to skip it on.
+        if review_path is None:
+            # No review file at all means this item never finished the
+            # pipeline — interrupted mid-review, or its review was cleared
+            # for a reassess cycle that never ran. Submitting would push
+            # content no review approved, and marking it processed would
+            # freeze it out of every future run at an unchanged hash
+            # (RHAIRFE-3201, RHAIFIRST-582). Leave it untouched and
+            # unprocessed: the next fetch selects it as NEW, and check_resume
+            # finds no passing review to skip it on. Deliberately narrower
+            # than review_data is None: a PRESENT but schema-invalid review
+            # keeps the old warn-and-proceed behavior, because check_resume
+            # reads reviews with a laxer bar and would keep skipping the
+            # re-review — leaving such an item unprocessed here would make
+            # it re-selected but never disposed of, forever.
             plan.append(
                 {
                     id_field: item_id,
@@ -617,7 +623,9 @@ def main():
             )
             continue
 
-        rec = review_data.get("recommendation", "submit")
+        rec = "submit"
+        if review_data:
+            rec = review_data.get("recommendation", "submit")
 
         original_labels = task_data.get("original_labels") or []
         attn_reason = None

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -1477,6 +1477,22 @@ class TestLoadRunReportRejectsCorruptFiles:
         assert ids == set()
         assert isinstance(report, dict)
 
+    def test_null_item_list_raises(self, tmp_path):
+        """per_rfe: null is schema drift, not a zero-count run — and it must
+        raise the documented ValueError, not escape as a bare TypeError."""
+        results, run = self._write_report(tmp_path, "per_rfe: null\n")
+
+        with pytest.raises(ValueError, match="non-list"):
+            _load_run_report(results, run)
+
+    def test_mapping_item_list_raises(self, tmp_path):
+        """per_rfe: {} iterates like an empty list — it must not masquerade
+        as a legitimate zero-count run and trigger the walk-back."""
+        results, run = self._write_report(tmp_path, "per_rfe: {}\n")
+
+        with pytest.raises(ValueError, match="non-list"):
+            _load_run_report(results, run)
+
     def test_non_dict_entry_raises_even_containing_error(self, tmp_path):
         """A malformed entry must refuse loudly — the error-entry skip is for
         error DICTS, not for anything whose text happens to contain 'error'."""

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -1217,6 +1217,34 @@ class TestBootstrapIntegration:
             snap = yaml.safe_load(f)
         assert set(snap["issues"]) == {"RHOAIENG-1"}
 
+    def test_walk_back_ignores_symlinked_run_dirs(self, tmp_path, mock_jira):
+        """A timestamp-named symlink must not route the walk-back to a report
+        outside results_dir (CWE-59) — the filter would be attacker-chosen."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Issue one.", "RHAIRFE-2": "Issue two."}
+        results = _make_results_dir(
+            tmp_path,
+            ["20260330-100000", "20260401-120000"],
+            latest="20260401-120000",
+            reports={"20260330-100000": ["RHAIRFE-1"], "20260401-120000": []},
+        )
+        # Outside dir with a newer-stamped report claiming a different filter.
+        outside = tmp_path / "outside" / "20260331-110000"
+        _write(
+            str(outside / "auto-fix-runs" / "20260331-110000.yaml"),
+            yaml.dump({"per_rfe": [{"id": "RHAIRFE-2", "recommendation": "submit"}]}),
+        )
+        os.symlink(str(outside), os.path.join(results, "20260331-110000"))
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        r = self._run_bootstrap(results, art_dir, url)
+        assert r.returncode == 0, r.stderr
+        # The symlinked dir is skipped; the walk lands on the real older run.
+        assert "walking back to 20260330-100000" in r.stderr
+        _, snap = self._load_snapshot(art_dir)
+        assert set(snap["issues"]) == {"RHAIRFE-1"}
+
     def test_pre_submit_report_warns(self, tmp_path, mock_jira):
         """A pre_submit tip predates that run's Jira writes — one warning
         naming the consequence (RHAIFIRST-569 item 2)."""
@@ -1491,6 +1519,14 @@ class TestLoadRunReportRejectsCorruptFiles:
         results, run = self._write_report(tmp_path, "per_rfe: {}\n")
 
         with pytest.raises(ValueError, match="non-list"):
+            _load_run_report(results, run)
+
+    def test_unhashable_id_raises_value_error(self, tmp_path):
+        """id: {} must follow the malformed-report path, not escape as a
+        TypeError traceback past main's ValueError handling."""
+        results, run = self._write_report(tmp_path, "per_rfe:\n- id: {}\n")
+
+        with pytest.raises(ValueError, match="malformed"):
             _load_run_report(results, run)
 
     def test_non_dict_entry_raises_even_containing_error(self, tmp_path):

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -1017,7 +1017,13 @@ class TestBootstrapIntegration:
             tmp_path,
             ["20260331-110000", "20260401-120000"],
             latest="20260401-120000",
-            reports={"20260331-110000": ["RHAIRFE-1"], "20260401-120000": []},
+            reports={
+                "20260331-110000": {
+                    "report_stage": "pre_submit",
+                    "per_rfe": [{"id": "RHAIRFE-1", "recommendation": "submit"}],
+                },
+                "20260401-120000": [],
+            },
         )
         art_dir = str(tmp_path / "artifacts")
         os.makedirs(art_dir)
@@ -1025,9 +1031,16 @@ class TestBootstrapIntegration:
         r = self._run_bootstrap(results, art_dir, url)
         assert r.returncode == 0, r.stderr
         assert "walking back to 20260331-110000" in r.stderr
+        # The stage warning is evaluated against the report actually USED —
+        # the walked-back one — not the empty tip (which has no stage field).
+        assert "run report 20260331-110000 is report_stage: pre_submit" in r.stderr
 
         name, snap = self._load_snapshot(art_dir)
-        assert name == "issue-snapshot-20260331-110000.yaml"
+        # The FILE keeps the tip run's name: find_previous_snapshot picks the
+        # reverse-lexically newest, so an older-named file would be shadowed
+        # forever by any stale snapshot a pre-walk-back bootstrap wrote, and
+        # a re-run must overwrite that file in place.
+        assert name == "issue-snapshot-20260401-120000.yaml"
         assert snap["bootstrapped_from"] == "20260331-110000"
         assert snap["query_timestamp"] == "2026-03-31T11:00:00Z"
         # Filtered by the older run's report — not include-all.
@@ -1047,6 +1060,14 @@ class TestBootstrapIntegration:
             latest="20260401-120000",
             reports={"20260331-110000": [], "20260401-120000": []},
         )
+        # Real pushed runs carry snapshots. Their presence must NOT trip the
+        # partial-clone guard here: the reports were read and say "processed
+        # nothing" — evidence, not absence.
+        for run in ("20260331-110000", "20260401-120000"):
+            _write(
+                os.path.join(results, run, "auto-fix-runs", f"issue-snapshot-{run}.yaml"),
+                "issues: {}\n",
+            )
         art_dir = str(tmp_path / "artifacts")
         os.makedirs(art_dir)
 
@@ -1103,6 +1124,98 @@ class TestBootstrapIntegration:
 
         r = self._run_bootstrap(results, art_dir, url, extra=["--include-all"])
         assert r.returncode == 0, r.stderr
+        _, snap = self._load_snapshot(art_dir)
+        assert set(snap["issues"]) == {"RHAIRFE-1"}
+        assert all(e == {"hash": e["hash"], "processed": False} for e in snap["issues"].values())
+
+    def test_walk_back_refuses_reportless_dir_with_snapshots(self, tmp_path, mock_jira):
+        """A dir met during walk-back that has snapshots but no report is the
+        aborted-run / partial-clone shape: its work is unknown, so bootstrap
+        hard-stops exactly like the tip-level guard (RHAIFIRST-582 review
+        finding). --include-all remains the escape hatch."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Issue one."}
+        results = _make_results_dir(
+            tmp_path,
+            ["20260330-100000", "20260401-120000"],
+            latest="20260401-120000",
+            reports={"20260401-120000": []},
+        )
+        _write(
+            os.path.join(
+                results,
+                "20260330-100000",
+                "auto-fix-runs",
+                "issue-snapshot-20260330-100000.yaml",
+            ),
+            "issues: {}\n",
+        )
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        r = self._run_bootstrap(results, art_dir, url)
+        assert r.returncode == 1
+        assert "20260330-100000" in r.stderr and "looks partial" in r.stderr
+
+        r = self._run_bootstrap(results, art_dir, url, extra=["--include-all"])
+        assert r.returncode == 0, r.stderr
+        _, snap = self._load_snapshot(art_dir)
+        assert all(e == {"hash": e["hash"], "processed": False} for e in snap["issues"].values())
+
+    def test_walk_back_ignores_replay_dirs_newer_than_latest(self, tmp_path, mock_jira):
+        """Replay dirs pushed with --no-update-latest sit NEWER than the
+        latest symlink target; the walk-back must only look older."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Issue one.", "RHAIRFE-2": "Issue two."}
+        results = _make_results_dir(
+            tmp_path,
+            ["20260331-110000", "20260401-120000", "20260402-130000"],
+            latest="20260401-120000",
+            reports={
+                "20260331-110000": ["RHAIRFE-1"],
+                "20260401-120000": [],
+                "20260402-130000": ["RHAIRFE-2"],
+            },
+        )
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        r = self._run_bootstrap(results, art_dir, url)
+        assert r.returncode == 0, r.stderr
+        assert "walking back to 20260331-110000" in r.stderr
+
+        _, snap = self._load_snapshot(art_dir)
+        assert set(snap["issues"]) == {"RHAIRFE-1"}
+
+    def test_initiative_walk_back_uses_initiative_report_names(self, tmp_path, mock_jira):
+        """The walk-back must read reports through the type config — the
+        initiative report is initiative-run-<ts>.yaml with per_initiative."""
+        url, server = mock_jira
+        server.issues = {"RHOAIENG-1": "Initiative one."}
+        results = _make_results_dir(
+            tmp_path, ["20260331-110000", "20260401-120000"], latest="20260401-120000"
+        )
+        for run, items in (
+            ("20260331-110000", [{"id": "RHOAIENG-1", "recommendation": "submit"}]),
+            ("20260401-120000", []),
+        ):
+            _write(
+                os.path.join(results, run, "auto-fix-runs", f"initiative-run-{run}.yaml"),
+                yaml.dump({"per_initiative": items}),
+            )
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        r = self._run_bootstrap(results, art_dir, url, extra=["--type", "initiative"])
+        assert r.returncode == 0, r.stderr
+        assert "walking back to 20260331-110000" in r.stderr
+
+        snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
+        snaps = [f for f in os.listdir(snapshot_dir) if f.startswith("initiative-snapshot-")]
+        assert snaps == ["initiative-snapshot-20260401-120000.yaml"]
+        with open(os.path.join(snapshot_dir, snaps[0])) as f:
+            snap = yaml.safe_load(f)
+        assert set(snap["issues"]) == {"RHOAIENG-1"}
 
     def test_pre_submit_report_warns(self, tmp_path, mock_jira):
         """A pre_submit tip predates that run's Jira writes — one warning
@@ -1363,6 +1476,14 @@ class TestLoadRunReportRejectsCorruptFiles:
 
         assert ids == set()
         assert isinstance(report, dict)
+
+    def test_non_dict_entry_raises_even_containing_error(self, tmp_path):
+        """A malformed entry must refuse loudly — the error-entry skip is for
+        error DICTS, not for anything whose text happens to contain 'error'."""
+        results, run = self._write_report(tmp_path, 'per_rfe:\n- "RHAIRFE-2 had an error"\n')
+
+        with pytest.raises(ValueError, match="malformed"):
+            _load_run_report(results, run)
 
     def test_error_entries_do_not_count_as_processed(self, tmp_path):
         """An error entry records that the run could NOT dispose of the item —

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -287,11 +287,13 @@ def mock_jira():
     server.shutdown()
 
 
-def _make_results_dir(tmp_path, run_names, latest=None, processed_ids=None):
+def _make_results_dir(tmp_path, run_names, latest=None, processed_ids=None, reports=None):
     """Create a results directory with run dirs.
 
     If processed_ids is provided and latest is set, writes a run report
-    with per_rfe entries for those IDs.
+    with per_rfe entries for those IDs. `reports` writes one report per
+    run name: a list becomes per_rfe entries, a dict is dumped as the
+    whole report, a string is written raw (for corrupt-report tests).
     """
     results = str(tmp_path / "results")
     os.makedirs(results)
@@ -300,10 +302,20 @@ def _make_results_dir(tmp_path, run_names, latest=None, processed_ids=None):
     if latest:
         os.symlink(latest, os.path.join(results, "latest"))
     if processed_ids is not None and latest:
-        report_dir = os.path.join(results, latest, "auto-fix-runs")
+        reports = {**(reports or {}), latest: processed_ids}
+    for name, spec in (reports or {}).items():
+        report_dir = os.path.join(results, name, "auto-fix-runs")
         os.makedirs(report_dir, exist_ok=True)
-        report = {"per_rfe": [{"id": pid, "recommendation": "submit"} for pid in processed_ids]}
-        with open(os.path.join(report_dir, f"{latest}.yaml"), "w") as f:
+        path = os.path.join(report_dir, f"{name}.yaml")
+        if isinstance(spec, str):
+            with open(path, "w") as f:
+                f.write(spec)
+            continue
+        if isinstance(spec, dict):
+            report = spec
+        else:
+            report = {"per_rfe": [{"id": pid, "recommendation": "submit"} for pid in spec]}
+        with open(path, "w") as f:
             yaml.dump(report, f)
     return results
 
@@ -963,53 +975,175 @@ class TestBootstrapIntegration:
         assert snap["issues"]["RHAIRFE-2"] == historical_hash_2
         assert snap["issues"]["RHAIRFE-3"] == historical_hash_3
 
-    def test_empty_per_rfe_includes_all(self, tmp_path, mock_jira):
-        """Run report with empty per_rfe falls back to including all."""
-        url, server = mock_jira
-        server.issues = {
-            "RHAIRFE-1": "Issue one.",
-            "RHAIRFE-2": "Issue two.",
-        }
-        # processed_ids=[] → run report exists but per_rfe is empty
-        results = _make_results_dir(
-            tmp_path, ["20260401-120000"], latest="20260401-120000", processed_ids=[]
-        )
-        art_dir = str(tmp_path / "artifacts")
-        os.makedirs(art_dir)
-
+    def _run_bootstrap(self, results, art_dir, url, extra=None):
         env = {
             **os.environ,
             "JIRA_SERVER": url,
             "JIRA_USER": "test@example.com",
             "JIRA_TOKEN": "test-token",
         }
-        r = subprocess.run(
-            [
-                sys.executable,
-                SCRIPT,
-                "--results-dir",
-                results,
-                "--artifacts-dir",
-                art_dir,
-                "project = RHAIRFE",
-            ],
-            capture_output=True,
-            text=True,
-            env=env,
-        )
-        assert r.returncode == 0, r.stderr
-        assert "no run report" in r.stderr
+        cmd = [
+            sys.executable,
+            SCRIPT,
+            "--results-dir",
+            results,
+            "--artifacts-dir",
+            art_dir,
+        ]
+        if extra:
+            cmd.extend(extra)
+        cmd.append("project = RHAIRFE")
+        return subprocess.run(cmd, capture_output=True, text=True, env=env)
 
+    @staticmethod
+    def _load_snapshot(art_dir):
         snapshot_dir = os.path.join(art_dir, "auto-fix-runs")
         snapshots = [f for f in os.listdir(snapshot_dir) if f.startswith("issue-snapshot-")]
+        assert len(snapshots) == 1, snapshots
         with open(os.path.join(snapshot_dir, snapshots[0])) as f:
-            snap = yaml.safe_load(f)
+            return snapshots[0], yaml.safe_load(f)
 
+    def test_empty_report_walks_back_to_previous_run(self, tmp_path, mock_jira):
+        """A zero-count latest run is evidence, not absence: filter and
+        timestamp come from the newest run that processed anything —
+        the newer timestamp would hash issues at post-edit state and hide
+        any edit made between the two runs (RHAIFIRST-569)."""
+        url, server = mock_jira
+        server.issues = {
+            "RHAIRFE-1": "Issue one.",
+            "RHAIRFE-2": "Issue two.",
+        }
+        results = _make_results_dir(
+            tmp_path,
+            ["20260331-110000", "20260401-120000"],
+            latest="20260401-120000",
+            reports={"20260331-110000": ["RHAIRFE-1"], "20260401-120000": []},
+        )
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        r = self._run_bootstrap(results, art_dir, url)
+        assert r.returncode == 0, r.stderr
+        assert "walking back to 20260331-110000" in r.stderr
+
+        name, snap = self._load_snapshot(art_dir)
+        assert name == "issue-snapshot-20260331-110000.yaml"
+        assert snap["bootstrapped_from"] == "20260331-110000"
+        assert snap["query_timestamp"] == "2026-03-31T11:00:00Z"
+        # Filtered by the older run's report — not include-all.
+        assert set(snap["issues"]) == {"RHAIRFE-1"}
+
+    def test_all_reports_empty_includes_all_unprocessed(self, tmp_path, mock_jira):
+        """Every report saying "processed nothing" is positive evidence, so no
+        --include-all gate: everything is snapshotted as unprocessed."""
+        url, server = mock_jira
+        server.issues = {
+            "RHAIRFE-1": "Issue one.",
+            "RHAIRFE-2": "Issue two.",
+        }
+        results = _make_results_dir(
+            tmp_path,
+            ["20260331-110000", "20260401-120000"],
+            latest="20260401-120000",
+            reports={"20260331-110000": [], "20260401-120000": []},
+        )
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        r = self._run_bootstrap(results, art_dir, url)
+        assert r.returncode == 0, r.stderr
+        assert "no run with a non-empty item list" in r.stderr
+
+        _, snap = self._load_snapshot(art_dir)
         assert len(snap["issues"]) == 2
-        # Fail-safe: bootstrap has no run-report evidence these were processed, so it must not
-        # write a bare hash — snapshot_fetch reads a missing `processed` as True and nothing
+        # Fail-safe: no run-report evidence of processing, so no bare hash —
+        # snapshot_fetch reads a missing `processed` as True and nothing
         # ever demotes such an entry.
         assert all(e == {"hash": e["hash"], "processed": False} for e in snap["issues"].values())
+
+    def test_walk_back_skips_reportless_dir(self, tmp_path, mock_jira):
+        """A run directory without a report cannot provide evidence either
+        way — the walk-back warns and keeps looking."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Issue one."}
+        results = _make_results_dir(
+            tmp_path,
+            ["20260330-100000", "20260331-110000", "20260401-120000"],
+            latest="20260401-120000",
+            reports={"20260330-100000": ["RHAIRFE-1"], "20260401-120000": []},
+        )
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        r = self._run_bootstrap(results, art_dir, url)
+        assert r.returncode == 0, r.stderr
+        assert "20260331-110000 has no run report — skipped in walk-back" in r.stderr
+        assert "walking back to 20260330-100000" in r.stderr
+
+        name, snap = self._load_snapshot(art_dir)
+        assert snap["bootstrapped_from"] == "20260330-100000"
+
+    def test_corrupt_report_during_walk_back_errors(self, tmp_path, mock_jira):
+        """The chain of evidence stops at the first unreadable report — same
+        strictness as a corrupt latest, same --include-all escape hatch."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Issue one."}
+        results = _make_results_dir(
+            tmp_path,
+            ["20260331-110000", "20260401-120000"],
+            latest="20260401-120000",
+            reports={"20260331-110000": "per_rfe: [unclosed", "20260401-120000": []},
+        )
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        r = self._run_bootstrap(results, art_dir, url)
+        assert r.returncode == 1
+        assert "Error:" in r.stderr and "20260331-110000" in r.stderr
+
+        r = self._run_bootstrap(results, art_dir, url, extra=["--include-all"])
+        assert r.returncode == 0, r.stderr
+
+    def test_pre_submit_report_warns(self, tmp_path, mock_jira):
+        """A pre_submit tip predates that run's Jira writes — one warning
+        naming the consequence (RHAIFIRST-569 item 2)."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Issue one."}
+        results = _make_results_dir(
+            tmp_path,
+            ["20260401-120000"],
+            latest="20260401-120000",
+            reports={
+                "20260401-120000": {
+                    "report_stage": "pre_submit",
+                    "per_rfe": [{"id": "RHAIRFE-1", "recommendation": "submit"}],
+                }
+            },
+        )
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        r = self._run_bootstrap(results, art_dir, url)
+        assert r.returncode == 0, r.stderr
+        assert "report_stage: pre_submit" in r.stderr
+        assert "split children" in r.stderr
+
+    def test_report_without_stage_is_silent(self, tmp_path, mock_jira):
+        """Pre-versioned reports say nothing about their stage — no warning."""
+        url, server = mock_jira
+        server.issues = {"RHAIRFE-1": "Issue one."}
+        results = _make_results_dir(
+            tmp_path,
+            ["20260401-120000"],
+            latest="20260401-120000",
+            processed_ids=["RHAIRFE-1"],
+        )
+        art_dir = str(tmp_path / "artifacts")
+        os.makedirs(art_dir)
+
+        r = self._run_bootstrap(results, art_dir, url)
+        assert r.returncode == 0, r.stderr
+        assert "pre_submit" not in r.stderr
 
     def test_partial_results_dir_is_refused(self, tmp_path, mock_jira):
         """Snapshots but no run report means a partial clone — do not silently include all."""
@@ -1220,13 +1354,32 @@ class TestLoadRunReportRejectsCorruptFiles:
         with pytest.raises(ValueError, match="has no per_rfe item list"):
             _load_run_report(results, run)
 
-    def test_empty_item_list_is_still_none(self, tmp_path):
-        """Key present, list empty — the legitimate zero-count shape keeps its meaning."""
+    def test_empty_item_list_returns_empty_set(self, tmp_path):
+        """Key present, list empty — positive evidence of a zero-count run,
+        distinct from (None, None) absence so the caller can walk back."""
         results, run = self._write_report(tmp_path, "per_rfe: []\n")
 
         ids, report = _load_run_report(results, run)
 
-        assert ids is None and report is None
+        assert ids == set()
+        assert isinstance(report, dict)
+
+    def test_error_entries_do_not_count_as_processed(self, tmp_path):
+        """An error entry records that the run could NOT dispose of the item —
+        counting it as processed would freeze it out of every future fetch
+        (the RHAIRFE-3201 shape, RHAIFIRST-582)."""
+        results, run = self._write_report(
+            tmp_path,
+            "per_rfe:\n"
+            "- id: RHAIRFE-1\n"
+            "  recommendation: submit\n"
+            "- id: RHAIRFE-2\n"
+            "  error: review file not found\n",
+        )
+
+        ids, _ = _load_run_report(results, run)
+
+        assert ids == {"RHAIRFE-1"}
 
     def test_missing_file_is_still_none(self, tmp_path):
         """Absence keeps its meaning — only corruption raises."""

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -254,6 +254,20 @@ class TestSplitChildrenIncluded:
         assert by_id["RFE-002"]["error"] == "review file not found"
         assert by_id["RFE-002"]["tracker_ref"] is None
 
+    def test_torn_task_file_still_surfaces(self, art_dir):
+        """A task file whose frontmatter was torn mid-write fails the scan —
+        the id must be recovered from the filename instead of vanishing."""
+        _write(
+            f"{art_dir}/rfe-tasks/RHAIRFE-99.md",
+            "---\nrfe_id: RHAIRFE-99\ntitle: Torn\n",  # no closing ---
+        )
+
+        report = build_report([], "20260825-151200", artifacts_dir=art_dir)
+
+        by_id = {e["id"]: e for e in report["per_rfe"]}
+        assert by_id["RHAIRFE-99"]["error"] == "review file not found"
+        assert by_id["RHAIRFE-99"]["tracker_ref"] == "RHAIRFE-99"
+
     def test_task_with_review_is_not_duplicated(self, art_dir):
         """The task-population fold must not double-report ids the review
         scan already covers."""

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -202,6 +202,81 @@ class TestSplitChildrenIncluded:
         assert report["input_count"] == 1
         assert len(report["per_rfe"]) == 2
 
+    def test_task_without_review_becomes_error_entry(self, art_dir):
+        """A task file with no review must surface as an error entry, not
+        vanish: the CLI's default population scans the reviews directory, so
+        RHAIRFE-3201 — whose review was cleared for a reassess cycle that
+        never ran — was absent from all 77 entries of its run while being
+        marked processed (RHAIFIRST-582)."""
+        _write(
+            f"{art_dir}/rfe-tasks/RHAIRFE-100.md",
+            TASK_TEMPLATE.format(rfe_id="RHAIRFE-100", extra=""),
+        )
+        _write(
+            f"{art_dir}/rfe-reviews/RHAIRFE-100-review.md",
+            REVIEW_TEMPLATE.format(
+                rfe_id="RHAIRFE-100",
+                score=9,
+                pass_val="true",
+                recommendation="submit",
+                right_sized=2,
+            ),
+        )
+        # Task present, review absent — the 3201 shape.
+        _write(
+            f"{art_dir}/rfe-tasks/RHAIRFE-101.md",
+            TASK_TEMPLATE.format(rfe_id="RHAIRFE-101", extra=""),
+        )
+
+        report = build_report(["RHAIRFE-100"], "20260825-151200", artifacts_dir=art_dir)
+
+        by_id = {e["id"]: e for e in report["per_rfe"]}
+        assert "RHAIRFE-101" in by_id, "task without review vanished from the report"
+        entry = by_id["RHAIRFE-101"]
+        assert entry["error"] == "review file not found"
+        assert entry["tracker_ref"] == "RHAIRFE-101"
+        assert report["results"]["errors"] == 1
+        assert [e["id"] for e in report["errors"]] == ["RHAIRFE-101"]
+        # input_count keeps meaning what was asked for, not what was found.
+        assert report["input_count"] == 1
+
+    def test_local_task_without_review_has_null_tracker_ref(self, art_dir):
+        """The error entry keeps the tracker_ref contract: a local id that was
+        never submitted has no remote reference."""
+        _write(
+            f"{art_dir}/rfe-tasks/RFE-002.md",
+            TASK_TEMPLATE.format(rfe_id="RFE-002", extra=""),
+        )
+
+        report = build_report([], "20260825-151200", artifacts_dir=art_dir)
+
+        by_id = {e["id"]: e for e in report["per_rfe"]}
+        assert by_id["RFE-002"]["error"] == "review file not found"
+        assert by_id["RFE-002"]["tracker_ref"] is None
+
+    def test_task_with_review_is_not_duplicated(self, art_dir):
+        """The task-population fold must not double-report ids the review
+        scan already covers."""
+        _write(
+            f"{art_dir}/rfe-tasks/RHAIRFE-100.md",
+            TASK_TEMPLATE.format(rfe_id="RHAIRFE-100", extra=""),
+        )
+        _write(
+            f"{art_dir}/rfe-reviews/RHAIRFE-100-review.md",
+            REVIEW_TEMPLATE.format(
+                rfe_id="RHAIRFE-100",
+                score=9,
+                pass_val="true",
+                recommendation="submit",
+                right_sized=2,
+            ),
+        )
+
+        report = build_report(["RHAIRFE-100"], "20260825-151200", artifacts_dir=art_dir)
+
+        assert [e["id"] for e in report["per_rfe"]] == ["RHAIRFE-100"]
+        assert report["results"]["errors"] == 0
+
     def test_no_children_no_change(self, art_dir):
         """When no splits occurred, behavior is unchanged."""
         _write(

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -573,6 +573,22 @@ class TestFeasibilityLabelOnSubmit:
         assert "Remove labels" not in stdout
         assert "rfe-creator-feasibility" not in stdout
 
+    def test_invalid_review_still_proceeds(self, art_dir):
+        """A PRESENT but schema-invalid review keeps the old warn-and-proceed
+        behavior: check_resume reads reviews with a laxer bar, so leaving the
+        item unprocessed would re-select it forever without ever re-reviewing
+        it — the skip is deliberately for ABSENT reviews only."""
+        _write(f"{art_dir}/rfe-tasks/RFE-001.md", self._task("RFE-001"))
+        _write(
+            f"{art_dir}/rfe-reviews/RFE-001-review.md",
+            "---\nrfe_id: RFE-001\nscore: not-a-number\n---\nBroken.",
+        )
+        stdout, stderr, rc = _run_submit(art_dir)
+        assert rc == 0
+        assert "cannot read review" in stderr
+        assert "Would create" in stdout
+        assert "no readable review" not in stdout
+
     def test_no_review_skips_the_item_entirely(self, art_dir):
         """Missing review file → the item is not submitted at all. It never
         finished the pipeline, so submitting would push content no review

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -573,15 +573,17 @@ class TestFeasibilityLabelOnSubmit:
         assert "Remove labels" not in stdout
         assert "rfe-creator-feasibility" not in stdout
 
-    def test_no_review_skips_feasibility_op(self, art_dir):
-        """Missing review file → no feasibility label, but submit still runs."""
+    def test_no_review_skips_the_item_entirely(self, art_dir):
+        """Missing review file → the item is not submitted at all. It never
+        finished the pipeline, so submitting would push content no review
+        approved, and disposing of it would freeze it out of future runs
+        (RHAIRFE-3201, RHAIFIRST-582)."""
         _write(f"{art_dir}/rfe-tasks/RFE-001.md", self._task("RFE-001"))
         # No review file written
         stdout, _, rc = _run_submit(art_dir)
         assert rc == 0
-        # Still creates the RFE
-        assert "Create" in stdout or "Would create" in stdout
-        # But no feasibility label
+        assert "no readable review" in stdout
+        assert "Would create" not in stdout
         assert "rfe-creator-feasibility" not in stdout
 
 

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -617,6 +617,43 @@ class TestSnapshotUpdate:
         entry = data["issues"]["RHAIRFE-1234"]
         assert entry == {"hash": "existing", "processed": True}
 
+    def test_unreviewed_item_left_unprocessed(self, art_dir, jira):
+        """An item without a readable review is not disposed of: no Jira
+        write, no processed flag — so the next fetch re-selects it instead
+        of freezing it at an unchanged hash (RHAIRFE-3201, RHAIFIRST-582)."""
+        # A selected issue enters the run unprocessed (cmd_fetch only ever
+        # resets or preserves the flag; submit.py alone sets it).
+        snap_path = self._seed_snapshot(
+            art_dir,
+            {
+                "RHAIRFE-1234": {"hash": "hash-a", "processed": False},
+                "RHAIRFE-5678": {"hash": "hash-b", "processed": False},
+            },
+        )
+        jira.create("RHAIRFE-1234", "Test RFE", "Original.")
+        jira.create("RHAIRFE-5678", "Other RFE", "Original.")
+        for key in ("RHAIRFE-1234", "RHAIRFE-5678"):
+            _write(f"{art_dir}/rfe-originals/{key}.md", "Original.")
+            _write(
+                f"{art_dir}/rfe-tasks/{key}.md",
+                f"---\nrfe_id: {key}\ntitle: Test RFE\n"
+                "priority: Major\nstatus: Ready\n---\nRevised.",
+            )
+        # Review only for 5678 — 1234 is the interrupted, unreviewed shape.
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-5678-review.md", _review("RHAIRFE-5678"))
+
+        r = _run_submit(art_dir, jira.url)
+        assert r.returncode == 0, r.stderr
+        assert "no readable review" in r.stdout
+
+        with open(snap_path) as f:
+            data = yaml.safe_load(f)
+        # The reviewed item was disposed of normally...
+        assert data["issues"]["RHAIRFE-5678"]["processed"] is True
+        # ...the unreviewed one was left exactly as it was: unchanged hash,
+        # still unprocessed, so the next fetch re-selects it.
+        assert data["issues"]["RHAIRFE-1234"] == {"hash": "hash-a", "processed": False}
+
     def test_dry_run_does_not_update_snapshot(self, art_dir, jira):
         """Dry-run must not write processed flags or hashes to snapshot."""
         snap_path = self._seed_snapshot(art_dir, {"RHAIRFE-1234": "existing"})


### PR DESCRIPTION
Implements RHAIFIRST-569 and RHAIFIRST-582 together — they interlock in the same code.

## RHAIFIRST-569 — bootstrap trusts evidence, not absence

- **Walk-back**: a latest run whose report has an **empty item list** is positive evidence of a zero-count run (valid since `bc2f553`), not missing evidence. Bootstrap now walks back to the newest run that processed anything and reconstructs state **as of that run** — using the empty run's newer timestamp would hash issues at post-edit state and hide any edit made between the two runs from change detection.
- When **every** report in history is empty, include-all-unprocessed proceeds without the `--include-all` gate: it states exactly what the reports state.
- A **`report_stage: pre_submit`** report is used but warned about (it predates that run's Jira writes; split children may appear under local ids). Absence of the field is silent. The warning is evaluated against the report actually *used*, walk-back included.
- Absent report keeps the existing fallback chain; corrupt report keeps erroring (`--include-all` escape unchanged) — including corruption met *during* walk-back: the chain of evidence stops at the first unreadable report.

## RHAIFIRST-582 — an interrupted item can no longer vanish or freeze

The `RHAIRFE-3201` shape (run `20260825-151200`): orchestrator died mid-reassess → review file absent → the item was missing from all 77 report entries yet marked processed at an unchanged hash — invisible and frozen out of every future run. Three mutually reinforcing fixes:

- **Report**: the population now folds in every task file (the CLI default scanned only the reviews dir), so review-less tasks land in the existing `review file not found` error path — with `tracker_ref`, per the provenance contract. A task file *torn mid-write* (fails the frontmatter scan) is recovered from its filename.
- **Submit**: a task with **no review file** is skipped — not submitted (that would push content no review approved), not labeled, and **left unprocessed** so the next fetch re-selects it and check_resume finds no passing review to skip it on. Deliberately narrowed to review-*absent*: a present-but-schema-invalid review keeps the old warn-and-proceed, because `check_resume` reads reviews with a laxer bar and would keep skipping the re-review — the strict version would re-select such items forever without ever disposing of them (caught in review).
- **Bootstrap**: report **error entries no longer count as processed** — the run recorded them precisely because it could not dispose of them.

⚠️ One deliberate behavior change worth reviewer attention: `submit.py` used to **create/update** an item that had no review at all (defaulting to `recommendation: submit`). That path now skips. The skill contract (`rfe.submit`: "Use after /rfe.review", "from reviewed RFE artifacts") says review is the precondition, and in CI the no-review shape only occurs on interruption — but if anyone relies on manual review-less submits, this is the PR to say so.

## Review hardening (second commit)

An adversarial multi-agent review of the first commit confirmed 4 code defects + 5 test gaps, all fixed in `db44efa`: the walk-back now hard-stops at a dir with snapshots-but-no-report (aborted-run/partial-clone shape — previously it silently include-all'd a backlog that run may already have submitted, exit 0 where the old code exited 1); the snapshot file keeps the **tip** run's name so a re-run overwrites any stale pre-fix snapshot instead of being reverse-lexically shadowed by it; torn task files surface via filename; malformed non-dict report entries refuse loudly again; and tests pin the initiative-typed walk-back, replay-dir exclusion, walked-back-stage warning, guard suppression on all-empty history, and the `--include-all` contract.

Two confirmed-but-declined findings, for the record: split children are created in Phase 1 without a review gate (pre-existing `split_submit.py` behavior — RHAIFIRST-570/571 territory, not this PR); and an item whose *submit* failed appears as a clean entry in the final report, so bootstrap disaster-recovery would count it processed (narrow: the live snapshot path handles it correctly via the untouched-on-error `mark_processed`; noting as follow-up on 582).

## Verification

- 863 tests pass (30 new/rewritten across 5 files); `test_empty_per_rfe_includes_all` rewritten to the walk-back contract per the 569 AC.
- **17 mutations, each killed by a specific test**: 7 on the original implementation (walk-back disabled / timestamp not walked back / warning dropped / error-entry filter dropped / population fold dropped / mark-processed exclusion dropped / skip-block dropped) and 10 on the review fixes (guard suppression, initiative config, run_report walk-back, replay-dir exclusion, include-all contract, snapshot-presence check, tip-name file, filename fold, non-dict refusal, absent-vs-invalid keying).
- `docs/snapshot-incremental-fetch.md` bootstrap section updated; all 8 design invariants re-checked (invariant 8 unchanged — submit.py remains the only `processed: true` setter, it just sets it for fewer ids).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bootstrap reconstructs state from the newest run with processed items when the latest report is empty.
  * Run reports include items discovered from task filenames, including incomplete or missing reviews.
  * Unreviewed items are skipped and remain available for future processing.
  * Bootstrap falls back to fetched issues when no usable run history exists.

* **Bug Fixes**
  * Error entries are no longer counted as processed.
  * Missing review files are clearly reported instead of being submitted.
  * Pre-submit reports trigger a warning when used for bootstrapping.

* **Documentation**
  * Updated bootstrap guidance to explain report filtering and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->