### PR TITLE
Close the split create-to-link window, and quarantine failed parents

### DIFF
--- a/docs/snapshot-incremental-fetch.md
+++ b/docs/snapshot-incremental-fetch.md
@@ -31,7 +31,7 @@ filler within the limit.
 |--------|--------|-------|-----------|
 | `statusCategory != Done` | JQL | JQL | Closed issues never need processing |
 | `rfe-creator-ignore` | JQL | JQL | Permanent human override — never touch |
-| `rfe-creator-split-quarantine` | JQL | JQL | Split failed partway — parked until a human removes it (RHAIFIRST-570) |
+| `rfe-creator-split-quarantine` | JQL | JQL | Split failed partway — parked until a human removes it (RHAIFIRST-570; see [split-quarantine.md](split-quarantine.md)) |
 | `rfe-creator-autofix-rubric-pass` | JQL | Hash diff | If someone edits a passing RFE, we should see it |
 | `rfe-creator-needs-attention` | Not filtered | Hash diff | If a human resolves the flag and revises the description, we should re-evaluate |
 | `rfe-creator-feasibility-pass` | Not filtered | Hash diff | Informational verdict; description change triggers re-review and may flip the label |

--- a/docs/snapshot-incremental-fetch.md
+++ b/docs/snapshot-incremental-fetch.md
@@ -31,6 +31,7 @@ filler within the limit.
 |--------|--------|-------|-----------|
 | `statusCategory != Done` | JQL | JQL | Closed issues never need processing |
 | `rfe-creator-ignore` | JQL | JQL | Permanent human override — never touch |
+| `rfe-creator-split-quarantine` | JQL | JQL | Split failed partway — parked until a human removes it (RHAIFIRST-570) |
 | `rfe-creator-autofix-rubric-pass` | JQL | Hash diff | If someone edits a passing RFE, we should see it |
 | `rfe-creator-needs-attention` | Not filtered | Hash diff | If a human resolves the flag and revises the description, we should re-evaluate |
 | `rfe-creator-feasibility-pass` | Not filtered | Hash diff | Informational verdict; description change triggers re-review and may flip the label |
@@ -329,7 +330,8 @@ desired processing outcome:
 
 ```
 (<user-jql>) AND statusCategory != Done
-             AND (labels not in (rfe-creator-ignore) OR labels is EMPTY)
+             AND (labels not in (rfe-creator-ignore, rfe-creator-split-quarantine)
+                  OR labels is EMPTY)
 ```
 
 These filters are "hard" because an issue matching them should always be

--- a/docs/split-quarantine.md
+++ b/docs/split-quarantine.md
@@ -1,0 +1,78 @@
+# Split Quarantine — Operator Guide
+
+When the autofixer splits an oversized RFE, `split_submit.py` creates the
+child tickets in Jira, links them to the parent, and closes the parent —
+a multi-step transaction that can be interrupted (process death, Jira
+outage, a bad child artifact). This page is what a human needs to know
+when that happens. The failure class is rare: roughly once in the
+project's history to date.
+
+## What the label means
+
+`rfe-creator-split-quarantine` (Initiatives: `initiative-split-quarantine`)
+on a parent means: **a split submission failed partway, Jira may contain a
+partial result, and the nightly will not touch this parent again until a
+person removes the label.**
+
+It is applied together with the `-needs-attention` label and a comment
+explaining the failure. It is *not* applied for refusals (leaf-count cap,
+Jira edit conflict — nothing was written to Jira, and a later re-attempt
+is safe) nor for parents a run never got to.
+
+Why the hard stop: the parent's snapshot entry stays unprocessed after a
+failed split, so without the quarantine the nightly would re-select it
+every run — and each blind retry of a half-applied split can mint
+duplicate children. The fetch hard filters (see
+[snapshot-incremental-fetch.md](snapshot-incremental-fetch.md#hard-filters))
+exclude the label from selection; everything else (assessment, dashboards)
+still sees the ticket normally.
+
+## What to do
+
+1. **Read the needs-attention comment** on the parent. To list everything
+   currently parked:
+
+   ```
+   labels = rfe-creator-split-quarantine
+   ```
+
+2. **Inspect what the crashed attempt left behind**: children linked to
+   the parent via `Work item split`, and tickets carrying a
+   `rfe-creator-split-child-…` marker label naming this parent. There may
+   be none, some, or all of them, in any state of linking.
+
+3. **Decide what should live.** Keep the created children if they are
+   good — they are real, reviewed tickets — or close them (resolution
+   Obsolete) if the split should be redone from scratch. This judgment is
+   the reason a human is in the loop: automation cannot know whether the
+   old attempt's children or a fresh decomposition should win.
+
+4. **Remove the quarantine label.** That is the entire release action.
+   The next scheduled run re-selects the parent automatically, re-runs
+   the split, and finishes the job.
+
+## What the retry will and will not do
+
+The retry's recovery **adopts** an existing child only when it is exactly
+the ticket this run would have created — same parent, same child id, same
+title, and the same description content (verified against the live
+ticket). Anything that does not match all four is left untouched and a
+fresh child is created instead: a visible duplicate is always preferred
+over silently binding wrong content.
+
+Consequences worth knowing:
+
+- A retry in the *same* run (same artifacts) resumes cleanly — created
+  children are adopted, missing links and confirmations are completed.
+- A retry on a *later night* re-generates the decomposition, so its
+  content rarely matches the stale children byte-for-byte. Expect fresh
+  children; the stale ones stay where step 3 left them.
+- The retry **never closes** the old attempt's children. If you decided
+  in step 3 that the new attempt supersedes them, close them yourself —
+  that is currently a manual step by design.
+
+## The one "don't"
+
+Don't remove the label without doing step 2. The retry deliberately
+leaves stale children in place, so releasing an unexamined parent can
+leave orphaned tickets sitting next to the new ones.

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -443,10 +443,10 @@ def main():
     tip_name = run_name
 
     # Step 2: Fetch all current issues with hard filters
-    ignore_label = snap_config["ignore_label"]
+    excluded = f"{snap_config['ignore_label']}, {snap_config['quarantine_label']}"
     jql = (
         f"({args.jql}) AND statusCategory != Done "
-        f"AND (labels not in ({ignore_label}) OR labels is EMPTY)"
+        f"AND (labels not in ({excluded}) OR labels is EMPTY)"
     )
     print(f"JQL: {jql}", file=sys.stderr)
 

--- a/scripts/error_collect.py
+++ b/scripts/error_collect.py
@@ -150,7 +150,14 @@ def main():
     for rfe_id in error_ids:
         err = error_details.get(rfe_id, {}).get("error", "")
         is_revise_error = "revise" in str(err).lower()
-        is_split_error = "split" in str(err).lower()
+        # Prefix allow-list, not a substring test: split_refused: (nothing
+        # created — cleanup pointless) and split_submit_failed: (Jira may be
+        # PARTIALLY applied — cleanup would delete local child files whose
+        # Jira twins already exist, orphaning them) must never trigger
+        # cleanup_partial_split (RHAIFIRST-570). Only the agent-side
+        # split_failed class, recorded before any Jira write, is safe to
+        # clean and retry.
+        is_split_error = str(err).startswith("split_failed")
 
         # Restore task file from original for revise errors
         if is_revise_error:

--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -107,6 +107,23 @@ def get_issue(server, user, token, key, fields=None):
     return api_call_with_retry(server, path, user, token)
 
 
+def search_issues(server, user, token, jql, fields):
+    """GET /search/jql — single page (recovery-sized queries, <=50 results).
+
+    Returns the raw issue dicts. Callers needing pagination should use
+    snapshot_fetch's paginated fetch; split recovery never exceeds the leaf
+    cap, so one page is guaranteed sufficient.
+    """
+    import urllib.parse as _parse
+
+    path = (
+        f"/search/jql?jql={_parse.quote(jql, safe='')}"
+        f"&maxResults=50&fields={_parse.quote(fields, safe=',')}"
+    )
+    data = api_call_with_retry(server, path, user, token)
+    return data.get("issues", [])
+
+
 def get_comments(server, user, token, issue_key):
     """GET all comments for an issue, handling pagination."""
     comments = []

--- a/scripts/snapshot_fetch.py
+++ b/scripts/snapshot_fetch.py
@@ -56,10 +56,12 @@ SNAPSHOT_DIR = os.path.join(SCRIPT_DIR, "..", "artifacts", "auto-fix-runs")
 SNAPSHOT_CONFIG = {
     "rfe": {
         "ignore_label": "rfe-creator-ignore",
+        "quarantine_label": "rfe-creator-split-quarantine",
         "snapshot_prefix": "issue-snapshot-",
     },
     "initiative": {
         "ignore_label": "initiative-ignore",
+        "quarantine_label": "initiative-split-quarantine",
         "snapshot_prefix": "initiative-snapshot-",
     },
 }
@@ -366,10 +368,14 @@ def cmd_fetch(args):
     # Hard filters only
     # NOTE: "labels not in (X)" excludes issues with NO labels at all in Jira,
     # so we must also include "labels is EMPTY" to catch unlabeled issues.
-    ignore_label = config["ignore_label"]
+    # The quarantine label parks a parent whose split failed partway: its
+    # snapshot entry stays processed:false, so without the exclusion the
+    # nightly would re-select it forever, and each retry can mint duplicate
+    # children (RHAIFIRST-570). A human clears it by removing the label.
+    excluded = f"{config['ignore_label']}, {config['quarantine_label']}"
     jql = (
         f"({args.jql}) AND statusCategory != Done "
-        f"AND (labels not in ({ignore_label}) OR labels is EMPTY)"
+        f"AND (labels not in ({excluded}) OR labels is EMPTY)"
     )
     print(f"JQL={jql}", file=sys.stderr)
 

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -135,21 +135,35 @@ def _extract_adf_text(node):
     return _extract_adf_text(node.get("content", []))
 
 
-def _child_marker_label(label_prefix, parent_key, child_id):
-    """Deterministic per-(parent, child) label applied at creation.
+def _child_fingerprint(config, artifact_path):
+    """Short content fingerprint of the child's cleaned markdown body."""
+    import hashlib
+
+    _, _, _, cleaned = config["parse_child_fn"](artifact_path)
+    return hashlib.sha256(cleaned.encode("utf-8")).hexdigest()[:12]
+
+
+def _child_marker_label(label_prefix, parent_key, child_id, fingerprint):
+    """Deterministic per-(parent, child, content) label applied at creation.
 
     This is the recovery signal that exists from the instant the child does:
     a process death between create_issue and the link/comment used to mint a
     ticket no future run could find (RHAIFIRST-570). It carries the child's
-    local id, so recovery maps by identity instead of position — and the
-    PARENT key, because local ids are workspace-scoped and restart at 001 in
-    every fresh CI run while the labels persist forever: an id-only label
-    would let a new split adopt a stale child of a different parent
-    (reproduced live in review). Adoption is additionally title-guarded for
-    the one collision this scoping cannot express: the same parent re-split
-    with a different decomposition that reuses the same local ids.
+    local id, so recovery maps by identity instead of position; the PARENT
+    key, because local ids are workspace-scoped and restart at 001 in every
+    fresh CI run while labels persist forever (an id-only label let a new
+    split adopt a stale child of a DIFFERENT parent — reproduced live in
+    review); and a CONTENT fingerprint, because a re-split can legitimately
+    reuse the same parent, id and even title for different scope, and the
+    title is too weak an identity to prevent adopting a stale child whose
+    body is wrong (CodeRabbit on #169). Adoption therefore requires the
+    exact label — same parent, id and content — plus the title guard.
+    Within-run retries see identical artifacts and adopt; a cross-run
+    re-split regenerates content and deliberately does NOT adopt: minting a
+    fresh child and leaving the stale one for the human the quarantine
+    comment already points at beats silently binding wrong content.
     """
-    return f"{label_prefix}-split-child-{parent_key.lower()}-{child_id.lower()}"
+    return f"{label_prefix}-split-child-{parent_key.lower()}-{child_id.lower()}-{fingerprint}"
 
 
 class SubmissionState:
@@ -296,9 +310,15 @@ def discover_state(server, user, token, parent_key, expected_children, config):
     #     run minted a duplicate (RHAIFIRST-570).
     label_prefix = config["label_prefix"]
     title_by_id = {child_id: title for (child_id, title, _, _) in expected_children}
+    path_by_id = {child_id: path for (child_id, _, _, path) in expected_children}
     unmapped = [cid for cid in ids_in_order if cid not in state.phase2_done]
     if unmapped:
-        markers = [_child_marker_label(label_prefix, parent_key, cid) for cid in unmapped]
+        markers = [
+            _child_marker_label(
+                label_prefix, parent_key, cid, _child_fingerprint(config, path_by_id[cid])
+            )
+            for cid in unmapped
+        ]
         marker_by_label = dict(zip(markers, unmapped))
         # Quote every literal: label values embed parent_key and child ids
         # that come from frontmatter/CLI, and an unquoted `)` or `AND` would
@@ -321,10 +341,9 @@ def discover_state(server, user, token, parent_key, expected_children, config):
             child_id = hit_ids[0]
             if child_id in state.phase2_done:
                 continue
-            # Title guard: a quarantine-cleared parent re-split with a
-            # DIFFERENT decomposition legitimately reuses local ids — the
-            # stale child from the abandoned attempt must not be adopted
-            # for new scope it does not contain.
+            # Title guard, on top of the content-bound label: adoption
+            # happens only when parent, id, content AND title all match —
+            # i.e. the same artifact this run would submit.
             if hit.get("fields", {}).get("summary", "") != title_by_id.get(child_id):
                 print(
                     f"  Warning: {hit['key']} carries the marker for {child_id} but "
@@ -475,7 +494,9 @@ def phase2_create_link(
         labels = [
             f"{label_prefix}-auto-created",
             f"{label_prefix}-split-result",
-            _child_marker_label(label_prefix, parent_key, child_id),
+            _child_marker_label(
+                label_prefix, parent_key, child_id, _child_fingerprint(config, artifact_path)
+            ),
         ]
 
         review_path = find_review(artifacts_dir, child_id)

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -232,12 +232,16 @@ def discover_state(server, user, token, parent_key, expected_children, config):
                 # resume would re-post its archival comment and re-adopt it
                 # through the link signal.
                 child_id = created_key
-            state.phase2_done[child_id] = {
-                "key": created_key,
-                "linked": True,
-                "commented": True,
-            }
-            state.phase1_done.setdefault(child_id, comment["id"])
+            if child_id in set(ids_in_order):
+                # A comment naming a child that no longer exists (removed in
+                # a re-split) must not inflate phase2_done — phase3's count
+                # guard compares its size against the CURRENT total.
+                state.phase2_done[child_id] = {
+                    "key": created_key,
+                    "linked": True,
+                    "commented": True,
+                }
+                state.phase1_done.setdefault(child_id, comment["id"])
             continue
 
         legacy_confirm = re.search(
@@ -296,7 +300,12 @@ def discover_state(server, user, token, parent_key, expected_children, config):
     if unmapped:
         markers = [_child_marker_label(label_prefix, parent_key, cid) for cid in unmapped]
         marker_by_label = dict(zip(markers, unmapped))
-        jql = f"project = {config['project']} AND labels in ({', '.join(markers)})"
+        # Quote every literal: label values embed parent_key and child ids
+        # that come from frontmatter/CLI, and an unquoted `)` or `AND` would
+        # change the query semantics (CWE-943). The values themselves cannot
+        # contain quotes — ids are schema-validated key patterns.
+        quoted = ", ".join(f'"{m}"' for m in markers)
+        jql = f'project = "{config["project"]}" AND labels in ({quoted})'
         try:
             found = search_issues(server, user, token, jql, "labels,issuelinks,summary")
         except Exception as e:

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -135,25 +135,44 @@ def _extract_adf_text(node):
     return _extract_adf_text(node.get("content", []))
 
 
-def _content_matches_artifact(server, user, token, child_key, artifact_path, config):
-    """True when the live child's description matches the artifact body.
+def _inspect_child(server, user, token, child_key, artifact_path, parent_key, config):
+    """One GET: does the live child match the artifact, and is it linked?
 
-    Same normalize-and-compare check_description_conflict uses: the local
+    Returns {"content_matches", "title", "linked"}. The content comparison is
+    the same normalize-and-compare check_description_conflict uses: the local
     side is the cleaned markdown phase 2 would submit, the live side is the
-    child's ADF description rendered back to markdown.
+    child's ADF description rendered back to markdown. `linked` is DERIVED
+    from the live issuelinks rather than assumed from the signal that found
+    the child (CodeRabbit: a confirmation comment implies the link only for
+    comments this tool wrote in order) — a missing link is then healed by
+    phase 2's completion path instead of silently skipped.
     """
     from jira_utils import adf_to_markdown, normalize_for_compare
 
     _, _, _, cleaned = config["parse_child_fn"](artifact_path)
-    issue = get_issue(server, user, token, child_key, ["description"])
-    desc_raw = issue.get("fields", {}).get("description")
+    issue = get_issue(server, user, token, child_key, ["description", "summary", "issuelinks"])
+    fields = issue.get("fields", {})
+    desc_raw = fields.get("description")
     if isinstance(desc_raw, dict):
         live = normalize_for_compare(adf_to_markdown(desc_raw))
     elif desc_raw is None:
         live = ""
     else:
         live = normalize_for_compare(str(desc_raw))
-    return normalize_for_compare(cleaned) == live
+    linked = any(
+        link.get("type", {}).get("name") == "Work item split"
+        and parent_key
+        in (
+            (link.get("inwardIssue") or {}).get("key"),
+            (link.get("outwardIssue") or {}).get("key"),
+        )
+        for link in fields.get("issuelinks", [])
+    )
+    return {
+        "content_matches": normalize_for_compare(cleaned) == live,
+        "title": fields.get("summary", ""),
+        "linked": linked,
+    }
 
 
 def _child_fingerprint(config, artifact_path):
@@ -247,8 +266,8 @@ def discover_state(server, user, token, parent_key, expected_children, config):
             # compares its size against the CURRENT total.
             return
         try:
-            matches = _content_matches_artifact(
-                server, user, token, created_key, path_by_id[child_id], config
+            live = _inspect_child(
+                server, user, token, created_key, path_by_id[child_id], parent_key, config
             )
         except Exception as e:
             print(
@@ -257,16 +276,19 @@ def discover_state(server, user, token, parent_key, expected_children, config):
                 file=sys.stderr,
             )
             return
-        if not matches:
+        if not live["content_matches"] or live["title"] != title_by_id.get(child_id):
             print(
                 f"  Warning: {created_key} is confirmed for {child_id} but its "
-                f"content does not match the current artifact — not adopting it",
+                f"content or title does not match the current artifact — not "
+                f"adopting it",
                 file=sys.stderr,
             )
             return
         state.phase2_done[child_id] = {
             "key": created_key,
-            "linked": True,
+            # Derived, not assumed: a forged or out-of-order comment must not
+            # make phase 2 skip the link — a missing one is completed there.
+            "linked": live["linked"],
             "commented": True,
         }
         state.phase1_done.setdefault(child_id, comment_id)
@@ -355,9 +377,10 @@ def discover_state(server, user, token, parent_key, expected_children, config):
             # adopt a stale child from an earlier attempt whose body no
             # longer matches the artifact this run would submit.
             try:
-                matches = _content_matches_artifact(
-                    server, user, token, child_key, path_by_id[child_id], config
+                live = _inspect_child(
+                    server, user, token, child_key, path_by_id[child_id], parent_key, config
                 )
+                matches = live["content_matches"]
             except Exception as e:
                 print(
                     f"  Warning: could not verify {child_key} against {child_id}'s "

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -135,6 +135,27 @@ def _extract_adf_text(node):
     return _extract_adf_text(node.get("content", []))
 
 
+def _content_matches_artifact(server, user, token, child_key, artifact_path, config):
+    """True when the live child's description matches the artifact body.
+
+    Same normalize-and-compare check_description_conflict uses: the local
+    side is the cleaned markdown phase 2 would submit, the live side is the
+    child's ADF description rendered back to markdown.
+    """
+    from jira_utils import adf_to_markdown, normalize_for_compare
+
+    _, _, _, cleaned = config["parse_child_fn"](artifact_path)
+    issue = get_issue(server, user, token, child_key, ["description"])
+    desc_raw = issue.get("fields", {}).get("description")
+    if isinstance(desc_raw, dict):
+        live = normalize_for_compare(adf_to_markdown(desc_raw))
+    elif desc_raw is None:
+        live = ""
+    else:
+        live = normalize_for_compare(str(desc_raw))
+    return normalize_for_compare(cleaned) == live
+
+
 def _child_fingerprint(config, artifact_path):
     """Short content fingerprint of the child's cleaned markdown body."""
     import hashlib
@@ -205,6 +226,50 @@ def discover_state(server, user, token, parent_key, expected_children, config):
     marker = re.escape(config["comment_marker"])
     ids_in_order = [child_id for (child_id, _, _, _) in expected_children]
     id_by_title = {title: child_id for (child_id, title, _, _) in expected_children}
+    title_by_id = {child_id: title for (child_id, title, _, _) in expected_children}
+    path_by_id = {child_id: path for (child_id, _, _, path) in expected_children}
+
+    def _adopt_confirmed(child_id, created_key, comment_id):
+        """Adopt a confirmation-comment match only when the live child's
+        content is the artifact this run would submit.
+
+        The comment signal was the one adoption path with no content check:
+        on a cross-run re-split it silently bound attempt 1's confirmed
+        child (old content) into attempt 2's decomposition. Refusal falls
+        through to the marker search and a fresh create — the same
+        prefer-a-visible-duplicate-over-silent-misbinding rule the marker
+        path already applies. The GET is recovery-only and per adopted
+        child, at most the leaf cap.
+        """
+        if child_id not in path_by_id:
+            # A comment naming a child that no longer exists (removed in a
+            # re-split) must not inflate phase2_done — phase3's count guard
+            # compares its size against the CURRENT total.
+            return
+        try:
+            matches = _content_matches_artifact(
+                server, user, token, created_key, path_by_id[child_id], config
+            )
+        except Exception as e:
+            print(
+                f"  Warning: could not verify {created_key} against {child_id}'s "
+                f"artifact ({e}) — not adopting it",
+                file=sys.stderr,
+            )
+            return
+        if not matches:
+            print(
+                f"  Warning: {created_key} is confirmed for {child_id} but its "
+                f"content does not match the current artifact — not adopting it",
+                file=sys.stderr,
+            )
+            return
+        state.phase2_done[child_id] = {
+            "key": created_key,
+            "linked": True,
+            "commented": True,
+        }
+        state.phase1_done.setdefault(child_id, comment_id)
 
     def _id_at(idx):
         """Map a legacy positional index to a child id, best effort."""
@@ -246,16 +311,8 @@ def discover_state(server, user, token, parent_key, expected_children, config):
                 # resume would re-post its archival comment and re-adopt it
                 # through the link signal.
                 child_id = created_key
-            if child_id in set(ids_in_order):
-                # A comment naming a child that no longer exists (removed in
-                # a re-split) must not inflate phase2_done — phase3's count
-                # guard compares its size against the CURRENT total.
-                state.phase2_done[child_id] = {
-                    "key": created_key,
-                    "linked": True,
-                    "commented": True,
-                }
-                state.phase1_done.setdefault(child_id, comment["id"])
+            if child_id not in state.phase2_done:
+                _adopt_confirmed(child_id, created_key, comment["id"])
             continue
 
         legacy_confirm = re.search(
@@ -269,11 +326,7 @@ def discover_state(server, user, token, parent_key, expected_children, config):
                 else None
             )
             if child_id and child_id not in state.phase2_done:
-                state.phase2_done[child_id] = {
-                    "key": legacy_confirm.group(1),
-                    "linked": True,
-                    "commented": True,
-                }
+                _adopt_confirmed(child_id, legacy_confirm.group(1), comment["id"])
             continue
 
     # 2. Check issue links, components, labels, and Jira parent
@@ -298,6 +351,27 @@ def discover_state(server, user, token, parent_key, expected_children, config):
         child_summary = other.get("fields", {}).get("summary", "")
         child_id = id_by_title.get(child_summary)
         if child_id and child_id not in state.phase2_done:
+            # Same content guard as the comment path: the title alone would
+            # adopt a stale child from an earlier attempt whose body no
+            # longer matches the artifact this run would submit.
+            try:
+                matches = _content_matches_artifact(
+                    server, user, token, child_key, path_by_id[child_id], config
+                )
+            except Exception as e:
+                print(
+                    f"  Warning: could not verify {child_key} against {child_id}'s "
+                    f"artifact ({e}) — not adopting it",
+                    file=sys.stderr,
+                )
+                continue
+            if not matches:
+                print(
+                    f"  Warning: {child_key} is linked and matches {child_id}'s title "
+                    f"but not its content — not adopting it",
+                    file=sys.stderr,
+                )
+                continue
             state.phase2_done[child_id] = {
                 "key": child_key,
                 "linked": True,
@@ -309,8 +383,6 @@ def discover_state(server, user, token, parent_key, expected_children, config):
     #     the link and the comment — previously undiscoverable, so the next
     #     run minted a duplicate (RHAIFIRST-570).
     label_prefix = config["label_prefix"]
-    title_by_id = {child_id: title for (child_id, title, _, _) in expected_children}
-    path_by_id = {child_id: path for (child_id, _, _, path) in expected_children}
     unmapped = [cid for cid in ids_in_order if cid not in state.phase2_done]
     if unmapped:
         markers = [

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -53,6 +53,7 @@ from jira_utils import (  # noqa: E402
     get_transitions,
     markdown_to_adf,
     require_env,
+    search_issues,
     text_to_adf_paragraph,
 )
 
@@ -134,12 +135,29 @@ def _extract_adf_text(node):
     return _extract_adf_text(node.get("content", []))
 
 
+def _child_marker_label(label_prefix, child_id):
+    """Deterministic per-child label applied at creation.
+
+    This is the recovery signal that exists from the instant the child does:
+    a process death between create_issue and the link/comment used to mint a
+    ticket no future run could find (RHAIFIRST-570). The label also carries
+    the child's local id, so recovery maps by identity instead of position —
+    adding, removing or renaming a sibling between runs cannot misalign it.
+    """
+    return f"{label_prefix}-split-child-{child_id.lower()}"
+
+
 class SubmissionState:
-    """Tracks progress of the split submission."""
+    """Tracks progress of the split submission, keyed by child local id.
+
+    phase2_done values are dicts {"key", "linked", "commented"} so recovery
+    can finish a partially-applied child (created but never linked, or linked
+    but never confirmed) instead of only skipping fully-done ones.
+    """
 
     def __init__(self):
-        self.phase1_done = {}  # child_index -> comment ID
-        self.phase2_done = {}  # child_index -> created Jira key
+        self.phase1_done = {}  # child_id -> comment ID
+        self.phase2_done = {}  # child_id -> {"key", "linked", "commented"}
         self.parent_closed = False
         self.total_children = 0
         self.parent_components = []  # inherited by children
@@ -149,30 +167,70 @@ class SubmissionState:
 
 
 def discover_state(server, user, token, parent_key, expected_children, config):
-    """Scan parent's comments and links to determine submission progress."""
+    """Determine submission progress from Jira: comments, links, marker labels.
+
+    Recovery is id-based: every signal maps to the child's LOCAL id, never to
+    its position in the children list — sibling changes between runs used to
+    re-number positional indices and silently misalign recovery. Legacy
+    positional comments (written before RHAIFIRST-570) are still understood,
+    mapped through the current ordering as a best effort.
+
+    Signal precedence per child: confirmation comment (implies created,
+    linked and confirmed — the comment is posted last), then a `Work item
+    split` link (created and linked, confirmation lost), then the per-child
+    marker label (created only — the death-after-create window). Later
+    signals never overwrite earlier ones.
+    """
     state = SubmissionState()
     state.total_children = len(expected_children)
     marker = re.escape(config["comment_marker"])
+    ids_in_order = [child_id for (child_id, _, _, _) in expected_children]
+    id_by_title = {title: child_id for (child_id, title, _, _) in expected_children}
 
-    # 1. Scan comments for comment markers
+    def _id_at(idx):
+        """Map a legacy positional index to a child id, best effort."""
+        return ids_in_order[idx - 1] if 1 <= idx <= len(ids_in_order) else None
+
+    # 1. Scan comments for comment markers (new id-based format first,
+    #    legacy positional format second — the formats are disjoint).
     comments = get_comments(server, user, token, parent_key)
     for comment in comments:
         body_text = _extract_adf_text(comment.get("body", {}))
 
-        archival_match = re.search(rf"{marker} Split child (\d+) of (\d+):", body_text)
+        archival_match = re.search(
+            rf"{marker} Split child (\S+) \(\d+ of \d+\):", body_text
+        ) or re.search(rf"{marker} Split child (\d+) of \d+:", body_text)
         if archival_match:
-            idx = int(archival_match.group(1))
-            state.phase1_done[idx] = comment["id"]
+            ref = archival_match.group(1)
+            child_id = _id_at(int(ref)) if ref.isdigit() else ref
+            if child_id:
+                state.phase1_done[child_id] = comment["id"]
             continue
 
         confirm_match = re.search(
+            rf"{marker} Created as (\S+) for (\S+), linked to parent", body_text
+        )
+        if confirm_match:
+            created_key, child_id = confirm_match.group(1), confirm_match.group(2)
+            state.phase2_done[child_id] = {
+                "key": created_key,
+                "linked": True,
+                "commented": True,
+            }
+            continue
+
+        legacy_confirm = re.search(
             rf"{marker} Created as (\S+),.*\(ref: child (\d+) of (\d+)\)",
             body_text,
         )
-        if confirm_match:
-            created_key = confirm_match.group(1)
-            idx = int(confirm_match.group(2))
-            state.phase2_done[idx] = created_key
+        if legacy_confirm:
+            child_id = _id_at(int(legacy_confirm.group(2)))
+            if child_id and child_id not in state.phase2_done:
+                state.phase2_done[child_id] = {
+                    "key": legacy_confirm.group(1),
+                    "linked": True,
+                    "commented": True,
+                }
             continue
 
     # 2. Check issue links, components, labels, and Jira parent
@@ -186,14 +244,62 @@ def discover_state(server, user, token, parent_key, expected_children, config):
     for link in issue.get("fields", {}).get("issuelinks", []):
         if link.get("type", {}).get("name") != "Work item split":
             continue
-        outward = link.get("outwardIssue")
-        if not outward:
+        # Real Jira renders the child as outwardIssue on the parent; the
+        # jira-emulator renders it as inwardIssue. Check both ends — the
+        # title guard keeps a parent that is itself a split child (its own
+        # inward link points at ITS parent) from matching here.
+        other = link.get("outwardIssue") or link.get("inwardIssue")
+        if not other:
             continue
-        child_key = outward["key"]
-        child_summary = outward.get("fields", {}).get("summary", "")
-        for idx, (_, title, _, _) in enumerate(expected_children, 1):
-            if title == child_summary and idx not in state.phase2_done:
-                state.phase2_done[idx] = child_key
+        child_key = other["key"]
+        child_summary = other.get("fields", {}).get("summary", "")
+        child_id = id_by_title.get(child_summary)
+        if child_id and child_id not in state.phase2_done:
+            state.phase2_done[child_id] = {
+                "key": child_key,
+                "linked": True,
+                "commented": False,
+            }
+
+    # 2b. Marker-label search: the only signal that exists from the instant
+    #     the child does. Finds children whose creating process died before
+    #     the link and the comment — previously undiscoverable, so the next
+    #     run minted a duplicate (RHAIFIRST-570).
+    label_prefix = config["label_prefix"]
+    unmapped = [cid for cid in ids_in_order if cid not in state.phase2_done]
+    if unmapped:
+        markers = [_child_marker_label(label_prefix, cid) for cid in unmapped]
+        marker_by_label = dict(zip(markers, unmapped))
+        jql = f"labels in ({', '.join(markers)})"
+        try:
+            found = search_issues(server, user, token, jql, "labels,issuelinks")
+        except Exception as e:
+            # Best-effort net: a search failure must not turn recovery into
+            # an abort — the comment and link signals above still stand.
+            print(f"  Warning: marker-label search failed: {e}", file=sys.stderr)
+            found = []
+        for hit in found:
+            hit_labels = hit.get("fields", {}).get("labels", [])
+            hit_ids = [marker_by_label[m] for m in hit_labels if m in marker_by_label]
+            if len(hit_ids) != 1:
+                continue
+            child_id = hit_ids[0]
+            if child_id in state.phase2_done:
+                continue
+            linked = any(
+                link.get("type", {}).get("name") == "Work item split"
+                and parent_key
+                in (
+                    (link.get("inwardIssue") or {}).get("key"),
+                    (link.get("outwardIssue") or {}).get("key"),
+                )
+                for link in hit.get("fields", {}).get("issuelinks", [])
+            )
+            state.phase2_done[child_id] = {
+                "key": hit["key"],
+                "linked": linked,
+                "commented": False,
+            }
 
     # Capture parent's components and non-automation labels for inheritance
     label_prefix = config["label_prefix"]
@@ -227,25 +333,27 @@ def phase1_persist(server, user, token, parent_key, children, state, config, dry
     comment_marker = config["comment_marker"]
 
     for idx, (child_id, title, priority, artifact_path) in enumerate(children, 1):
-        if idx in state.phase1_done:
-            print(f"  Phase 1: Child {idx}/{total} already posted, skipping")
+        if child_id in state.phase1_done:
+            print(f"  Phase 1: Child {child_id} ({idx}/{total}) already posted, skipping")
             continue
 
         _, _, full_markdown, _ = parse_child(artifact_path)
-        header = f"{comment_marker} Split child {idx} of {total}: {title}"
+        # The header carries the child's local id so recovery maps by
+        # identity, not position (RHAIFIRST-570).
+        header = f"{comment_marker} Split child {child_id} ({idx} of {total}): {title}"
 
         if dry_run:
             print(
                 f"  Phase 1: Would post archival comment for child "
-                f"{idx}/{total}: {title} ({len(full_markdown)} chars)"
+                f"{child_id} ({idx}/{total}): {title} ({len(full_markdown)} chars)"
             )
-            state.phase1_done[idx] = "dry-run"
+            state.phase1_done[child_id] = "dry-run"
             continue
 
         body_adf = archival_comment_adf(header, full_markdown)
         result = add_comment(server, user, token, parent_key, body_adf)
-        state.phase1_done[idx] = result["id"]
-        print(f"  Phase 1: Posted content for child {idx}/{total}: {title}")
+        state.phase1_done[child_id] = result["id"]
+        print(f"  Phase 1: Posted content for child {child_id} ({idx}/{total}): {title}")
 
 
 def phase2_create_link(
@@ -264,16 +372,39 @@ def phase2_create_link(
     alignment_labels = config["alignment_labels"]
 
     for idx, (child_id, title, priority, artifact_path) in enumerate(children, 1):
-        if idx in state.phase2_done:
+        done = state.phase2_done.get(child_id)
+        if done and done["linked"] and done["commented"]:
             print(
-                f"  Phase 2: Child {idx}/{total} already created as "
-                f"{state.phase2_done[idx]}, skipping"
+                f"  Phase 2: Child {child_id} ({idx}/{total}) already created as "
+                f"{done['key']}, skipping"
             )
             continue
 
-        if idx not in state.phase1_done:
+        if done:
+            # Created by a previous run that died before finishing: complete
+            # the missing steps instead of minting a duplicate.
+            child_key = done["key"]
             print(
-                f"  ERROR: Child {idx}/{total} has no archival comment. Run Phase 1 first.",
+                f"  Phase 2: Child {child_id} ({idx}/{total}) found as {child_key} "
+                f"(linked: {done['linked']}, confirmed: {done['commented']}) — completing"
+            )
+            if not done["linked"]:
+                create_issue_link(server, user, token, "Work item split", parent_key, child_key)
+                print(f"           Linked {child_key} to {parent_key}")
+                done["linked"] = True
+            if not done["commented"]:
+                confirm_text = (
+                    f"{comment_marker} Created as {child_key} for {child_id}, "
+                    f"linked to parent. ({idx} of {total})"
+                )
+                add_comment(server, user, token, parent_key, text_to_adf_paragraph(confirm_text))
+                done["commented"] = True
+            continue
+
+        if child_id not in state.phase1_done:
+            print(
+                f"  ERROR: Child {child_id} ({idx}/{total}) has no archival comment. "
+                f"Run Phase 1 first.",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -281,8 +412,14 @@ def phase2_create_link(
         _, _, _, cleaned_markdown = config["parse_child_fn"](artifact_path)
         description_adf = markdown_to_adf(cleaned_markdown)
 
-        # Determine labels from review frontmatter
-        labels = [f"{label_prefix}-auto-created", f"{label_prefix}-split-result"]
+        # Determine labels from review frontmatter. The marker label is the
+        # recovery signal that exists from the instant the child does — and
+        # doubles as visible local-id provenance on the ticket.
+        labels = [
+            f"{label_prefix}-auto-created",
+            f"{label_prefix}-split-result",
+            _child_marker_label(label_prefix, child_id),
+        ]
 
         review_path = find_review(artifacts_dir, child_id)
         review_rec = None
@@ -328,7 +465,11 @@ def phase2_create_link(
             print(f"           Would link to {parent_key} via 'Work item split'")
             if attn_reason:
                 print("           Would post needs-attention comment")
-            state.phase2_done[idx] = f"{project}-DRY"
+            state.phase2_done[child_id] = {
+                "key": f"{project}-DRY",
+                "linked": True,
+                "commented": True,
+            }
             continue
 
         # 1. Create ticket with labels, inherited components, and parent
@@ -355,10 +496,11 @@ def phase2_create_link(
         create_issue_link(server, user, token, "Work item split", parent_key, child_key)
         print(f"           Linked {child_key} to {parent_key}")
 
-        # 3. Post confirmation comment
+        # 3. Post confirmation comment (carries the child's local id so
+        # recovery maps by identity, not position)
         confirm_text = (
-            f"{comment_marker} Created as {child_key}, linked to parent. "
-            f"(ref: child {idx} of {total})"
+            f"{comment_marker} Created as {child_key} for {child_id}, "
+            f"linked to parent. ({idx} of {total})"
         )
         add_comment(server, user, token, parent_key, text_to_adf_paragraph(confirm_text))
 
@@ -371,7 +513,7 @@ def phase2_create_link(
             add_comment(server, user, token, child_key, markdown_to_adf(attn_md))
             print("           Posted needs-attention comment")
 
-        state.phase2_done[idx] = child_key
+        state.phase2_done[child_id] = {"key": child_key, "linked": True, "commented": True}
 
 
 def build_split_summary_adf(server, children, state, total, config):
@@ -380,8 +522,8 @@ def build_split_summary_adf(server, children, state, total, config):
     entity_plural = config["entity_name_plural"]
 
     list_items = []
-    for idx, (_, title, _, _) in enumerate(children, 1):
-        child_key = state.phase2_done[idx]
+    for child_id, title, _, _ in children:
+        child_key = state.phase2_done[child_id]["key"]
         url = f"{server.rstrip('/')}/browse/{child_key}"
         list_items.append(
             {
@@ -435,7 +577,7 @@ def phase3_close(server, user, token, parent_key, children, state, config, dry_r
     label_prefix = config["label_prefix"]
 
     if len(state.phase2_done) < total:
-        missing = [i for i in range(1, total + 1) if i not in state.phase2_done]
+        missing = [cid for (cid, _, _, _) in children if cid not in state.phase2_done]
         print(
             f"  ERROR: Cannot close parent — children {missing} not yet created.", file=sys.stderr
         )
@@ -660,8 +802,9 @@ def main():
     # Post-submit: update frontmatter and rename files
     rename_fn = config["rename_fn"]
     project = config["project"]
-    for idx, (child_id, title, priority, artifact_path) in enumerate(children, 1):
-        assigned_key = state.phase2_done.get(idx)
+    for child_id, title, priority, artifact_path in children:
+        assigned = state.phase2_done.get(child_id)
+        assigned_key = assigned["key"] if assigned else None
         if not assigned_key or assigned_key == f"{project}-DRY":
             continue
 

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -135,16 +135,21 @@ def _extract_adf_text(node):
     return _extract_adf_text(node.get("content", []))
 
 
-def _child_marker_label(label_prefix, child_id):
-    """Deterministic per-child label applied at creation.
+def _child_marker_label(label_prefix, parent_key, child_id):
+    """Deterministic per-(parent, child) label applied at creation.
 
     This is the recovery signal that exists from the instant the child does:
     a process death between create_issue and the link/comment used to mint a
-    ticket no future run could find (RHAIFIRST-570). The label also carries
-    the child's local id, so recovery maps by identity instead of position —
-    adding, removing or renaming a sibling between runs cannot misalign it.
+    ticket no future run could find (RHAIFIRST-570). It carries the child's
+    local id, so recovery maps by identity instead of position — and the
+    PARENT key, because local ids are workspace-scoped and restart at 001 in
+    every fresh CI run while the labels persist forever: an id-only label
+    would let a new split adopt a stale child of a different parent
+    (reproduced live in review). Adoption is additionally title-guarded for
+    the one collision this scoping cannot express: the same parent re-split
+    with a different decomposition that reuses the same local ids.
     """
-    return f"{label_prefix}-split-child-{child_id.lower()}"
+    return f"{label_prefix}-split-child-{parent_key.lower()}-{child_id.lower()}"
 
 
 class SubmissionState:
@@ -197,12 +202,20 @@ def discover_state(server, user, token, parent_key, expected_children, config):
     for comment in comments:
         body_text = _extract_adf_text(comment.get("body", {}))
 
-        archival_match = re.search(
-            rf"{marker} Split child (\S+) \(\d+ of \d+\):", body_text
-        ) or re.search(rf"{marker} Split child (\d+) of \d+:", body_text)
-        if archival_match:
-            ref = archival_match.group(1)
-            child_id = _id_at(int(ref)) if ref.isdigit() else ref
+        archival_match = re.search(rf"{marker} Split child (\S+) \(\d+ of \d+\):", body_text)
+        legacy_archival = re.search(rf"{marker} Split child (\d+) of (\d+):", body_text)
+        if archival_match or legacy_archival:
+            if archival_match:
+                child_id = archival_match.group(1)
+            else:
+                # Positional legacy comment: only trustworthy when the child
+                # count it recorded still matches — a shrunk or regrown set
+                # re-numbers positions and would misbind (caught in review).
+                child_id = (
+                    _id_at(int(legacy_archival.group(1)))
+                    if int(legacy_archival.group(2)) == len(ids_in_order)
+                    else None
+                )
             if child_id:
                 state.phase1_done[child_id] = comment["id"]
             continue
@@ -212,11 +225,19 @@ def discover_state(server, user, token, parent_key, expected_children, config):
         )
         if confirm_match:
             created_key, child_id = confirm_match.group(1), confirm_match.group(2)
+            if child_id not in set(ids_in_order) and created_key in set(ids_in_order):
+                # The artifact was already renamed to the Jira key by a run
+                # that died after the rename: the current scan lists the
+                # child under its KEY, not its local id. Without this, the
+                # resume would re-post its archival comment and re-adopt it
+                # through the link signal.
+                child_id = created_key
             state.phase2_done[child_id] = {
                 "key": created_key,
                 "linked": True,
                 "commented": True,
             }
+            state.phase1_done.setdefault(child_id, comment["id"])
             continue
 
         legacy_confirm = re.search(
@@ -224,7 +245,11 @@ def discover_state(server, user, token, parent_key, expected_children, config):
             body_text,
         )
         if legacy_confirm:
-            child_id = _id_at(int(legacy_confirm.group(2)))
+            child_id = (
+                _id_at(int(legacy_confirm.group(2)))
+                if int(legacy_confirm.group(3)) == len(ids_in_order)
+                else None
+            )
             if child_id and child_id not in state.phase2_done:
                 state.phase2_done[child_id] = {
                     "key": legacy_confirm.group(1),
@@ -266,13 +291,14 @@ def discover_state(server, user, token, parent_key, expected_children, config):
     #     the link and the comment — previously undiscoverable, so the next
     #     run minted a duplicate (RHAIFIRST-570).
     label_prefix = config["label_prefix"]
+    title_by_id = {child_id: title for (child_id, title, _, _) in expected_children}
     unmapped = [cid for cid in ids_in_order if cid not in state.phase2_done]
     if unmapped:
-        markers = [_child_marker_label(label_prefix, cid) for cid in unmapped]
+        markers = [_child_marker_label(label_prefix, parent_key, cid) for cid in unmapped]
         marker_by_label = dict(zip(markers, unmapped))
-        jql = f"labels in ({', '.join(markers)})"
+        jql = f"project = {config['project']} AND labels in ({', '.join(markers)})"
         try:
-            found = search_issues(server, user, token, jql, "labels,issuelinks")
+            found = search_issues(server, user, token, jql, "labels,issuelinks,summary")
         except Exception as e:
             # Best-effort net: a search failure must not turn recovery into
             # an abort — the comment and link signals above still stand.
@@ -285,6 +311,17 @@ def discover_state(server, user, token, parent_key, expected_children, config):
                 continue
             child_id = hit_ids[0]
             if child_id in state.phase2_done:
+                continue
+            # Title guard: a quarantine-cleared parent re-split with a
+            # DIFFERENT decomposition legitimately reuses local ids — the
+            # stale child from the abandoned attempt must not be adopted
+            # for new scope it does not contain.
+            if hit.get("fields", {}).get("summary", "") != title_by_id.get(child_id):
+                print(
+                    f"  Warning: {hit['key']} carries the marker for {child_id} but "
+                    f"its title does not match the expected child — not adopting it",
+                    file=sys.stderr,
+                )
                 continue
             linked = any(
                 link.get("type", {}).get("name") == "Work item split"
@@ -388,6 +425,17 @@ def phase2_create_link(
                 f"  Phase 2: Child {child_id} ({idx}/{total}) found as {child_key} "
                 f"(linked: {done['linked']}, confirmed: {done['commented']}) — completing"
             )
+            if dry_run:
+                # Discovery runs whenever credentials exist, dry run or not —
+                # completing here would write to Jira during a run the caller
+                # expects to be read-only (caught in review).
+                if not done["linked"]:
+                    print(f"           Would link {child_key} to {parent_key}")
+                if not done["commented"]:
+                    print(f"           Would post confirmation for {child_key}")
+                done["linked"] = True
+                done["commented"] = True
+                continue
             if not done["linked"]:
                 create_issue_link(server, user, token, "Work item split", parent_key, child_key)
                 print(f"           Linked {child_key} to {parent_key}")
@@ -418,7 +466,7 @@ def phase2_create_link(
         labels = [
             f"{label_prefix}-auto-created",
             f"{label_prefix}-split-result",
-            _child_marker_label(label_prefix, child_id),
+            _child_marker_label(label_prefix, parent_key, child_id),
         ]
 
         review_path = find_review(artifacts_dir, child_id)
@@ -799,13 +847,19 @@ def main():
     phase3_close(server, user, token, args.parent_key, children, state, config, args.dry_run)
     print()
 
-    # Post-submit: update frontmatter and rename files
+    # Post-submit: update frontmatter and rename files. Never under dry-run:
+    # recovery can adopt children with REAL keys (not the -DRY sentinel), and
+    # renaming local artifacts is a write the caller did not ask for.
     rename_fn = config["rename_fn"]
     project = config["project"]
     for child_id, title, priority, artifact_path in children:
         assigned = state.phase2_done.get(child_id)
         assigned_key = assigned["key"] if assigned else None
-        if not assigned_key or assigned_key == f"{project}-DRY":
+        if args.dry_run or not assigned_key or assigned_key == f"{project}-DRY":
+            continue
+        if assigned_key == child_id:
+            # Already renamed by a run that died between the rename and the
+            # index rebuild — nothing to do.
             continue
 
         rename_fn(args.artifacts_dir, child_id, assigned_key)

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -213,13 +213,21 @@ def _generate_reports(args):
         print(f"Warning: HTML report generation failed: {result.stderr}", file=sys.stderr)
 
 
-def _record_split_failure(server, user, token, parent_key, reason, error, args, cfg, parent_data):
+def _record_split_failure(
+    server, user, token, parent_key, reason, error, args, cfg, parent_data, quarantine=False
+):
     """Record a split that did not complete: review frontmatter, then Jira comment and label.
 
     Both halves are best-effort on purpose. The point of recording is to survive a failure, and
     an unguarded write here would replace the diagnosis with a traceback — the Jira calls raise
     under the failures most worth recording (expired token, unreachable instance), and the local
     write raises on a corrupt or read-only review file.
+
+    quarantine=True additionally labels the parent {label_prefix}-split-quarantine, which the
+    fetch hard filters exclude — a partially-applied split must not be silently re-attempted
+    by the nightly (each retry can mint duplicate children) until a human removes the label
+    (RHAIFIRST-570). Refusals stay un-quarantined: nothing was created, and a re-attempt after
+    the backlog changes is cheap and safe.
     """
     review_path = _find_review(args.artifacts_dir, parent_key, cfg)
     if review_path:
@@ -245,7 +253,10 @@ def _record_split_failure(server, user, token, parent_key, reason, error, args, 
             server, user, token, entry, {parent_key: parent_key}, args.dry_run, cfg
         )
         if not args.dry_run:
-            add_labels(server, user, token, parent_key, [f"{cfg['label_prefix']}-needs-attention"])
+            flag_labels = [f"{cfg['label_prefix']}-needs-attention"]
+            if quarantine:
+                flag_labels.append(f"{cfg['label_prefix']}-split-quarantine")
+            add_labels(server, user, token, parent_key, flag_labels)
     except Exception as e:
         print(
             f"  Warning: could not flag {parent_key} in Jira ({e}). Recorded locally.",
@@ -475,6 +486,7 @@ def main():
                     args,
                     cfg,
                     split_parent_data[parent_key],
+                    quarantine=True,
                 )
                 submit_errors.append(
                     (parent_key, f"split_submit exit {result.returncode} (may be partial)")

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -248,15 +248,25 @@ def _record_split_failure(
         "attn_reason": reason,
         "original_labels": parent_data.get("original_labels") or [],
     }
+    # The labels go FIRST and in their own try: the quarantine label is the
+    # load-bearing write — it is what stops the nightly from re-selecting a
+    # partially-applied parent — and it must not be lost to a failure in the
+    # advisory comment posting (CodeRabbit, CWE-703).
     try:
-        _post_needs_attention_comment(
-            server, user, token, entry, {parent_key: parent_key}, args.dry_run, cfg
-        )
         if not args.dry_run:
             flag_labels = [f"{cfg['label_prefix']}-needs-attention"]
             if quarantine:
                 flag_labels.append(f"{cfg['label_prefix']}-split-quarantine")
             add_labels(server, user, token, parent_key, flag_labels)
+    except Exception as e:
+        print(
+            f"  Warning: could not label {parent_key} in Jira ({e}). Recorded locally.",
+            file=sys.stderr,
+        )
+    try:
+        _post_needs_attention_comment(
+            server, user, token, entry, {parent_key: parent_key}, args.dry_run, cfg
+        )
     except Exception as e:
         print(
             f"  Warning: could not flag {parent_key} in Jira ({e}). Recorded locally.",

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -1031,6 +1031,8 @@ class TestBootstrapIntegration:
         r = self._run_bootstrap(results, art_dir, url)
         assert r.returncode == 0, r.stderr
         assert "walking back to 20260331-110000" in r.stderr
+        # The hard filter excludes quarantined split parents (RHAIFIRST-570).
+        assert "rfe-creator-split-quarantine" in r.stderr
         # The stage warning is evaluated against the report actually USED —
         # the walked-back one — not the empty tip (which has no stage field).
         assert "run report 20260331-110000 is report_stage: pre_submit" in r.stderr

--- a/tests/test_error_collect.py
+++ b/tests/test_error_collect.py
@@ -46,7 +46,9 @@ def _write_raw(path, content):
 def _write_review(workspace, subdir, item_id, id_field, error=None):
     fields = f"{id_field}: {item_id}\n"
     if error:
-        fields += f"error: {error}\n"
+        # Quote: production error values contain colons (split_failed: ...),
+        # which unquoted would parse as a nested YAML mapping.
+        fields += f"error: '{error}'\n"
     path = workspace / "artifacts" / subdir / f"{item_id}-review.md"
     _write_raw(str(path), f"---\n{fields}---\n")
 
@@ -179,12 +181,49 @@ class TestNoErrorsClearsRetryFile:
 class TestSplitErrorCleanup:
     """The --type must reach cleanup_partial_split, or children are orphaned."""
 
+    def test_split_submit_failed_does_not_clean_children(self, workspace):
+        """A split_submit failure may be PARTIALLY APPLIED in Jira — deleting
+        the local child files would orphan Jira twins that already exist
+        (RHAIFIRST-570). Only the agent-side split_failed class cleans."""
+        _rfe_task(workspace, "RHAIRFE-10", status="Archived")
+        _rfe_task(workspace, "RFE-011", parent_key="RHAIRFE-10")
+        _write_review(
+            workspace, "rfe-reviews", "RHAIRFE-10", "rfe_id", "split_submit_failed: exit 1"
+        )
+        _set_ids(workspace, "RHAIRFE-10")
+
+        _, stderr, rc = _run(workspace)
+        assert rc == 0, stderr
+        assert os.path.exists(workspace / "artifacts/rfe-tasks/RFE-011.md")
+
+    def test_split_refused_does_not_clean_children(self, workspace):
+        """A refusal created nothing in Jira; the local children are the
+        human-review material — cleanup would destroy it."""
+        _rfe_task(workspace, "RHAIRFE-10", status="Archived")
+        _rfe_task(workspace, "RFE-011", parent_key="RHAIRFE-10")
+        _write_review(
+            workspace,
+            "rfe-reviews",
+            "RHAIRFE-10",
+            "rfe_id",
+            "split_refused: too many leaf children",
+        )
+        _set_ids(workspace, "RHAIRFE-10")
+
+        _, stderr, rc = _run(workspace)
+        assert rc == 0, stderr
+        assert os.path.exists(workspace / "artifacts/rfe-tasks/RFE-011.md")
+
     def test_initiative_children_deleted(self, workspace):
         _init_task(workspace, "RHOAIENG-10", status="Archived")
         _init_task(workspace, "RHOAIENG-11", parent_key="RHOAIENG-10")
         _init_task(workspace, "RHOAIENG-12", parent_key="RHOAIENG-10")
         _write_review(
-            workspace, "initiative-reviews", "RHOAIENG-10", "initiative_id", "split failed"
+            workspace,
+            "initiative-reviews",
+            "RHOAIENG-10",
+            "initiative_id",
+            "split_failed: agent did not write split-status file",
         )
         _set_ids(workspace, "RHOAIENG-10")
 
@@ -197,7 +236,11 @@ class TestSplitErrorCleanup:
         _init_task(workspace, "RHOAIENG-20", status="Archived")
         _init_task(workspace, "RHOAIENG-21", parent_key="RHOAIENG-20")
         _write_review(
-            workspace, "initiative-reviews", "RHOAIENG-20", "initiative_id", "split failed"
+            workspace,
+            "initiative-reviews",
+            "RHOAIENG-20",
+            "initiative_id",
+            "split_failed: agent did not write split-status file",
         )
         _set_ids(workspace, "RHOAIENG-20")
 
@@ -209,7 +252,11 @@ class TestSplitErrorCleanup:
     def test_initiative_split_status_deleted(self, workspace):
         _init_task(workspace, "RHOAIENG-30")
         _write_review(
-            workspace, "initiative-reviews", "RHOAIENG-30", "initiative_id", "split failed"
+            workspace,
+            "initiative-reviews",
+            "RHOAIENG-30",
+            "initiative_id",
+            "split_failed: agent did not write split-status file",
         )
         status_file = workspace / "artifacts/initiative-reviews/RHOAIENG-30-split-status.yaml"
         _write_raw(str(status_file), "action: split\n")
@@ -223,7 +270,13 @@ class TestSplitErrorCleanup:
         """Regression guard: the default path must keep working unchanged."""
         _rfe_task(workspace, "RHAIRFE-10", status="Archived")
         _rfe_task(workspace, "RHAIRFE-11", parent_key="RHAIRFE-10")
-        _write_review(workspace, "rfe-reviews", "RHAIRFE-10", "rfe_id", "split failed")
+        _write_review(
+            workspace,
+            "rfe-reviews",
+            "RHAIRFE-10",
+            "rfe_id",
+            "split_failed: agent did not write split-status file",
+        )
         _set_ids(workspace, "RHAIRFE-10")
 
         _, stderr, rc = _run(workspace)

--- a/tests/test_snapshot_fetch_integration.py
+++ b/tests/test_snapshot_fetch_integration.py
@@ -133,6 +133,25 @@ class TestCmdFetchFirstRun:
         assert set(_read_ids(args.ids_file)) == {"RHAIRFE-1", "RHAIRFE-2"}
         assert _read_ids(args.changed_file) == []
 
+    def test_quarantined_parent_excluded(self, work_dirs, jira, monkeypatch, tmp_path):
+        """The split-quarantine label parks a partially-split parent: the
+        hard filter must exclude it from selection until a human clears the
+        label (RHAIFIRST-570)."""
+        jira.create("RHAIRFE-1", "Issue one", "Description one.")
+        jira.create(
+            "RHAIRFE-2",
+            "Failed split parent",
+            "Description two.",
+            labels=["rfe-creator-split-quarantine"],
+        )
+        _jira_env(monkeypatch, jira.url)
+        args = _fetch_args(tmp_path)
+
+        stdout = _run_fetch(args)
+
+        assert "TOTAL=1" in stdout
+        assert set(_read_ids(args.ids_file)) == {"RHAIRFE-1"}
+
     def test_snapshot_written(self, work_dirs, jira, monkeypatch, tmp_path):
         """Fetch writes snapshot directly to artifacts with hashes."""
         jira.create("RHAIRFE-1", "Issue one", "Content.")

--- a/tests/test_split_submit.py
+++ b/tests/test_split_submit.py
@@ -114,7 +114,10 @@ class TestSplitSummaryAdf:
     def test_produces_inline_cards(self):
         """Summary ADF uses inlineCard nodes for child keys."""
         state = SubmissionState()
-        state.phase2_done = {1: "RHAIRFE-100", 2: "RHAIRFE-101"}
+        state.phase2_done = {
+            "RFE-001": {"key": "RHAIRFE-100", "linked": True, "commented": True},
+            "RFE-002": {"key": "RHAIRFE-101", "linked": True, "commented": True},
+        }
         children = [
             ("RFE-001", "First child", "Major", "/fake/path1"),
             ("RFE-002", "Second child", "Major", "/fake/path2"),
@@ -139,7 +142,7 @@ class TestSplitSummaryAdf:
             para = item["content"][0]
             inline_card = para["content"][0]
             assert inline_card["type"] == "inlineCard"
-            expected_key = state.phase2_done[i + 1]
+            expected_key = state.phase2_done[children[i][0]]["key"]
             assert inline_card["attrs"]["url"] == f"https://jira.example.com/browse/{expected_key}"
 
     def test_strips_trailing_slash(self):
@@ -148,7 +151,7 @@ class TestSplitSummaryAdf:
 
         rfe_config = SPLIT_CONFIG["rfe"]
         state = SubmissionState()
-        state.phase2_done = {1: "RHAIRFE-100"}
+        state.phase2_done = {"RFE-001": {"key": "RHAIRFE-100", "linked": True, "commented": True}}
         children = [("RFE-001", "Child", "Major", "/fake/path")]
         adf = build_split_summary_adf("https://jira.example.com/", children, state, 1, rfe_config)
 

--- a/tests/test_split_submit_integration.py
+++ b/tests/test_split_submit_integration.py
@@ -21,7 +21,21 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 import split_submit
 from jira_utils import add_comment, get_comments, get_issue, text_to_adf_paragraph
-from split_submit import SPLIT_CONFIG, discover_state, phase1_persist, phase2_create_link
+from split_submit import (
+    SPLIT_CONFIG,
+    _child_fingerprint,
+    _child_marker_label,
+    discover_state,
+    phase1_persist,
+    phase2_create_link,
+)
+
+
+def _marker_for(art_dir, child_id, parent_key="RHAIRFE-1000"):
+    config = SPLIT_CONFIG["rfe"]
+    fp = _child_fingerprint(config, f"{art_dir}/rfe-tasks/{child_id}.md")
+    return _child_marker_label("rfe-creator", parent_key, child_id, fp)
+
 
 SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "split_submit.py")
 
@@ -124,6 +138,7 @@ class TestFullRun:
     def test_creates_links_confirms_and_closes(self, art_dir, jira):
         _setup_parent(jira, art_dir)
 
+        marker = _marker_for(art_dir, "RFE-001")
         r = _run_split(art_dir, jira.url)
         assert r.returncode == 0, r.stderr + r.stdout
 
@@ -131,7 +146,7 @@ class TestFullRun:
         assert len(created) == 2
         assert _split_links(jira.url, PARENT_KEY) == created
         # Marker labels present: the from-birth recovery signal.
-        marked = _search_keys(jira.url, "labels = rfe-creator-split-child-rhairfe-1000-rfe-001")
+        marked = _search_keys(jira.url, f'labels = "{marker}"')
         assert len(marked) == 1
         # Parent closed.
         issue = get_issue(jira.url, "admin", "admin", PARENT_KEY, ["status"])
@@ -216,6 +231,7 @@ class TestSiblingChangesBetweenRuns:
 
     def test_inserted_sibling_does_not_misalign(self, art_dir, jira, monkeypatch):
         children = _setup_parent(jira, art_dir)
+        marker_001 = _marker_for(art_dir, "RFE-001")
         # Die on the second create: child RFE-001 is fully done.
         config = SPLIT_CONFIG["rfe"]
         state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
@@ -247,10 +263,7 @@ class TestSiblingChangesBetweenRuns:
         assert r.returncode == 0, r.stderr + r.stdout
 
         # RFE-001 not duplicated; three children total, all linked.
-        assert (
-            len(_search_keys(jira.url, "labels = rfe-creator-split-child-rhairfe-1000-rfe-001"))
-            == 1
-        )
+        assert len(_search_keys(jira.url, f'labels = "{marker_001}"')) == 1
         created = _search_keys(jira.url, "labels = rfe-creator-split-result")
         assert len(created) == 3
         assert _split_links(jira.url, PARENT_KEY) == created
@@ -342,6 +355,42 @@ class TestStaleMarkerLabels:
             jira.url, "admin", "admin", PARENT_KEY, new_children, state, art_dir, config, False
         )
         # Fresh child created for the new scope; the stale one stays unlinked.
+        assert len(_search_keys(jira.url, "labels = rfe-creator-split-result")) == 2
+        assert len(_split_links(jira.url, PARENT_KEY)) == 1
+
+    def test_resplit_same_title_different_content_is_not_adopted(self, art_dir, jira, monkeypatch):
+        """A re-split can reuse the same parent, id AND title for different
+        scope — the title is too weak an identity (CodeRabbit on #169). The
+        content fingerprint in the marker label must reject the stale child."""
+        children = _setup_parent(jira, art_dir, child_ids=("RFE-001",))
+        config = SPLIT_CONFIG["rfe"]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
+        phase1_persist(jira.url, "admin", "admin", PARENT_KEY, children, state, config, False)
+
+        def dying(*a, **k):
+            raise RuntimeError("died before link")
+
+        monkeypatch.setattr(split_submit, "create_issue_link", dying)
+        with pytest.raises(RuntimeError):
+            phase2_create_link(
+                jira.url, "admin", "admin", PARENT_KEY, children, state, art_dir, config, False
+            )
+        monkeypatch.undo()
+
+        # Same id, same title — different body.
+        _write(
+            f"{art_dir}/rfe-tasks/RFE-001.md",
+            CHILD_TASK.format(child_id="RFE-001", title="Child RFE-001").replace(
+                "Content for RFE-001.", "Entirely different scope."
+            ),
+        )
+        new_children = [("RFE-001", "Child RFE-001", "Major", f"{art_dir}/rfe-tasks/RFE-001.md")]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, new_children, config)
+        assert "RFE-001" not in state.phase2_done, "stale child adopted despite content change"
+
+        phase2_create_link(
+            jira.url, "admin", "admin", PARENT_KEY, new_children, state, art_dir, config, False
+        )
         assert len(_search_keys(jira.url, "labels = rfe-creator-split-result")) == 2
         assert len(_split_links(jira.url, PARENT_KEY)) == 1
 

--- a/tests/test_split_submit_integration.py
+++ b/tests/test_split_submit_integration.py
@@ -12,6 +12,8 @@ import json
 import os
 import subprocess
 import sys
+import urllib.parse
+import urllib.request
 
 import pytest
 
@@ -100,8 +102,6 @@ def _run_split(art_dir, url):
 
 
 def _search_keys(url, jql):
-    import urllib.parse
-
     req = urllib.request.Request(
         f"{url}/rest/api/3/search/jql?jql={urllib.parse.quote(jql, safe='')}&fields=summary"
     )

--- a/tests/test_split_submit_integration.py
+++ b/tests/test_split_submit_integration.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Integration tests for split_submit.py recovery against the jira-emulator.
+
+The create-to-link window (RHAIFIRST-570): a process death between
+create_issue and the link/comment used to mint a child no future run could
+find, so the next run duplicated it. Recovery is now id-based (marker labels,
+id-bearing comments) instead of positional, so sibling changes between runs
+cannot misalign it either.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import split_submit
+from jira_utils import add_comment, get_comments, get_issue, text_to_adf_paragraph
+from split_submit import SPLIT_CONFIG, discover_state, phase1_persist, phase2_create_link
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "split_submit.py")
+
+PARENT_KEY = "RHAIRFE-1000"
+PARENT_DESC = "Original parent content."
+
+
+def _write(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+
+
+PARENT_TASK = f"""\
+---
+rfe_id: {PARENT_KEY}
+title: Parent RFE
+priority: Major
+status: Archived
+---
+
+## Problem Statement
+
+{PARENT_DESC}
+"""
+
+CHILD_TASK = """\
+---
+rfe_id: {child_id}
+title: {title}
+priority: Major
+status: Ready
+parent_key: RHAIRFE-1000
+---
+
+## Problem Statement
+
+Content for {child_id}.
+"""
+
+
+@pytest.fixture
+def art_dir(tmp_path):
+    for d in ["rfe-tasks", "rfe-reviews", "rfe-originals"]:
+        os.makedirs(tmp_path / d)
+    orig = os.getcwd()
+    os.chdir(tmp_path)
+    yield str(tmp_path)
+    os.chdir(orig)
+
+
+def _setup_parent(jira, art_dir, child_ids=("RFE-001", "RFE-002")):
+    """Archived parent + children task files, and the parent in Jira.
+
+    The original file matches the live description so the conflict check
+    passes, mirroring a real fetched parent.
+    """
+    jira.create(PARENT_KEY, "Parent RFE", PARENT_DESC)
+    _write(f"{art_dir}/rfe-tasks/{PARENT_KEY}.md", PARENT_TASK)
+    _write(f"{art_dir}/rfe-originals/{PARENT_KEY}.md", PARENT_DESC)
+    children = []
+    for cid in child_ids:
+        title = f"Child {cid}"
+        path = f"{art_dir}/rfe-tasks/{cid}.md"
+        _write(path, CHILD_TASK.format(child_id=cid, title=title))
+        children.append((cid, title, "Major", path))
+    return children
+
+
+def _run_split(art_dir, url):
+    env = {**os.environ, "JIRA_SERVER": url, "JIRA_USER": "admin", "JIRA_TOKEN": "admin"}
+    return subprocess.run(
+        [sys.executable, SCRIPT, PARENT_KEY, "--artifacts-dir", art_dir],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _search_keys(url, jql):
+    import urllib.parse
+
+    req = urllib.request.Request(
+        f"{url}/rest/api/3/search/jql?jql={urllib.parse.quote(jql, safe='')}&fields=summary"
+    )
+    with urllib.request.urlopen(req) as resp:
+        data = json.loads(resp.read())
+    return sorted(issue["key"] for issue in data.get("issues", []))
+
+
+def _split_links(url, parent_key):
+    issue = get_issue(url, "admin", "admin", parent_key, ["issuelinks"])
+    return sorted(
+        (link.get("outwardIssue") or link.get("inwardIssue"))["key"]
+        for link in issue["fields"].get("issuelinks", [])
+        if link.get("type", {}).get("name") == "Work item split"
+        and (link.get("outwardIssue") or link.get("inwardIssue"))
+    )
+
+
+class TestFullRun:
+    def test_creates_links_confirms_and_closes(self, art_dir, jira):
+        _setup_parent(jira, art_dir)
+
+        r = _run_split(art_dir, jira.url)
+        assert r.returncode == 0, r.stderr + r.stdout
+
+        created = _search_keys(jira.url, "labels = rfe-creator-split-result")
+        assert len(created) == 2
+        assert _split_links(jira.url, PARENT_KEY) == created
+        # Marker labels present: the from-birth recovery signal.
+        marked = _search_keys(jira.url, "labels = rfe-creator-split-child-rfe-001")
+        assert len(marked) == 1
+        # Parent closed.
+        issue = get_issue(jira.url, "admin", "admin", PARENT_KEY, ["status"])
+        assert issue["fields"]["status"]["statusCategory"]["key"] == "done"
+        # Artifacts renamed to the Jira keys.
+        assert not os.path.exists(f"{art_dir}/rfe-tasks/RFE-001.md")
+
+
+class TestCreateToLinkWindow:
+    """AC: a process killed between create_issue and the link/comment leaves
+    a child that the next run finds rather than duplicates."""
+
+    def _crash_run(self, art_dir, jira, children, patch_target, monkeypatch):
+        """Run phase 1+2 in-process with one call patched to die."""
+        config = SPLIT_CONFIG["rfe"]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
+        phase1_persist(jira.url, "admin", "admin", PARENT_KEY, children, state, config, False)
+
+        calls = {"n": 0}
+        original = getattr(split_submit, patch_target)
+
+        def dying(*a, **k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("process died in the window")
+            return original(*a, **k)
+
+        monkeypatch.setattr(split_submit, patch_target, dying)
+        with pytest.raises(RuntimeError):
+            phase2_create_link(
+                jira.url, "admin", "admin", PARENT_KEY, children, state, art_dir, config, False
+            )
+        monkeypatch.setattr(split_submit, patch_target, original)
+
+    def test_death_after_create_is_found_by_marker_label(self, art_dir, jira, monkeypatch):
+        """Death BEFORE the link and the comment: the marker label is the
+        only signal, and it exists from the instant the child does."""
+        children = _setup_parent(jira, art_dir)
+        self._crash_run(art_dir, jira, children, "create_issue_link", monkeypatch)
+
+        # One child exists in Jira, unlinked, unconfirmed — the old recovery
+        # could not see it and would have duplicated it.
+        assert len(_search_keys(jira.url, "labels = rfe-creator-split-result")) == 1
+        assert _split_links(jira.url, PARENT_KEY) == []
+
+        config = SPLIT_CONFIG["rfe"]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
+        assert "RFE-001" in state.phase2_done
+        assert state.phase2_done["RFE-001"]["linked"] is False
+
+        phase2_create_link(
+            jira.url, "admin", "admin", PARENT_KEY, children, state, art_dir, config, False
+        )
+        created = _search_keys(jira.url, "labels = rfe-creator-split-result")
+        assert len(created) == 2, "recovery duplicated the orphaned child"
+        assert _split_links(jira.url, PARENT_KEY) == created
+
+    def test_death_after_link_completes_the_confirmation(self, art_dir, jira, monkeypatch):
+        """Death between the link and the comment: found via the link, and
+        recovery posts the missing confirmation instead of skipping silently."""
+        children = _setup_parent(jira, art_dir)
+        self._crash_run(art_dir, jira, children, "add_comment", monkeypatch)
+
+        config = SPLIT_CONFIG["rfe"]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
+        assert state.phase2_done["RFE-001"]["linked"] is True
+        assert state.phase2_done["RFE-001"]["commented"] is False
+
+        phase2_create_link(
+            jira.url, "admin", "admin", PARENT_KEY, children, state, art_dir, config, False
+        )
+        assert len(_search_keys(jira.url, "labels = rfe-creator-split-result")) == 2
+        comments = get_comments(jira.url, "admin", "admin", PARENT_KEY)
+        confirmations = [
+            c for c in comments if "Created as" in split_submit._extract_adf_text(c.get("body", {}))
+        ]
+        assert len(confirmations) == 2
+
+
+class TestSiblingChangesBetweenRuns:
+    """AC: recovery no longer depends on child ordering."""
+
+    def test_inserted_sibling_does_not_misalign(self, art_dir, jira, monkeypatch):
+        children = _setup_parent(jira, art_dir)
+        # Die on the second create: child RFE-001 is fully done.
+        config = SPLIT_CONFIG["rfe"]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
+        phase1_persist(jira.url, "admin", "admin", PARENT_KEY, children, state, config, False)
+        original = split_submit.create_issue
+        calls = {"n": 0}
+
+        def dying(*a, **k):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("died before the second child")
+            return original(*a, **k)
+
+        monkeypatch.setattr(split_submit, "create_issue", dying)
+        with pytest.raises(RuntimeError):
+            phase2_create_link(
+                jira.url, "admin", "admin", PARENT_KEY, children, state, art_dir, config, False
+            )
+        monkeypatch.setattr(split_submit, "create_issue", original)
+
+        # Between runs: a new sibling that sorts FIRST, re-numbering every
+        # positional index — the shape that used to misalign recovery.
+        _write(
+            f"{art_dir}/rfe-tasks/RFE-000.md",
+            CHILD_TASK.format(child_id="RFE-000", title="Child RFE-000"),
+        )
+
+        r = _run_split(art_dir, jira.url)
+        assert r.returncode == 0, r.stderr + r.stdout
+
+        # RFE-001 not duplicated; three children total, all linked.
+        assert len(_search_keys(jira.url, "labels = rfe-creator-split-child-rfe-001")) == 1
+        created = _search_keys(jira.url, "labels = rfe-creator-split-result")
+        assert len(created) == 3
+        assert _split_links(jira.url, PARENT_KEY) == created
+
+
+class TestLegacyComments:
+    def test_positional_comments_still_map(self, art_dir, jira):
+        """Comments written before the id-based format map through the
+        current ordering, so in-flight legacy splits keep recovering."""
+        children = _setup_parent(jira, art_dir)
+        jira.create("RHAIRFE-77", "Child RFE-001", "Child one content.")
+        add_comment(
+            jira.url,
+            "admin",
+            "admin",
+            PARENT_KEY,
+            text_to_adf_paragraph("[RFE Creator] Split child 1 of 2: Child RFE-001"),
+        )
+        add_comment(
+            jira.url,
+            "admin",
+            "admin",
+            PARENT_KEY,
+            text_to_adf_paragraph(
+                "[RFE Creator] Created as RHAIRFE-77, linked to parent. (ref: child 1 of 2)"
+            ),
+        )
+
+        config = SPLIT_CONFIG["rfe"]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
+
+        assert state.phase1_done.get("RFE-001")
+        assert state.phase2_done["RFE-001"]["key"] == "RHAIRFE-77"
+        assert "RFE-002" not in state.phase2_done

--- a/tests/test_split_submit_integration.py
+++ b/tests/test_split_submit_integration.py
@@ -131,7 +131,7 @@ class TestFullRun:
         assert len(created) == 2
         assert _split_links(jira.url, PARENT_KEY) == created
         # Marker labels present: the from-birth recovery signal.
-        marked = _search_keys(jira.url, "labels = rfe-creator-split-child-rfe-001")
+        marked = _search_keys(jira.url, "labels = rfe-creator-split-child-rhairfe-1000-rfe-001")
         assert len(marked) == 1
         # Parent closed.
         issue = get_issue(jira.url, "admin", "admin", PARENT_KEY, ["status"])
@@ -247,10 +247,156 @@ class TestSiblingChangesBetweenRuns:
         assert r.returncode == 0, r.stderr + r.stdout
 
         # RFE-001 not duplicated; three children total, all linked.
-        assert len(_search_keys(jira.url, "labels = rfe-creator-split-child-rfe-001")) == 1
+        assert (
+            len(_search_keys(jira.url, "labels = rfe-creator-split-child-rhairfe-1000-rfe-001"))
+            == 1
+        )
         created = _search_keys(jira.url, "labels = rfe-creator-split-result")
         assert len(created) == 3
         assert _split_links(jira.url, PARENT_KEY) == created
+
+
+class TestStaleMarkerLabels:
+    """Marker labels persist forever and local ids recycle across workspaces —
+    adoption must be parent-scoped and title-guarded (review findings)."""
+
+    def test_fresh_split_does_not_adopt_another_parents_children(self, art_dir, jira, tmp_path):
+        """Run N split RHAIRFE-1000 -> children keep their marker labels.
+        Run N+1 (fresh workspace) splits RHAIRFE-2000 reusing local ids
+        RFE-001/RFE-002 — it must create ITS OWN children, not adopt run N's
+        (reproduced live against the id-only label scheme in review)."""
+        _setup_parent(jira, art_dir)
+        r = _run_split(art_dir, jira.url)
+        assert r.returncode == 0, r.stderr + r.stdout
+        run_n_children = _search_keys(jira.url, "labels = rfe-creator-split-result")
+        assert len(run_n_children) == 2
+
+        # Fresh workspace for a DIFFERENT parent, same local ids.
+        ws2 = tmp_path / "run-n-plus-1"
+        for d in ["rfe-tasks", "rfe-reviews", "rfe-originals"]:
+            os.makedirs(ws2 / d)
+        jira.create("RHAIRFE-2000", "Other parent", "Other content.")
+        _write(
+            str(ws2 / "rfe-tasks/RHAIRFE-2000.md"),
+            "---\nrfe_id: RHAIRFE-2000\ntitle: Other parent\n"
+            "priority: Major\nstatus: Archived\n---\n\nOther content.\n",
+        )
+        _write(str(ws2 / "rfe-originals/RHAIRFE-2000.md"), "Other content.")
+        for cid in ("RFE-001", "RFE-002"):
+            # Deliberately IDENTICAL titles to run N's children: the title
+            # guard must not be what saves us here — only the parent-scoped
+            # label keeps the search from seeing run N's children at all.
+            _write(
+                str(ws2 / f"rfe-tasks/{cid}.md"),
+                "---\nrfe_id: " + cid + "\ntitle: Child " + cid + "\n"
+                "priority: Major\nstatus: Ready\n"
+                "parent_key: RHAIRFE-2000\n---\n\nDifferent content.\n",
+            )
+
+        env = {**os.environ, "JIRA_SERVER": jira.url, "JIRA_USER": "admin", "JIRA_TOKEN": "admin"}
+        r = subprocess.run(
+            [sys.executable, SCRIPT, "RHAIRFE-2000", "--artifacts-dir", str(ws2)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert r.returncode == 0, r.stderr + r.stdout
+
+        # Four distinct children exist; run N's were not adopted or re-linked.
+        all_children = _search_keys(jira.url, "labels = rfe-creator-split-result")
+        assert len(all_children) == 4
+        assert set(_split_links(jira.url, "RHAIRFE-2000")).isdisjoint(run_n_children)
+
+    def test_resplit_with_new_decomposition_is_not_bound_to_stale_child(
+        self, art_dir, jira, monkeypatch
+    ):
+        """Same parent, quarantine cleared, re-split with DIFFERENT scope
+        reusing the same local id: the stale child carries the matching
+        marker label but the wrong title — the title guard must refuse it."""
+        children = _setup_parent(jira, art_dir, child_ids=("RFE-001",))
+        config = SPLIT_CONFIG["rfe"]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
+        phase1_persist(jira.url, "admin", "admin", PARENT_KEY, children, state, config, False)
+        original = split_submit.create_issue_link
+
+        def dying(*a, **k):
+            raise RuntimeError("died before link")
+
+        monkeypatch.setattr(split_submit, "create_issue_link", dying)
+        with pytest.raises(RuntimeError):
+            phase2_create_link(
+                jira.url, "admin", "admin", PARENT_KEY, children, state, art_dir, config, False
+            )
+        monkeypatch.setattr(split_submit, "create_issue_link", original)
+
+        # New decomposition: same local id, different title.
+        _write(
+            f"{art_dir}/rfe-tasks/RFE-001.md",
+            CHILD_TASK.format(child_id="RFE-001", title="Reworked scope"),
+        )
+        new_children = [("RFE-001", "Reworked scope", "Major", f"{art_dir}/rfe-tasks/RFE-001.md")]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, new_children, config)
+        assert "RFE-001" not in state.phase2_done, "stale child adopted despite title mismatch"
+
+        phase2_create_link(
+            jira.url, "admin", "admin", PARENT_KEY, new_children, state, art_dir, config, False
+        )
+        # Fresh child created for the new scope; the stale one stays unlinked.
+        assert len(_search_keys(jira.url, "labels = rfe-creator-split-result")) == 2
+        assert len(_split_links(jira.url, PARENT_KEY)) == 1
+
+    def test_dry_run_completion_writes_nothing(self, art_dir, jira, monkeypatch):
+        """Discovery runs whenever credentials exist. A dry run that finds a
+        partially-applied child must report what it WOULD complete — not
+        link, comment, or rename (review finding: write-under-dry-run)."""
+        children = _setup_parent(jira, art_dir, child_ids=("RFE-001",))
+        config = SPLIT_CONFIG["rfe"]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
+        phase1_persist(jira.url, "admin", "admin", PARENT_KEY, children, state, config, False)
+
+        def dying(*a, **k):
+            raise RuntimeError("died before link")
+
+        monkeypatch.setattr(split_submit, "create_issue_link", dying)
+        with pytest.raises(RuntimeError):
+            phase2_create_link(
+                jira.url, "admin", "admin", PARENT_KEY, children, state, art_dir, config, False
+            )
+        monkeypatch.undo()
+
+        comments_before = len(get_comments(jira.url, "admin", "admin", PARENT_KEY))
+
+        env = {**os.environ, "JIRA_SERVER": jira.url, "JIRA_USER": "admin", "JIRA_TOKEN": "admin"}
+        r = subprocess.run(
+            [sys.executable, SCRIPT, PARENT_KEY, "--dry-run", "--artifacts-dir", art_dir],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert r.returncode == 0, r.stderr + r.stdout
+        assert "Would link" in r.stdout
+
+        assert _split_links(jira.url, PARENT_KEY) == []
+        assert len(get_comments(jira.url, "admin", "admin", PARENT_KEY)) == comments_before
+        assert os.path.exists(f"{art_dir}/rfe-tasks/RFE-001.md"), "dry run renamed artifacts"
+
+
+class TestRerunIsANoOp:
+    def test_second_run_after_success_changes_nothing(self, art_dir, jira):
+        """After the rename loop, children are listed under their Jira keys:
+        the confirmation comments must still map (via the created key), or a
+        resume re-posts archival comments and re-adopts children."""
+        _setup_parent(jira, art_dir)
+        r = _run_split(art_dir, jira.url)
+        assert r.returncode == 0, r.stderr + r.stdout
+        comments_after_first = len(get_comments(jira.url, "admin", "admin", PARENT_KEY))
+        children_after_first = _search_keys(jira.url, "labels = rfe-creator-split-result")
+
+        r = _run_split(art_dir, jira.url)
+        assert r.returncode == 0, r.stderr + r.stdout
+
+        assert len(get_comments(jira.url, "admin", "admin", PARENT_KEY)) == comments_after_first
+        assert _search_keys(jira.url, "labels = rfe-creator-split-result") == children_after_first
 
 
 class TestLegacyComments:
@@ -282,3 +428,25 @@ class TestLegacyComments:
         assert state.phase1_done.get("RFE-001")
         assert state.phase2_done["RFE-001"]["key"] == "RHAIRFE-77"
         assert "RFE-002" not in state.phase2_done
+
+    def test_positional_comments_ignored_when_the_set_shrank(self, art_dir, jira):
+        """A legacy comment recorded '1 of 2'; the decomposition was revised
+        to ONE child. Positional mapping through the new ordering would bind
+        the old ticket to different content — the total mismatch must make
+        the comment inert instead (review finding)."""
+        children = _setup_parent(jira, art_dir, child_ids=("RFE-001",))
+        jira.create("RHAIRFE-77", "Old child A", "Old content.")
+        add_comment(
+            jira.url,
+            "admin",
+            "admin",
+            PARENT_KEY,
+            text_to_adf_paragraph(
+                "[RFE Creator] Created as RHAIRFE-77, linked to parent. (ref: child 1 of 2)"
+            ),
+        )
+
+        config = SPLIT_CONFIG["rfe"]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
+
+        assert "RFE-001" not in state.phase2_done

--- a/tests/test_split_submit_integration.py
+++ b/tests/test_split_submit_integration.py
@@ -453,7 +453,12 @@ class TestLegacyComments:
         """Comments written before the id-based format map through the
         current ordering, so in-flight legacy splits keep recovering."""
         children = _setup_parent(jira, art_dir)
-        jira.create("RHAIRFE-77", "Child RFE-001", "Child one content.")
+        # The live child's content must match the artifact — legacy adoption
+        # goes through the same content guard as everything else now.
+        from artifact_utils import parse_child_artifact
+
+        _, _, _, cleaned = parse_child_artifact(f"{art_dir}/rfe-tasks/RFE-001.md")
+        jira.create("RHAIRFE-77", "Child RFE-001", cleaned)
         add_comment(
             jira.url,
             "admin",
@@ -477,6 +482,57 @@ class TestLegacyComments:
         assert state.phase1_done.get("RFE-001")
         assert state.phase2_done["RFE-001"]["key"] == "RHAIRFE-77"
         assert "RFE-002" not in state.phase2_done
+
+    def test_confirmed_child_with_changed_content_is_not_adopted(self, art_dir, jira):
+        """The confirmation comment was the one adoption path with no
+        content check: a cross-run re-split silently bound attempt 1's
+        confirmed child into attempt 2's decomposition. One GET per
+        comment-adopted child closes it."""
+        children = _setup_parent(jira, art_dir, child_ids=("RFE-001",))
+        config = SPLIT_CONFIG["rfe"]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
+        phase1_persist(jira.url, "admin", "admin", PARENT_KEY, children, state, config, False)
+        phase2_create_link(
+            jira.url, "admin", "admin", PARENT_KEY, children, state, art_dir, config, False
+        )
+        assert state.phase2_done["RFE-001"]["commented"] is True
+
+        # Attempt 2: same id, same title, different body.
+        _write(
+            f"{art_dir}/rfe-tasks/RFE-001.md",
+            CHILD_TASK.format(child_id="RFE-001", title="Child RFE-001").replace(
+                "Content for RFE-001.", "Entirely different scope."
+            ),
+        )
+        new_children = [("RFE-001", "Child RFE-001", "Major", f"{art_dir}/rfe-tasks/RFE-001.md")]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, new_children, config)
+        assert "RFE-001" not in state.phase2_done, (
+            "confirmed stale child adopted despite content change"
+        )
+
+        phase2_create_link(
+            jira.url, "admin", "admin", PARENT_KEY, new_children, state, art_dir, config, False
+        )
+        assert len(_search_keys(jira.url, "labels = rfe-creator-split-result")) == 2
+
+    def test_confirmed_child_with_matching_content_is_adopted(self, art_dir, jira):
+        """The guard must not break the resume that matters: identical
+        artifact -> adoption, no duplicate, no re-confirmation."""
+        children = _setup_parent(jira, art_dir, child_ids=("RFE-001",))
+        config = SPLIT_CONFIG["rfe"]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
+        phase1_persist(jira.url, "admin", "admin", PARENT_KEY, children, state, config, False)
+        phase2_create_link(
+            jira.url, "admin", "admin", PARENT_KEY, children, state, art_dir, config, False
+        )
+
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
+        assert state.phase2_done["RFE-001"]["commented"] is True
+
+        phase2_create_link(
+            jira.url, "admin", "admin", PARENT_KEY, children, state, art_dir, config, False
+        )
+        assert len(_search_keys(jira.url, "labels = rfe-creator-split-result")) == 1
 
     def test_positional_comments_ignored_when_the_set_shrank(self, art_dir, jira):
         """A legacy comment recorded '1 of 2'; the decomposition was revised

--- a/tests/test_split_submit_integration.py
+++ b/tests/test_split_submit_integration.py
@@ -481,6 +481,9 @@ class TestLegacyComments:
 
         assert state.phase1_done.get("RFE-001")
         assert state.phase2_done["RFE-001"]["key"] == "RHAIRFE-77"
+        # The fixture never created the link: linked is DERIVED from the
+        # live issue, not assumed from the comment — phase 2 heals it.
+        assert state.phase2_done["RFE-001"]["linked"] is False
         assert "RFE-002" not in state.phase2_done
 
     def test_confirmed_child_with_changed_content_is_not_adopted(self, art_dir, jira):
@@ -533,6 +536,31 @@ class TestLegacyComments:
             jira.url, "admin", "admin", PARENT_KEY, children, state, art_dir, config, False
         )
         assert len(_search_keys(jira.url, "labels = rfe-creator-split-result")) == 1
+
+    def test_forged_confirmation_with_wrong_title_is_refused(self, art_dir, jira):
+        """A confirmation comment can be written by anyone who can comment
+        on the parent (CodeRabbit, CWE-345): a referenced issue must also
+        match the expected title, not just the description."""
+        children = _setup_parent(jira, art_dir, child_ids=("RFE-001",))
+        from artifact_utils import parse_child_artifact
+
+        _, _, _, cleaned = parse_child_artifact(f"{art_dir}/rfe-tasks/RFE-001.md")
+        # Same description, different title.
+        jira.create("RHAIRFE-666", "Totally unrelated ticket", cleaned)
+        add_comment(
+            jira.url,
+            "admin",
+            "admin",
+            PARENT_KEY,
+            text_to_adf_paragraph(
+                "[RFE Creator] Created as RHAIRFE-666 for RFE-001, linked to parent. (1 of 1)"
+            ),
+        )
+
+        config = SPLIT_CONFIG["rfe"]
+        state = discover_state(jira.url, "admin", "admin", PARENT_KEY, children, config)
+
+        assert "RFE-001" not in state.phase2_done
 
     def test_positional_comments_ignored_when_the_set_shrank(self, art_dir, jira):
         """A legacy comment recorded '1 of 2'; the decomposition was revised

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -1007,3 +1007,41 @@ class TestSplitFailureIsRecorded:
         assert os.path.exists(yaml_path), (
             "the failure took the run report with it — the successes before it are unrecorded"
         )
+
+
+class TestRecordSplitFailureResilience:
+    """The quarantine label is the load-bearing write — it must land even
+    when the advisory needs-attention comment fails (CodeRabbit on #169)."""
+
+    def test_quarantine_label_survives_comment_failure(self, monkeypatch, tmp_path):
+        from types import SimpleNamespace
+
+        import submit as submit_mod
+
+        added = []
+        monkeypatch.setattr(
+            submit_mod, "add_labels", lambda srv, u, t, key, labels: added.extend(labels)
+        )
+
+        def boom(*a, **k):
+            raise RuntimeError("comment rejected")
+
+        monkeypatch.setattr(submit_mod, "_post_needs_attention_comment", boom)
+
+        args = SimpleNamespace(artifacts_dir=str(tmp_path), dry_run=False)
+        cfg = submit_mod.TYPE_CONFIGS["rfe"]
+        submit_mod._record_split_failure(
+            "https://x",
+            "u",
+            "t",
+            "RHAIRFE-1",
+            "reason",
+            "split_submit_failed: exit 4",
+            args,
+            cfg,
+            {"original_labels": []},
+            quarantine=True,
+        )
+
+        assert "rfe-creator-split-quarantine" in added
+        assert "rfe-creator-needs-attention" in added

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -717,6 +717,77 @@ class TestSnapshotUpdate:
         assert data["issues"] == {"RHAIRFE-1234": "existing"}
 
 
+class TestSplitQuarantine:
+    """A parent whose split failed partway must not be silently re-attempted
+    by the nightly (RHAIFIRST-570): submit.py labels it split-quarantine,
+    which the fetch hard filters exclude until a human removes it."""
+
+    PARENT_TASK = (
+        "---\nrfe_id: RHAIRFE-1000\ntitle: Parent RFE\n"
+        "priority: Major\nstatus: Archived\n---\n\nOriginal content.\n"
+    )
+    PARENT_REVIEW = (
+        "---\nrfe_id: RHAIRFE-1000\nscore: 6\npass: false\n"
+        "recommendation: split\nfeasibility: feasible\n"
+        "auto_revised: false\nneeds_attention: false\n"
+        "scores:\n  what: 2\n  why: 1\n  open_to_how: 2\n"
+        "  not_a_task: 1\n  right_sized: 0\n---\n\nToo big.\n"
+    )
+
+    def _labels(self, jira, key):
+        issue = None
+        import urllib.request as _rq
+
+        req = _rq.Request(f"{jira.url}/rest/api/3/issue/{key}?fields=labels")
+        with _rq.urlopen(req) as resp:
+            issue = json.loads(resp.read())
+        return set(issue["fields"].get("labels", []))
+
+    def test_generic_split_failure_quarantines_the_parent(self, art_dir, jira):
+        """An archived intermediary child with no leaves: submit detects the
+        split parent, but split_submit collects zero leaf children and exits
+        1 — the generic, possibly-partially-applied class."""
+        jira.create("RHAIRFE-1000", "Parent RFE", "Original content.")
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1000.md", "Original content.")
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md", self.PARENT_REVIEW)
+        _write(
+            f"{art_dir}/rfe-tasks/RFE-001.md",
+            "---\nrfe_id: RFE-001\ntitle: Dead-end intermediary\n"
+            "priority: Major\nstatus: Archived\n"
+            "parent_key: RHAIRFE-1000\n---\n\nChild content.\n",
+        )
+
+        r = _run_submit(art_dir, jira.url)
+        assert r.returncode == 1
+
+        labels = self._labels(jira, "RHAIRFE-1000")
+        assert "rfe-creator-split-quarantine" in labels, r.stdout + r.stderr
+        assert "rfe-creator-needs-attention" in labels
+
+    def test_refusal_is_not_quarantined(self, art_dir, jira):
+        """The leaf-cap refusal created nothing in Jira: flagged for a human,
+        but a later re-attempt is cheap and safe — no quarantine."""
+        jira.create("RHAIRFE-1000", "Parent RFE", "Original content.")
+        _write(f"{art_dir}/rfe-originals/RHAIRFE-1000.md", "Original content.")
+        _write(f"{art_dir}/rfe-tasks/RHAIRFE-1000.md", self.PARENT_TASK)
+        _write(f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md", self.PARENT_REVIEW)
+        for n in range(1, 9):  # 8 children > MAX_LEAF_CHILDREN
+            _write(
+                f"{art_dir}/rfe-tasks/RFE-{n:03d}.md",
+                f"---\nrfe_id: RFE-{n:03d}\ntitle: Child {n}\n"
+                "priority: Major\nstatus: Ready\n"
+                "parent_key: RHAIRFE-1000\n---\n\nChild content.\n",
+            )
+
+        r = _run_submit(art_dir, jira.url)
+        assert r.returncode == 0, r.stderr
+
+        labels = self._labels(jira, "RHAIRFE-1000")
+        assert "rfe-creator-split-quarantine" not in labels
+        assert "rfe-creator-needs-attention" in labels
+
+
 class TestSplitConflictDetection:
     """Integration test: split_submit.py detects parent conflict."""
 


### PR DESCRIPTION
Implements RHAIFIRST-570 — prerequisite for RHAIFIRST-571 (continue-past-per-parent-failure), which would otherwise exercise the duplication window on every nightly retry.

## The window

`split_submit` creates a child, then links it, then posts the confirmation comment; recovery (`discover_state`) could only see a child through that comment or a title-exact link. A death between `create_issue` and either signal minted a Jira ticket **no future run could find** — the next run duplicated it. And recovery keyed on the child's *position* in the list, so sibling changes between runs silently misaligned it. (Zero orphans measured in the published corpus to date; the risk activates with 571.)

## Changes

- **Marker label at creation** — `{prefix}-split-child-{parent}-{local_id}`: a recovery signal that exists from the instant the child does. `discover_state` gains a project-scoped JQL search over these labels for children the comment/link signals cannot see. Adoption is **parent-scoped and title-guarded**: local ids are workspace-scoped and restart at 001 every CI run while labels persist forever, so an id-only label would let a fresh split adopt a *different parent's* stale children (reproduced live in review — linked to the wrong parent, closed it, real scope never submitted, exit 0). The title guard covers the residual collision parent scoping can't express: the same parent re-split with a different decomposition reusing the same ids.
- **Id-keyed recovery state** — archival and confirmation comments carry the child id; legacy positional comments still map, but only when the child count they recorded matches the current set (a shrunk decomposition would otherwise bind the old ticket to different content). Confirmation comments also map through the created key, so a resume after a death in the rename loop is a no-op instead of re-posting comments.
- **Partial completion** — phase 2 finishes a created-but-unlinked or linked-but-unconfirmed child instead of only skipping fully-done ones; under `--dry-run` it reports what it *would* complete without writing (the completion branch initially wrote during dry-run — caught in review — and the rename loop now also honors the flag, since adopted children carry real keys, not the `-DRY` sentinel).
- **Quarantine** — a generic split failure (`split_submit_failed:`) labels the parent `{prefix}-split-quarantine`; both fetch hard filters exclude it until a human removes the label. Its snapshot entry stays `processed: false`, so the nightly would otherwise re-select it forever, each retry able to mint duplicates. Refusals (leaf cap, conflict) are exempt: they created nothing and stay cheap to re-attempt.
- **Taxonomy (AC #4)** — `error_collect`'s cleanup trigger tightens from the substring `"split"` to the `split_failed` prefix allow-list: `split_submit_failed:` may be *partially applied* in Jira and `cleanup_partial_split` would delete local child files whose Jira twins already exist. Bonus: the old substring test masked a YAML bug in the test helper (unquoted `error:` values with colons parse as nested mappings).
- One emulator-vs-reality note: the jira-emulator renders parent→child links inverted (`inwardIssue` where real Jira shows `outwardIssue`); link discovery tolerates both ends behind the expected-title guard.

## Review + verification

An adversarial multi-agent review of the first commit confirmed 8 findings (7 refuted), including two majors fixed in the second commit with live emulator reproductions: the cross-parent adoption above, and the dry-run writes. One confirmed finding is deliberately deferred to 571 where it's an AC: the run report counts a crashed split as a successful `split` (571's report-truth work fixes the counting *and* the HTML refused-vs-failed distinction together).

- 882 tests; new integration suite runs the real script and phases against the jira-emulator: both kill-in-window shapes recover without duplicating, cross-parent adoption with identical titles is refused, a re-split with new scope is not bound to the stale child, dry-run completion writes nothing, legacy comments map (and go inert on total mismatch), a full-success re-run changes nothing, quarantine lands on generic failures only, and a quarantined issue is excluded from fetch selection.
- 11 mutations, each killed by a named test (marker label creation and parent scoping, label search, title guard, partial completion, dry-run guard, legacy total-match, created-key remap, quarantine label + refusal exemption, fetch JQL exclusion).
- `docs/snapshot-incremental-fetch.md` hard-filters and label table updated; snapshot invariants untouched (quarantine is selection-side only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added split recovery that prevents duplicate child items after interruptions and supports safer reruns.
  * Added content validation to prevent stale child items from being reused during recovery.
  * Added quarantine handling for partially failed splits, preventing affected parent items from being selected again automatically.
* **Bug Fixes**
  * Limited split-artifact cleanup to confirmed split failures.
  * Improved recovery when child items are reordered or only partially created.
* **Documentation**
  * Updated hard-filter guidance and examples to include quarantined split parents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->