### PR TITLE
Continue past a per-parent split failure, abort fast on a systemic one

### DIFF
--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -109,7 +109,13 @@ def _load_run_report(results_dir, run_name, config=None):
                 f"run report {path} has malformed {item_key} entries: "
                 f"expected a mapping, got {type(entry).__name__}"
             )
-        if "error" in entry:
+        if "error" in entry or "failed_reason" in entry or "blocked_reason" in entry:
+            # None of these were disposed of: error entries could not even be
+            # reported on; failed_reason marks a crashed or never-attempted
+            # split; blocked_reason a refusal. The live snapshot leaves all
+            # of them processed:false — bootstrap recovery must agree, or a
+            # quarantine-cleared parent bootstrapped from this report would
+            # be frozen at processed:true (review finding, RHAIFIRST-571).
             continue
         try:
             ids.add(entry["id"])

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -109,6 +109,17 @@ def _load_run_report(results_dir, run_name, config=None):
                 f"run report {path} has malformed {item_key} entries: "
                 f"expected a mapping, got {type(entry).__name__}"
             )
+        try:
+            # Validate BEFORE the outcome-key skip: an id-less or unhashable
+            # id is corrupt input whatever the entry's outcome, and skipping
+            # it silently would build a snapshot from an incomplete
+            # processed-id set instead of refusing (CodeRabbit, CWE-20).
+            # TypeError included: an unhashable id ({} / []) must follow the
+            # same malformed-report path as a missing one.
+            entry_id = entry["id"]
+            hash(entry_id)
+        except (KeyError, TypeError) as e:
+            raise ValueError(f"run report {path} has malformed {item_key} entries: {e}") from e
         if "error" in entry or "failed_reason" in entry or "blocked_reason" in entry:
             # None of these were disposed of: error entries could not even be
             # reported on; failed_reason marks a crashed or never-attempted
@@ -117,13 +128,7 @@ def _load_run_report(results_dir, run_name, config=None):
             # quarantine-cleared parent bootstrapped from this report would
             # be frozen at processed:true (review finding, RHAIFIRST-571).
             continue
-        try:
-            ids.add(entry["id"])
-        except (KeyError, TypeError) as e:
-            # TypeError included: an unhashable id ({} / []) must follow the
-            # same malformed-report path as a missing one, not escape as a
-            # traceback past main's ValueError handling.
-            raise ValueError(f"run report {path} has malformed {item_key} entries: {e}") from e
+        ids.add(entry_id)
     return ids, report
 
 

--- a/scripts/error_collect.py
+++ b/scripts/error_collect.py
@@ -148,7 +148,7 @@ def main():
     # split_submit_failed: may be PARTIALLY APPLIED in Jira — its parent is
     # quarantined (RHAIFIRST-570) and an automated retry could mint
     # duplicate children. Both remain in the error history above.
-    non_retryable = ("split_refused:", "split_submit_failed:")
+    non_retryable = ("split_refused:", "split_submit_failed:", "split_not_attempted:")
     retryable_ids = [
         rfe_id
         for rfe_id in error_ids

--- a/scripts/error_collect.py
+++ b/scripts/error_collect.py
@@ -143,11 +143,32 @@ def main():
     with open(RETRY_ERRORS_FILE, "w") as f:
         yaml.dump(error_details, f, default_flow_style=False, sort_keys=False)
 
+    # Non-retryable classes stay OUT of the retry batch (RHAIFIRST-571):
+    # split_refused: is routed to a human (RHAIFIRST-562), and
+    # split_submit_failed: may be PARTIALLY APPLIED in Jira — its parent is
+    # quarantined (RHAIFIRST-570) and an automated retry could mint
+    # duplicate children. Both remain in the error history above.
+    non_retryable = ("split_refused:", "split_submit_failed:")
+    retryable_ids = [
+        rfe_id
+        for rfe_id in error_ids
+        if not str(error_details.get(rfe_id, {}).get("error", "")).startswith(non_retryable)
+    ]
+    excluded = [rfe_id for rfe_id in error_ids if rfe_id not in retryable_ids]
+    if excluded:
+        print(f"ERROR_COLLECT: excluded from retry (non-retryable): {', '.join(excluded)}")
+    if not retryable_ids:
+        # Same contract as the zero-errors return above: a cleared file sends
+        # the ERROR_COLLECT transition to REPORT instead of a retry batch.
+        _write_ids(RETRY_IDS_FILE, [])
+        print("ERROR_COLLECT: no retryable error IDs found")
+        return
+
     # Step 4: Persist retry IDs
-    _write_ids(RETRY_IDS_FILE, error_ids)
+    _write_ids(RETRY_IDS_FILE, retryable_ids)
 
     # Step 5: Artifact cleanup
-    for rfe_id in error_ids:
+    for rfe_id in retryable_ids:
         err = error_details.get(rfe_id, {}).get("error", "")
         is_revise_error = "revise" in str(err).lower()
         # Prefix allow-list, not a substring test: split_refused: (nothing
@@ -217,7 +238,7 @@ def main():
 
     # Step 6: Post-cleanup verification
     warnings = []
-    for rfe_id in error_ids:
+    for rfe_id in retryable_ids:
         for path in [
             f"tmp/rfe-assess/single/{rfe_id}.result.md",
             f"{tc['reviews_dir']}/{rfe_id}-review.md",
@@ -242,9 +263,12 @@ def main():
         state["retry_batch"] = retry_batch
         state["total_batches"] = retry_batch
         _save_state(state)
-    _write_ids(f"tmp/pipeline-batch-{retry_batch}-ids.txt", error_ids)
+    _write_ids(f"tmp/pipeline-batch-{retry_batch}-ids.txt", retryable_ids)
 
-    print(f"ERROR_COLLECT: retry batch with {len(error_ids)} error IDs [{', '.join(error_ids)}]")
+    print(
+        f"ERROR_COLLECT: retry batch with {len(retryable_ids)} error IDs "
+        f"[{', '.join(retryable_ids)}]"
+    )
     for rfe_id, details in error_details.items():
         print(f"  {rfe_id}: {details.get('error', 'unknown')}")
 

--- a/scripts/generate_review_pdf.py
+++ b/scripts/generate_review_pdf.py
@@ -278,6 +278,17 @@ def diff_to_html(diff_text):
     return "\n".join(html_parts)
 
 
+def _is_split_refusal(err):
+    """Refusal (nothing reached Jira) vs crash/abort (may be partially applied).
+
+    split_submit_failed:* and split_not_attempted:* are NOT refusals — their
+    children may exist in Jira (or the parent will simply be retried), and
+    rendering them as "Refused — Not Submitted" misstates both
+    (RHAIFIRST-571).
+    """
+    return bool(err) and not str(err).startswith(("split_submit_failed:", "split_not_attempted:"))
+
+
 def badge(passed, error=None, tooltip=None):
     if error:
         tip = tooltip or str(error)
@@ -512,14 +523,11 @@ def main():
     # submission (split_submit_failed:*) is different — it may be partially
     # applied and its real children must not be dropped from the submitted
     # stats or rendered as a refusal (RHAIFIRST-571).
-    def _is_refusal(err):
-        return bool(err) and not str(err).startswith("split_submit_failed:")
-
-    refused_parents = {sp["rfe_id"] for sp in split_parents if _is_refusal(sp.get("error"))}
+    refused_parents = {sp["rfe_id"] for sp in split_parents if _is_split_refusal(sp.get("error"))}
     failed_parents = {
         sp["rfe_id"]
         for sp in split_parents
-        if sp.get("error") and str(sp["error"]).startswith("split_submit_failed:")
+        if sp.get("error") and not _is_split_refusal(sp["error"])
     }
 
     def _has_refused_ancestor(r):
@@ -1619,7 +1627,7 @@ def main():
             <td class="key-col"><a href="#{r["rfe_id"]}">{html_escape(r["rfe_id"])}</a>{jira_ext(r["rfe_id"])} {badge(False, error=error, tooltip=tip)}</td>
             <td>{r["before_total"]}/10</td>
             <td>{badge(r["before_pass"])}</td>
-            <td colspan="2" style="font-size:8pt;color:#8b4513;font-weight:600;">&rarr; {len(leaves)} children (not submitted)</td>
+            <td colspan="2" style="font-size:8pt;color:#8b4513;font-weight:600;">&rarr; {len(leaves)} children ({"not submitted" if _is_split_refusal(error) else "may be partially submitted"})</td>
             <td>&mdash;</td>
             <td>{feas}</td>
             <td>&mdash;</td>
@@ -1972,7 +1980,7 @@ def main():
                 reason_text = f": {html_escape(attn_reason)}" if attn_reason else ""
                 html += f"""
             <div style="background:#fef3e6;border:2px solid #e67e22;border-radius:6pt;padding:12pt 16pt;margin-bottom:14pt;">
-                <div style="font-size:11pt;font-weight:700;color:#e67e22;margin-bottom:4pt;">&#x26A0; Split Refused &mdash; Not Submitted</div>
+                <div style="font-size:11pt;font-weight:700;color:#e67e22;margin-bottom:4pt;">&#x26A0; {"Split Refused &mdash; Not Submitted" if _is_split_refusal(split_error) else "Split Failed &mdash; May Be Partially Applied"}</div>
                 <div style="font-size:9pt;color:#8b4513;">{html_escape(str(split_error))}{reason_text}</div>
             </div>
 """
@@ -1989,7 +1997,7 @@ def main():
                     <div class="stat-box">
                         <div class="stat-label">Split Into</div>
                         <div class="stat-value">{len(leaves)}</div>
-                        <div class="stat-label">children{" (not submitted)" if split_error else ""}</div>
+                        <div class="stat-label">children{" (not submitted)" if _is_split_refusal(split_error) else (" (may be partial)" if split_error else "")}</div>
                     </div>
                     <div class="stat-box">
                         <div class="stat-label">Children Passing</div>

--- a/scripts/generate_review_pdf.py
+++ b/scripts/generate_review_pdf.py
@@ -278,15 +278,24 @@ def diff_to_html(diff_text):
     return "\n".join(html_parts)
 
 
-def _is_split_refusal(err):
-    """Refusal (nothing reached Jira) vs crash/abort (may be partially applied).
+def _split_outcome(err):
+    """Three-way split disposition, or None for a clean split.
 
-    split_submit_failed:* and split_not_attempted:* are NOT refusals — their
-    children may exist in Jira (or the parent will simply be retried), and
-    rendering them as "Refused — Not Submitted" misstates both
-    (RHAIFIRST-571).
+    'refused' (leaf cap / conflict — nothing reached Jira) and
+    'not_attempted' (skipped by a phase abort — nothing reached Jira
+    either) both exclude the children from submitted stats, but say
+    different things about WHY. 'failed' (split_submit crashed) is the
+    only one whose children may be partially applied in Jira — the
+    partial-application wording is reserved for it (RHAIFIRST-571).
     """
-    return bool(err) and not str(err).startswith(("split_submit_failed:", "split_not_attempted:"))
+    if not err:
+        return None
+    text = str(err)
+    if text.startswith("split_submit_failed:"):
+        return "failed"
+    if text.startswith("split_not_attempted:"):
+        return "not_attempted"
+    return "refused"
 
 
 def badge(passed, error=None, tooltip=None):
@@ -523,17 +532,23 @@ def main():
     # submission (split_submit_failed:*) is different — it may be partially
     # applied and its real children must not be dropped from the submitted
     # stats or rendered as a refusal (RHAIFIRST-571).
-    refused_parents = {sp["rfe_id"] for sp in split_parents if _is_split_refusal(sp.get("error"))}
-    failed_parents = {
-        sp["rfe_id"]
-        for sp in split_parents
-        if sp.get("error") and not _is_split_refusal(sp["error"])
+    refused_parents = {
+        sp["rfe_id"] for sp in split_parents if _split_outcome(sp.get("error")) == "refused"
     }
+    not_attempted_parents = {
+        sp["rfe_id"] for sp in split_parents if _split_outcome(sp.get("error")) == "not_attempted"
+    }
+    failed_parents = {
+        sp["rfe_id"] for sp in split_parents if _split_outcome(sp.get("error")) == "failed"
+    }
+    # Children of refused AND not-attempted parents were never submitted —
+    # both are excluded from submitted stats; only 'failed' children stay.
+    unsubmitted_parents = refused_parents | not_attempted_parents
 
     def _has_refused_ancestor(r):
         pk = r.get("parent_key")
         while pk:
-            if pk in refused_parents:
+            if pk in unsubmitted_parents:
                 return True
             parent = rfe_by_id.get(pk)
             pk = parent.get("parent_key") if parent else None
@@ -1627,7 +1642,7 @@ def main():
             <td class="key-col"><a href="#{r["rfe_id"]}">{html_escape(r["rfe_id"])}</a>{jira_ext(r["rfe_id"])} {badge(False, error=error, tooltip=tip)}</td>
             <td>{r["before_total"]}/10</td>
             <td>{badge(r["before_pass"])}</td>
-            <td colspan="2" style="font-size:8pt;color:#8b4513;font-weight:600;">&rarr; {len(leaves)} children ({"not submitted" if _is_split_refusal(error) else "may be partially submitted"})</td>
+            <td colspan="2" style="font-size:8pt;color:#8b4513;font-weight:600;">&rarr; {len(leaves)} children ({"may be partially submitted" if _split_outcome(error) == "failed" else "not submitted"})</td>
             <td>&mdash;</td>
             <td>{feas}</td>
             <td>&mdash;</td>
@@ -1723,6 +1738,14 @@ def main():
             else ""
         }\
 {
+            f'''            <div class="stat-box" style="border-color: #7f8c8d;">
+                <div class="stat-value" style="color: #7f8c8d;">{len(not_attempted_parents)}</div>
+                <div class="stat-label">Not Attempted</div>
+            </div>'''
+            if not_attempted_parents
+            else ""
+        }\
+{
             f'''
             <div class="stat-box" style="border-color: #f39c12;">
                 <div class="stat-value" style="color: #f39c12;">{sc_needs_attn}</div>
@@ -1749,6 +1772,8 @@ def main():
                 sp_header += f", {len(refused_parents)} refused"
             if failed_parents:
                 sp_header += f", {len(failed_parents)} failed"
+            if not_attempted_parents:
+                sp_header += f", {len(not_attempted_parents)} not attempted"
             sp_header += ")"
             html += f"""        <tr id="section-splits"><td colspan="8" style="background:#fff3e0;font-weight:700;font-size:9pt;padding:6pt 8pt;color:#e65100;">{sp_header}</td></tr>
 """
@@ -1978,9 +2003,14 @@ def main():
             if split_error:
                 attn_reason = r.get("needs_attention_reason", "")
                 reason_text = f": {html_escape(attn_reason)}" if attn_reason else ""
+                banner_text = {
+                    "refused": "Split Refused &mdash; Not Submitted",
+                    "not_attempted": "Split Not Attempted &mdash; Not Submitted",
+                    "failed": "Split Failed &mdash; May Be Partially Applied",
+                }[_split_outcome(split_error)]
                 html += f"""
             <div style="background:#fef3e6;border:2px solid #e67e22;border-radius:6pt;padding:12pt 16pt;margin-bottom:14pt;">
-                <div style="font-size:11pt;font-weight:700;color:#e67e22;margin-bottom:4pt;">&#x26A0; {"Split Refused &mdash; Not Submitted" if _is_split_refusal(split_error) else "Split Failed &mdash; May Be Partially Applied"}</div>
+                <div style="font-size:11pt;font-weight:700;color:#e67e22;margin-bottom:4pt;">&#x26A0; {banner_text}</div>
                 <div style="font-size:9pt;color:#8b4513;">{html_escape(str(split_error))}{reason_text}</div>
             </div>
 """
@@ -1997,7 +2027,7 @@ def main():
                     <div class="stat-box">
                         <div class="stat-label">Split Into</div>
                         <div class="stat-value">{len(leaves)}</div>
-                        <div class="stat-label">children{" (not submitted)" if _is_split_refusal(split_error) else (" (may be partial)" if split_error else "")}</div>
+                        <div class="stat-label">children{" (may be partial)" if _split_outcome(split_error) == "failed" else (" (not submitted)" if split_error else "")}</div>
                     </div>
                     <div class="stat-box">
                         <div class="stat-label">Children Passing</div>

--- a/scripts/generate_review_pdf.py
+++ b/scripts/generate_review_pdf.py
@@ -506,8 +506,21 @@ def main():
     for sp in split_parents:
         leaves_by_parent[sp["rfe_id"]] = get_leaf_descendants(sp["rfe_id"])
 
-    # Tag children of refused/errored split parents so stats exclude them
-    refused_parents = {sp["rfe_id"] for sp in split_parents if sp.get("error")}
+    # Tag children of REFUSED split parents so stats exclude them: a refusal
+    # (split_refused:*, and legacy agent-side split_failed:*) created nothing
+    # in Jira, so its children were genuinely not submitted. A CRASHED
+    # submission (split_submit_failed:*) is different — it may be partially
+    # applied and its real children must not be dropped from the submitted
+    # stats or rendered as a refusal (RHAIFIRST-571).
+    def _is_refusal(err):
+        return bool(err) and not str(err).startswith("split_submit_failed:")
+
+    refused_parents = {sp["rfe_id"] for sp in split_parents if _is_refusal(sp.get("error"))}
+    failed_parents = {
+        sp["rfe_id"]
+        for sp in split_parents
+        if sp.get("error") and str(sp["error"]).startswith("split_submit_failed:")
+    }
 
     def _has_refused_ancestor(r):
         pk = r.get("parent_key")
@@ -1694,6 +1707,14 @@ def main():
             else ""
         }\
 {
+            f'''            <div class="stat-box" style="border-color: #c0392b;">
+                <div class="stat-value" style="color: #c0392b;">{len(failed_parents)}</div>
+                <div class="stat-label">Failed Splits</div>
+            </div>'''
+            if failed_parents
+            else ""
+        }\
+{
             f'''
             <div class="stat-box" style="border-color: #f39c12;">
                 <div class="stat-value" style="color: #f39c12;">{sc_needs_attn}</div>
@@ -1713,12 +1734,13 @@ def main():
         html += table_header
 
         if split_parents:
-            sp_error_count = sum(1 for r in split_parents if r.get("error"))
             sp_header = (
                 f"Split {entities} ({len(split_parents)} &rarr; {sp_total_children} children"
             )
-            if sp_error_count:
-                sp_header += f", {sp_error_count} refused"
+            if refused_parents:
+                sp_header += f", {len(refused_parents)} refused"
+            if failed_parents:
+                sp_header += f", {len(failed_parents)} failed"
             sp_header += ")"
             html += f"""        <tr id="section-splits"><td colspan="8" style="background:#fff3e0;font-weight:700;font-size:9pt;padding:6pt 8pt;color:#e65100;">{sp_header}</td></tr>
 """

--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -75,6 +75,10 @@ REPORT_STAGES = ("pre_submit", "final")
 # Nothing was created in Jira, so the parent is blocked, not split.
 SPLIT_REFUSED_PREFIX = "split_refused:"
 
+# submit.py writes this marker when split_submit CRASHED partway (as opposed
+# to refusing before any Jira write): children and links may exist in Jira.
+SPLIT_FAILED_PREFIX = "split_submit_failed:"
+
 
 def split_children_map(artifacts_dir, config, tasks=None):
     """Map parent ID -> child IDs for split children found in the task dir.
@@ -309,12 +313,23 @@ def build_report(
         # cap lives in split_submit and refusal has more than one cause.
         review_error = data.get("error") or ""
         blocked_reason = None
+        failed_reason = None
         if review_error.startswith(SPLIT_REFUSED_PREFIX):
             blocked_reason = data.get("needs_attention_reason") or review_error
             entry["blocked_reason"] = blocked_reason
+        elif review_error.startswith(SPLIT_FAILED_PREFIX):
+            # A crashed split still carries recommendation: split — counting
+            # it as a successful split reported the crash as an outcome
+            # (RHAIFIRST-571). Not an `error` entry: the review is fully
+            # readable and the entry keeps its scores; failed_reason marks
+            # the disposition.
+            failed_reason = data.get("needs_attention_reason") or review_error
+            entry["failed_reason"] = failed_reason
 
         if blocked_reason:
             counts["blocked"] += 1
+        elif failed_reason:
+            counts["failed"] += 1
         elif rec == "split":
             counts["split"] += 1
         elif data.get("pass", False):

--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -79,6 +79,12 @@ SPLIT_REFUSED_PREFIX = "split_refused:"
 # to refusing before any Jira write): children and links may exist in Jira.
 SPLIT_FAILED_PREFIX = "split_submit_failed:"
 
+# submit.py writes this LOCAL-ONLY marker on split parents a phase abort
+# skipped (systemic failure, circuit breaker, dead preflight): nothing was
+# attempted in Jira, but counting them as successful splits would report an
+# abort as an outcome.
+SPLIT_NOT_ATTEMPTED_PREFIX = "split_not_attempted:"
+
 
 def split_children_map(artifacts_dir, config, tasks=None):
     """Map parent ID -> child IDs for split children found in the task dir.
@@ -317,7 +323,7 @@ def build_report(
         if review_error.startswith(SPLIT_REFUSED_PREFIX):
             blocked_reason = data.get("needs_attention_reason") or review_error
             entry["blocked_reason"] = blocked_reason
-        elif review_error.startswith(SPLIT_FAILED_PREFIX):
+        elif review_error.startswith((SPLIT_FAILED_PREFIX, SPLIT_NOT_ATTEMPTED_PREFIX)):
             # A crashed split still carries recommendation: split — counting
             # it as a successful split reported the crash as an outcome
             # (RHAIFIRST-571). Not an `error` entry: the review is fully

--- a/scripts/jira_utils.py
+++ b/scripts/jira_utils.py
@@ -107,6 +107,15 @@ def get_issue(server, user, token, key, fields=None):
     return api_call_with_retry(server, path, user, token)
 
 
+def get_myself(server, user, token):
+    """GET /myself — the cheapest authenticated call, used as a preflight.
+
+    A dead token or unreachable instance fails here for the cost of ONE
+    request, instead of once per parent inside a fan-out (RHAIFIRST-571).
+    """
+    return api_call_with_retry(server, "/myself", user, token)
+
+
 def search_issues(server, user, token, jql, fields):
     """GET /search/jql — single page (recovery-sized queries, <=50 results).
 

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -23,6 +23,7 @@ import argparse
 import os
 import re
 import sys
+import urllib.error
 
 # Ensure progress output is visible immediately when stdout is redirected
 # to a file or pipe (Python defaults to full buffering in that case).
@@ -58,6 +59,47 @@ from jira_utils import (  # noqa: E402
 )
 
 MAX_LEAF_CHILDREN = 6
+
+# Exit-code contract consumed by submit.py's split loop (RHAIFIRST-571).
+# 2 and 3 predate this and stay: leaf-cap refusal and Jira conflict.
+EXIT_PER_PARENT = 4  # this parent failed; others are unaffected — continue
+EXIT_SYSTEMIC = 5  # Jira itself is unusable (auth, outage) — abort the loop
+EXIT_USAGE = 64  # argparse would exit 2, which reads as the leaf cap
+
+
+class _Parser(argparse.ArgumentParser):
+    """argparse exits 2 on usage errors — indistinguishable from the leaf-cap
+    refusal to the caller. Route usage errors to EX_USAGE instead."""
+
+    def error(self, message):
+        self.print_usage(sys.stderr)
+        print(f"{self.prog}: error: {message}", file=sys.stderr)
+        sys.exit(EXIT_USAGE)
+
+
+def _classify_exit(exc):
+    """Map an escaped exception to the per-parent/systemic exit code.
+
+    jira_utils.api_call_with_retry is a RETRY classifier, not a fatal one:
+    it re-raises 401/403/400/404 immediately and 429/5xx/URLError after
+    three attempts. What reaches here is one undifferentiated bucket, so
+    classify by what the failure says about the NEXT parent: an expired
+    token or an unreachable instance fails every parent identically
+    (systemic), while a 400 on one child's field or a local artifact
+    problem says nothing about the others (per-parent).
+    """
+    if isinstance(exc, urllib.error.HTTPError):
+        if exc.code in (401, 403):
+            return EXIT_SYSTEMIC
+        if exc.code in (429, 502, 503, 504):
+            # Only reachable after api_call_with_retry exhausted its
+            # attempts — a healthy instance would have recovered within.
+            return EXIT_SYSTEMIC
+        return EXIT_PER_PARENT
+    if isinstance(exc, urllib.error.URLError):
+        return EXIT_SYSTEMIC
+    return EXIT_PER_PARENT
+
 
 SPLIT_CONFIG = {
     "rfe": {
@@ -464,7 +506,7 @@ def phase2_create_link(
                 f"Run Phase 1 first.",
                 file=sys.stderr,
             )
-            sys.exit(1)
+            sys.exit(EXIT_PER_PARENT)
 
         _, _, _, cleaned_markdown = config["parse_child_fn"](artifact_path)
         description_adf = markdown_to_adf(cleaned_markdown)
@@ -638,7 +680,7 @@ def phase3_close(server, user, token, parent_key, children, state, config, dry_r
         print(
             f"  ERROR: Cannot close parent — children {missing} not yet created.", file=sys.stderr
         )
-        sys.exit(1)
+        sys.exit(EXIT_PER_PARENT)
 
     if dry_run:
         print(f"  Phase 3: Would label {parent_key} with {label_prefix}-split-original")
@@ -685,9 +727,7 @@ def phase3_close(server, user, token, parent_key, children, state, config, dry_r
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
+    parser = _Parser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("parent_key", help="Parent Jira issue key to split")
     parser.add_argument(
         "--type",
@@ -709,7 +749,7 @@ def main():
     if not args.dry_run and not all([server, user, token]):
         print("Error: JIRA_SERVER, JIRA_USER, and JIRA_TOKEN env vars required.", file=sys.stderr)
         print("Set these or use --dry-run for local-only validation.", file=sys.stderr)
-        sys.exit(1)
+        sys.exit(EXIT_SYSTEMIC)
 
     # Scan task files to find parent and children via frontmatter
     scan_fn = config["scan_fn"]
@@ -722,7 +762,7 @@ def main():
             f"Error: No {entity_name.lower()} files found. Run /{entity_name.lower()}.split first.",
             file=sys.stderr,
         )
-        sys.exit(1)
+        sys.exit(EXIT_PER_PARENT)
 
     # Find parent: status=Archived with matching id
     parent_task = None
@@ -736,7 +776,7 @@ def main():
             f"Error: No archived parent with {id_field}={args.parent_key} found.",
             file=sys.stderr,
         )
-        sys.exit(1)
+        sys.exit(EXIT_PER_PARENT)
 
     # Find leaf children: walk the tree recursively to collect all
     # non-archived descendants.  Intermediary nodes (archived local IDs
@@ -765,7 +805,7 @@ def main():
             f"Error: No child {entity_name}s found with parent_key={args.parent_key}.",
             file=sys.stderr,
         )
-        sys.exit(1)
+        sys.exit(EXIT_PER_PARENT)
 
     if len(child_tasks) > MAX_LEAF_CHILDREN:
         print(
@@ -814,72 +854,87 @@ def main():
         except Exception as e:
             print(f"Warning: conflict check failed for {args.parent_key}: {e}", file=sys.stderr)
 
-    # Discover state (skip for dry-run without credentials)
-    if args.dry_run and not all([server, user, token]):
-        print("Dry run (no Jira credentials — skipping recovery check)")
+    # Everything from discovery on talks to Jira. An escaped exception is
+    # classified for submit.py's loop policy: per-parent failures let the
+    # other parents proceed; systemic ones (dead auth, unreachable
+    # instance) abort the whole split phase without fanning out
+    # (RHAIFIRST-571).
+    try:
+        # Discover state (skip for dry-run without credentials)
+        if args.dry_run and not all([server, user, token]):
+            print("Dry run (no Jira credentials — skipping recovery check)")
+            print()
+            state = SubmissionState()
+            state.total_children = len(children)
+        else:
+            print("Checking submission state...")
+            state = discover_state(server, user, token, args.parent_key, children, config)
+            if state.phase1_done:
+                print(
+                    f"  Phase 1: {len(state.phase1_done)}/{len(children)} archival comments found"
+                )
+            if state.phase2_done:
+                print(f"  Phase 2: {len(state.phase2_done)}/{len(children)} tickets created")
+            if state.parent_closed:
+                print("  Phase 3: Parent already closed")
+            if not state.phase1_done and not state.phase2_done:
+                print("  Fresh start — no prior progress found")
+            print()
+
+        # Run phases
+        print(f"Phase 1: Persisting child {entity_name} content to parent comments...")
+        phase1_persist(server, user, token, args.parent_key, children, state, config, args.dry_run)
         print()
-        state = SubmissionState()
-        state.total_children = len(children)
-    else:
-        print("Checking submission state...")
-        state = discover_state(server, user, token, args.parent_key, children, config)
-        if state.phase1_done:
-            print(f"  Phase 1: {len(state.phase1_done)}/{len(children)} archival comments found")
-        if state.phase2_done:
-            print(f"  Phase 2: {len(state.phase2_done)}/{len(children)} tickets created")
-        if state.parent_closed:
-            print("  Phase 3: Parent already closed")
-        if not state.phase1_done and not state.phase2_done:
-            print("  Fresh start — no prior progress found")
+
+        print("Phase 2: Creating tickets and linking...")
+        phase2_create_link(
+            server,
+            user,
+            token,
+            args.parent_key,
+            children,
+            state,
+            args.artifacts_dir,
+            config,
+            args.dry_run,
+        )
         print()
 
-    # Run phases
-    print(f"Phase 1: Persisting child {entity_name} content to parent comments...")
-    phase1_persist(server, user, token, args.parent_key, children, state, config, args.dry_run)
-    print()
+        print("Phase 3: Closing parent...")
+        phase3_close(server, user, token, args.parent_key, children, state, config, args.dry_run)
+        print()
 
-    print("Phase 2: Creating tickets and linking...")
-    phase2_create_link(
-        server,
-        user,
-        token,
-        args.parent_key,
-        children,
-        state,
-        args.artifacts_dir,
-        config,
-        args.dry_run,
-    )
-    print()
+        # Post-submit: update frontmatter and rename files. Never under dry-run:
+        # recovery can adopt children with REAL keys (not the -DRY sentinel), and
+        # renaming local artifacts is a write the caller did not ask for.
+        rename_fn = config["rename_fn"]
+        project = config["project"]
+        for child_id, title, priority, artifact_path in children:
+            assigned = state.phase2_done.get(child_id)
+            assigned_key = assigned["key"] if assigned else None
+            if args.dry_run or not assigned_key or assigned_key == f"{project}-DRY":
+                continue
+            if assigned_key == child_id:
+                # Already renamed by a run that died between the rename and the
+                # index rebuild — nothing to do.
+                continue
 
-    print("Phase 3: Closing parent...")
-    phase3_close(server, user, token, args.parent_key, children, state, config, args.dry_run)
-    print()
+            rename_fn(args.artifacts_dir, child_id, assigned_key)
+            print(f"  {child_id}: Renamed artifacts to {assigned_key}")
 
-    # Post-submit: update frontmatter and rename files. Never under dry-run:
-    # recovery can adopt children with REAL keys (not the -DRY sentinel), and
-    # renaming local artifacts is a write the caller did not ask for.
-    rename_fn = config["rename_fn"]
-    project = config["project"]
-    for child_id, title, priority, artifact_path in children:
-        assigned = state.phase2_done.get(child_id)
-        assigned_key = assigned["key"] if assigned else None
-        if args.dry_run or not assigned_key or assigned_key == f"{project}-DRY":
-            continue
-        if assigned_key == child_id:
-            # Already renamed by a run that died between the rename and the
-            # index rebuild — nothing to do.
-            continue
-
-        rename_fn(args.artifacts_dir, child_id, assigned_key)
-        print(f"  {child_id}: Renamed artifacts to {assigned_key}")
-
-    # Rebuild index (RFE only)
-    if config["do_rebuild_index"]:
-        rebuild_index(args.artifacts_dir)
-        print(f"Done. Index rebuilt at {args.artifacts_dir}/rfes.md")
-    else:
-        print("Done.")
+        # Rebuild index (RFE only)
+        if config["do_rebuild_index"]:
+            rebuild_index(args.artifacts_dir)
+            print(f"Done. Index rebuilt at {args.artifacts_dir}/rfes.md")
+        else:
+            print("Done.")
+    except SystemExit:
+        raise
+    except Exception as e:
+        code = _classify_exit(e)
+        kind = "systemic Jira failure" if code == EXIT_SYSTEMIC else "per-parent failure"
+        print(f"Error: {kind}: {type(e).__name__}: {e}", file=sys.stderr)
+        sys.exit(code)
 
 
 if __name__ == "__main__":

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -91,9 +91,14 @@ def _classify_exit(exc):
     if isinstance(exc, urllib.error.HTTPError):
         if exc.code in (401, 403):
             return EXIT_SYSTEMIC
-        if exc.code in (429, 502, 503, 504):
-            # Only reachable after api_call_with_retry exhausted its
-            # attempts — a healthy instance would have recovered within.
+        if exc.code == 429 or exc.code >= 500:
+            # 429/502/503/504 are only reachable after api_call_with_retry
+            # exhausted its attempts; a bare 500 (and any other 5xx) is
+            # re-raised immediately — but it is still a server-side fault,
+            # and misreading an instance-wide 500 as per-parent fans out
+            # requests and quarantine flags across the whole batch
+            # (CodeRabbit). A payload-specific 500 aborting one night is
+            # the cheaper error: the parent is untouched and retried.
             return EXIT_SYSTEMIC
         return EXIT_PER_PARENT
     if isinstance(exc, urllib.error.URLError):

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -214,6 +214,29 @@ def _generate_reports(args):
         print(f"Warning: HTML report generation failed: {result.stderr}", file=sys.stderr)
 
 
+def _record_not_attempted(args, cfg, parent_keys, error):
+    """Local-only record for split parents a phase abort skipped.
+
+    Deliberately touches nothing in Jira — the whole point of aborting is to
+    avoid a fan-out of flags on parents that were never examined. The review
+    error keeps the run report truthful (they count failed, not split) and
+    keeps bootstrap from treating them as disposed. The next nightly
+    re-selects them normally: their snapshot entries stay unprocessed and
+    no quarantine label is applied.
+    """
+    for parent_key in parent_keys:
+        review_path = _find_review(args.artifacts_dir, parent_key, cfg)
+        if not review_path:
+            continue
+        try:
+            update_frontmatter(review_path, {"error": error}, cfg["review_schema"])
+        except Exception as e:
+            print(
+                f"  Warning: could not record not-attempted on {parent_key} ({e}).",
+                file=sys.stderr,
+            )
+
+
 def _record_split_failure(
     server, user, token, parent_key, reason, error, args, cfg, parent_data, quarantine=False
 ):
@@ -425,10 +448,11 @@ def main():
         script_dir = os.path.dirname(os.path.abspath(__file__))
         # Test seam: the loop policy (systemic abort, circuit breaker) cannot
         # be exercised end-to-end with the real script, which classifies
-        # everything it can reach into 0/2/3/4/5.
-        split_script = os.environ.get("RFE_SPLIT_SUBMIT_SCRIPT") or os.path.join(
-            script_dir, "split_submit.py"
-        )
+        # everything it can reach into 0/2/3/4/5. Honored only under pytest —
+        # in production a stray env var must not silently swap the script.
+        split_script = os.path.join(script_dir, "split_submit.py")
+        if os.environ.get("RFE_SPLIT_SUBMIT_SCRIPT") and os.environ.get("PYTEST_CURRENT_TEST"):
+            split_script = os.environ["RFE_SPLIT_SUBMIT_SCRIPT"]
 
         # Preflight one cheap authenticated call: a dead token or unreachable
         # instance must cost one request and one accurate message, not a
@@ -445,6 +469,12 @@ def main():
                     file=sys.stderr,
                 )
                 submit_errors.append(("jira-preflight", f"{type(e).__name__}: {e}"))
+                _record_not_attempted(
+                    args,
+                    cfg,
+                    sorted(split_parents),
+                    "split_not_attempted: Jira preflight failed",
+                )
                 _finish(args, type_label, submit_errors)
 
         # Circuit breaker for failures the exit-code classifier cannot see
@@ -453,8 +483,10 @@ def main():
         # never sys.exit, so _finish() still writes the report.
         consecutive_generic = 0
         abort_splits = False
+        attempted_parents = set()
 
         for parent_key in sorted(split_parents):
+            attempted_parents.add(parent_key)
             cmd = [
                 sys.executable,
                 split_script,
@@ -468,7 +500,12 @@ def main():
                 cmd.append("--dry-run")
             print(f"--- {parent_key} ---")
             result = subprocess.run(cmd)
-            if result.returncode == 0:
+            if result.returncode in (0, 2, 3, 4, 5):
+                # Any CLASSIFIED outcome resets the streak: the breaker's
+                # discriminator is "the classifier missed twice in a row",
+                # and a refusal or per-parent failure in between proves the
+                # classifier is alive (review finding: two isolated signal
+                # deaths separated by a healthy refusal are not a streak).
                 consecutive_generic = 0
             # argparse used to exit 2 as well; split_submit now routes usage
             # errors to 64, so 2 is unambiguously the leaf cap.
@@ -506,15 +543,33 @@ def main():
                 continue
             elif result.returncode == 5:
                 # Systemic: Jira itself is unusable (dead auth, outage). The
-                # parent was never really examined, so no quarantine and no
-                # needs-attention flag — the next nightly retries it once the
-                # instance recovers. Abort the loop: every remaining parent
-                # would fail identically, ~3 requests and ~21s of backoff
-                # each, leaving bogus flags behind.
+                # FAILING parent is recorded and quarantined like a
+                # per-parent failure — the classify wrapper spans discovery
+                # through phase 3, so a mid-run token death can exit 5 AFTER
+                # real Jira writes, and an unquarantined partial split is
+                # re-decomposed by the next nightly into duplicates
+                # (reproduced in review). The Jira half of the record is
+                # best-effort and likely fails here too; the LOCAL review
+                # error is what keeps the report truthful. Then abort: every
+                # remaining parent would fail identically, ~3 requests and
+                # ~21s of backoff each, leaving bogus flags behind.
                 print(
                     f"Error: systemic Jira failure on {parent_key} — aborting the "
                     f"split phase; remaining parents were not attempted.",
                     file=sys.stderr,
+                )
+                _record_split_failure(
+                    server,
+                    user,
+                    token,
+                    parent_key,
+                    "Systemic Jira failure during split submission (exit 5). Jira may "
+                    f"be partially updated — check {parent_key} before retrying.",
+                    "split_submit_failed: exit 5",
+                    args,
+                    cfg,
+                    split_parent_data[parent_key],
+                    quarantine=True,
                 )
                 submit_errors.append((parent_key, "systemic Jira failure (split phase aborted)"))
                 abort_splits = True
@@ -580,6 +635,18 @@ def main():
             print()
 
         if abort_splits:
+            # The parents the abort skipped still carry recommendation:
+            # split with no error — the final report would count them as
+            # SUCCESSFUL splits (review finding). Record a LOCAL-ONLY error
+            # on each: no Jira flags (that fan-out is what the abort
+            # avoids), but the report shows them failed and bootstrap does
+            # not count them disposed.
+            _record_not_attempted(
+                args,
+                cfg,
+                [p for p in sorted(split_parents) if p not in attempted_parents],
+                "split_not_attempted: split phase aborted before this parent",
+            )
             # The report is still written — the parents that succeeded
             # earlier in this loop are real in Jira and this is the only
             # place they are recorded.

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -45,6 +45,7 @@ from jira_utils import (  # noqa: E402
     add_labels,
     check_description_conflict,
     create_issue,
+    get_myself,
     markdown_to_adf,
     remove_labels,
     require_env,
@@ -422,7 +423,36 @@ def main():
     if split_parents:
         print(f"Phase 1: Submitting {len(split_parents)} split parent(s)\n")
         script_dir = os.path.dirname(os.path.abspath(__file__))
-        split_script = os.path.join(script_dir, "split_submit.py")
+        # Test seam: the loop policy (systemic abort, circuit breaker) cannot
+        # be exercised end-to-end with the real script, which classifies
+        # everything it can reach into 0/2/3/4/5.
+        split_script = os.environ.get("RFE_SPLIT_SUBMIT_SCRIPT") or os.path.join(
+            script_dir, "split_submit.py"
+        )
+
+        # Preflight one cheap authenticated call: a dead token or unreachable
+        # instance must cost one request and one accurate message, not a
+        # fan-out of N failures and N bogus needs-attention flags
+        # (RHAIFIRST-571).
+        if not args.dry_run:
+            try:
+                get_myself(server, user, token)
+            except Exception as e:
+                print(
+                    f"Error: Jira preflight failed — {type(e).__name__}: {e}. "
+                    f"Skipping all {len(split_parents)} split parent(s); nothing "
+                    f"was attempted.",
+                    file=sys.stderr,
+                )
+                submit_errors.append(("jira-preflight", f"{type(e).__name__}: {e}"))
+                _finish(args, type_label, submit_errors)
+
+        # Circuit breaker for failures the exit-code classifier cannot see
+        # (signal deaths, unexpected codes): consecutive-ness is the
+        # discriminator — a one-off continues, a streak of K aborts. break,
+        # never sys.exit, so _finish() still writes the report.
+        consecutive_generic = 0
+        abort_splits = False
 
         for parent_key in sorted(split_parents):
             cmd = [
@@ -438,8 +468,10 @@ def main():
                 cmd.append("--dry-run")
             print(f"--- {parent_key} ---")
             result = subprocess.run(cmd)
-            # NB: argparse also exits 2, so a malformed argv above would be misread as the
-            # leaf cap and skipped rather than failing loudly.
+            if result.returncode == 0:
+                consecutive_generic = 0
+            # argparse used to exit 2 as well; split_submit now routes usage
+            # errors to 64, so 2 is unambiguously the leaf cap.
             if result.returncode == 2:
                 print(f"  {parent_key}: Split refused — too many children")
                 _record_split_failure(
@@ -472,13 +504,48 @@ def main():
                     split_parent_data[parent_key],
                 )
                 continue
+            elif result.returncode == 5:
+                # Systemic: Jira itself is unusable (dead auth, outage). The
+                # parent was never really examined, so no quarantine and no
+                # needs-attention flag — the next nightly retries it once the
+                # instance recovers. Abort the loop: every remaining parent
+                # would fail identically, ~3 requests and ~21s of backoff
+                # each, leaving bogus flags behind.
+                print(
+                    f"Error: systemic Jira failure on {parent_key} — aborting the "
+                    f"split phase; remaining parents were not attempted.",
+                    file=sys.stderr,
+                )
+                submit_errors.append((parent_key, "systemic Jira failure (split phase aborted)"))
+                abort_splits = True
+                break
+            elif result.returncode == 4:
+                # Per-parent: this parent failed, the others are unaffected —
+                # record, quarantine (Jira may be partially updated), continue.
+                print(
+                    f"Error: split_submit.py failed for {parent_key} (per-parent, exit 4)",
+                    file=sys.stderr,
+                )
+                _record_split_failure(
+                    server,
+                    user,
+                    token,
+                    parent_key,
+                    f"Split submission failed partway (exit 4). Jira may be "
+                    f"partially updated — check {parent_key} for child {type_label}s that were "
+                    "already created, and for unlinked children, before retrying.",
+                    "split_submit_failed: exit 4",
+                    args,
+                    cfg,
+                    split_parent_data[parent_key],
+                    quarantine=True,
+                )
+                submit_errors.append((parent_key, "split_submit exit 4 (may be partial)"))
             elif result.returncode != 0:
-                # Unlike the refusals above, this one may be PARTIALLY APPLIED — split_submit
-                # writes to Jira across three phases, so children and links may already exist.
-                # Still an abort: continuing past an unclassified failure needs the systemic-vs-
-                # per-parent distinction the exit codes cannot currently express. But the report
-                # is written first, because the parents that succeeded earlier in this loop are
-                # real in Jira and this is the only place they are recorded.
+                # Unclassified (signal death, usage error, unexpected code):
+                # may be PARTIALLY APPLIED, so record and quarantine like a
+                # per-parent failure — but count the streak: the classifier
+                # missing twice in a row is the systemic shape it cannot see.
                 print(
                     f"Error: split_submit.py failed for {parent_key} "
                     f"(exit code {result.returncode})",
@@ -501,8 +568,22 @@ def main():
                 submit_errors.append(
                     (parent_key, f"split_submit exit {result.returncode} (may be partial)")
                 )
-                _finish(args, type_label, submit_errors)
+                consecutive_generic += 1
+                if consecutive_generic >= 2:
+                    print(
+                        "Error: 2 consecutive unclassified split failures — stopping the "
+                        "split phase; remaining parents were not attempted.",
+                        file=sys.stderr,
+                    )
+                    abort_splits = True
+                    break
             print()
+
+        if abort_splits:
+            # The report is still written — the parents that succeeded
+            # earlier in this loop are real in Jira and this is the only
+            # place they are recorded.
+            _finish(args, type_label, submit_errors)
 
     # Record split-child hashes in the snapshot
     if split_parents and not args.dry_run:

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -1539,6 +1539,29 @@ class TestLoadRunReportRejectsCorruptFiles:
         with pytest.raises(ValueError, match="malformed"):
             _load_run_report(results, run)
 
+    def test_failed_and_blocked_entries_do_not_count_as_processed(self, tmp_path):
+        """failed_reason (crashed/never-attempted split) and blocked_reason
+        (refusal) entries were not disposed of: the live snapshot leaves
+        them processed:false, and bootstrap recovery must agree or a
+        quarantine-cleared parent would be frozen at processed:true
+        (RHAIFIRST-571 review finding)."""
+        results, run = self._write_report(
+            tmp_path,
+            "per_rfe:\n"
+            "- id: RHAIRFE-1\n"
+            "  recommendation: submit\n"
+            "- id: RHAIRFE-2\n"
+            "  recommendation: split\n"
+            "  failed_reason: 'split_submit_failed: exit 5'\n"
+            "- id: RHAIRFE-3\n"
+            "  recommendation: split\n"
+            "  blocked_reason: too many leaf children\n",
+        )
+
+        ids, _ = _load_run_report(results, run)
+
+        assert ids == {"RHAIRFE-1"}
+
     def test_error_entries_do_not_count_as_processed(self, tmp_path):
         """An error entry records that the run could NOT dispose of the item —
         counting it as processed would freeze it out of every future fetch

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -1531,6 +1531,23 @@ class TestLoadRunReportRejectsCorruptFiles:
         with pytest.raises(ValueError, match="malformed"):
             _load_run_report(results, run)
 
+    @pytest.mark.parametrize(
+        "entry_yaml",
+        [
+            "- failed_reason: 'split_submit_failed: exit 5'",
+            "- blocked_reason: too many leaf children",
+            "- error: review file not found",
+        ],
+    )
+    def test_outcome_entry_without_id_raises(self, tmp_path, entry_yaml):
+        """An id-less entry is corrupt whatever its outcome key — skipping it
+        silently would build a snapshot from an incomplete processed-id set
+        instead of refusing (CodeRabbit on #170, CWE-20)."""
+        results, run = self._write_report(tmp_path, f"per_rfe:\n{entry_yaml}\n")
+
+        with pytest.raises(ValueError, match="malformed"):
+            _load_run_report(results, run)
+
     def test_non_dict_entry_raises_even_containing_error(self, tmp_path):
         """A malformed entry must refuse loudly — the error-entry skip is for
         error DICTS, not for anything whose text happens to contain 'error'."""

--- a/tests/test_error_collect.py
+++ b/tests/test_error_collect.py
@@ -181,6 +181,45 @@ class TestNoErrorsClearsRetryFile:
 class TestSplitErrorCleanup:
     """The --type must reach cleanup_partial_split, or children are orphaned."""
 
+    def test_split_submit_failed_stays_out_of_the_retry_batch(self, workspace):
+        """The quarantined class must not re-enter through the retry loop:
+        an automated retry of a partially-applied split can mint duplicate
+        children (RHAIFIRST-571)."""
+        _rfe_task(workspace, "RHAIRFE-10", status="Archived")
+        _write_review(
+            workspace, "rfe-reviews", "RHAIRFE-10", "rfe_id", "split_submit_failed: exit 4"
+        )
+        _rfe_task(workspace, "RHAIRFE-20")
+        _write_review(workspace, "rfe-reviews", "RHAIRFE-20", "rfe_id", "review_failed: timeout")
+        _set_ids(workspace, "RHAIRFE-10", "RHAIRFE-20")
+
+        stdout, stderr, rc = _run(workspace)
+        assert rc == 0, stderr
+        assert "excluded from retry" in stdout and "RHAIRFE-10" in stdout
+
+        retry_ids = (workspace / "tmp/pipeline-retry-ids.txt").read_text().split()
+        assert retry_ids == ["RHAIRFE-20"]
+        batch = (workspace / "tmp/pipeline-batch-3-ids.txt").read_text().split()
+        assert batch == ["RHAIRFE-20"]
+
+    def test_only_non_retryable_errors_clears_the_retry_file(self, workspace):
+        """All errors non-retryable → same contract as zero errors: cleared
+        file routes ERROR_COLLECT to REPORT (RHAIFIRST-581 path)."""
+        _rfe_task(workspace, "RHAIRFE-10", status="Archived")
+        _write_review(
+            workspace,
+            "rfe-reviews",
+            "RHAIRFE-10",
+            "rfe_id",
+            "split_refused: too many leaf children",
+        )
+        _set_ids(workspace, "RHAIRFE-10")
+
+        stdout, stderr, rc = _run(workspace)
+        assert rc == 0, stderr
+        assert "no retryable error IDs" in stdout
+        assert (workspace / "tmp/pipeline-retry-ids.txt").read_text().strip() == ""
+
     def test_split_submit_failed_does_not_clean_children(self, workspace):
         """A split_submit failure may be PARTIALLY APPLIED in Jira — deleting
         the local child files would orphan Jira twins that already exist

--- a/tests/test_generate_review_pdf.py
+++ b/tests/test_generate_review_pdf.py
@@ -11,6 +11,7 @@ from generate_review_pdf import (
     _ensure_trailing_newline,
     _open_nofollow,
     _safe_artifact_path,
+    _split_outcome,
     _strip_frontmatter,
     generate_diff,
 )
@@ -317,3 +318,23 @@ class TestOpenNofollowEncoding:
         assert "hello" in content
         assert "world" in content
         assert "�" in content
+
+
+class TestSplitOutcome:
+    """Three-way disposition: only 'failed' may be partially applied in
+    Jira — lumping not-attempted parents into failed misstated the Jira
+    state in every renderer (CodeRabbit on #170)."""
+
+    def test_refusals(self):
+        assert _split_outcome("split_refused: too many leaf children") == "refused"
+        assert _split_outcome("split_failed: agent did not write split-status file") == "refused"
+
+    def test_failed(self):
+        assert _split_outcome("split_submit_failed: exit 5") == "failed"
+
+    def test_not_attempted(self):
+        assert _split_outcome("split_not_attempted: split phase aborted") == "not_attempted"
+
+    def test_clean(self):
+        assert _split_outcome(None) is None
+        assert _split_outcome("") is None

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -568,6 +568,34 @@ class TestRefusedSplitIsBlockedNotSplit:
         assert report["results"]["split"] == 1
         assert report["results"]["blocked"] == 0
 
+    def test_crashed_split_counts_failed_not_split(self, art_dir):
+        """A split_submit crash leaves recommendation: split on the review —
+        counting it as a successful split reported the crash as an outcome
+        (RHAIFIRST-571)."""
+        _write(
+            f"{art_dir}/rfe-tasks/RHAIRFE-100.md",
+            TASK_TEMPLATE.format(rfe_id="RHAIRFE-100", extra=""),
+        )
+        _write(
+            f"{art_dir}/rfe-reviews/RHAIRFE-100-review.md",
+            REVIEW_REFUSED_TEMPLATE.format(
+                rfe_id="RHAIRFE-100",
+                reason="Split submission failed partway (exit 4).",
+                error="split_submit_failed: exit 4",
+            ),
+        )
+
+        report = build_report(["RHAIRFE-100"], "20260831-120000", artifacts_dir=art_dir)
+
+        assert report["results"]["failed"] == 1
+        assert report["results"]["split"] == 0
+        assert report["results"]["blocked"] == 0
+        entry = report["per_rfe"][0]
+        assert entry["failed_reason"].startswith("Split submission failed")
+        assert "blocked_reason" not in entry
+        # Not an error entry: the review is readable and the scores are real.
+        assert report["errors"] == []
+
     def test_unrelated_review_error_is_not_blocked(self, art_dir):
         """Only the split_refused marker means blocked, not any error field."""
         _write(

--- a/tests/test_split_submit.py
+++ b/tests/test_split_submit.py
@@ -177,8 +177,12 @@ class TestClassifyExit:
     failures (dead auth, outage) fail every parent identically; everything
     else says nothing about the next parent (RHAIFIRST-571)."""
 
-    @pytest.mark.parametrize("code", [401, 403, 429, 502, 503, 504])
+    @pytest.mark.parametrize("code", [401, 403, 429, 500, 501, 502, 503, 504, 521])
     def test_systemic_http_codes(self, code):
+        """Any 5xx is a server-side fault: a bare 500 is re-raised by
+        api_call_with_retry without retrying, and misreading an
+        instance-wide 500 as per-parent fans out across the batch
+        (CodeRabbit on #170)."""
         assert _classify_exit(_http_error(code)) == EXIT_SYSTEMIC
 
     @pytest.mark.parametrize("code", [400, 404, 409, 422])

--- a/tests/test_split_submit.py
+++ b/tests/test_split_submit.py
@@ -1,14 +1,22 @@
 #!/usr/bin/env python3
 """Tests for scripts/split_submit.py — guardrails and ADF output."""
 
+import io
 import os
 import subprocess
 import sys
+import urllib.error
 
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
-from split_submit import SubmissionState, build_split_summary_adf
+from split_submit import (
+    EXIT_PER_PARENT,
+    EXIT_SYSTEMIC,
+    SubmissionState,
+    _classify_exit,
+    build_split_summary_adf,
+)
 
 SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "split_submit.py")
 
@@ -158,3 +166,40 @@ class TestSplitSummaryAdf:
         item = adf["content"][1]["content"][0]
         url = item["content"][0]["content"][0]["attrs"]["url"]
         assert "//" not in url.replace("https://", "")
+
+
+def _http_error(code):
+    return urllib.error.HTTPError("http://x", code, "err", {}, io.BytesIO(b""))
+
+
+class TestClassifyExit:
+    """The exit-code contract submit.py's loop policy relies on: systemic
+    failures (dead auth, outage) fail every parent identically; everything
+    else says nothing about the next parent (RHAIFIRST-571)."""
+
+    @pytest.mark.parametrize("code", [401, 403, 429, 502, 503, 504])
+    def test_systemic_http_codes(self, code):
+        assert _classify_exit(_http_error(code)) == EXIT_SYSTEMIC
+
+    @pytest.mark.parametrize("code", [400, 404, 409, 422])
+    def test_per_parent_http_codes(self, code):
+        assert _classify_exit(_http_error(code)) == EXIT_PER_PARENT
+
+    def test_network_error_is_systemic(self):
+        assert _classify_exit(urllib.error.URLError("no route")) == EXIT_SYSTEMIC
+
+    def test_local_errors_are_per_parent(self):
+        assert _classify_exit(ValueError("bad artifact")) == EXIT_PER_PARENT
+        assert _classify_exit(FileNotFoundError("gone")) == EXIT_PER_PARENT
+
+
+class TestUsageExitCode:
+    def test_malformed_argv_exits_64_not_2(self):
+        """argparse's default exit 2 reads as the leaf-cap refusal to
+        submit.py — usage errors must be distinguishable."""
+        r = subprocess.run(
+            [sys.executable, SCRIPT, "--no-such-flag"],
+            capture_output=True,
+            text=True,
+        )
+        assert r.returncode == 64

--- a/tests/test_split_submit_integration.py
+++ b/tests/test_split_submit_integration.py
@@ -399,6 +399,50 @@ class TestRerunIsANoOp:
         assert _search_keys(jira.url, "labels = rfe-creator-split-result") == children_after_first
 
 
+class TestSystemicClassification:
+    def test_dead_auth_exits_systemic_without_fanout(self, art_dir):
+        """Every call answered 401: one classified message, exit 5, and only
+        a handful of requests — not a per-child fan-out (RHAIFIRST-571)."""
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        counter = {"n": 0}
+
+        class Deny(BaseHTTPRequestHandler):
+            def _deny(self):
+                counter["n"] += 1
+                self.send_response(401)
+                self.end_headers()
+                self.wfile.write(b"{}")
+
+            do_GET = _deny  # noqa: N815
+            do_POST = _deny  # noqa: N815
+            do_PUT = _deny  # noqa: N815
+
+            def log_message(self, *a):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), Deny)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        url = f"http://127.0.0.1:{server.server_port}"
+        try:
+            _write(f"{art_dir}/rfe-tasks/{PARENT_KEY}.md", PARENT_TASK)
+            _write(f"{art_dir}/rfe-originals/{PARENT_KEY}.md", PARENT_DESC)
+            for cid in ("RFE-001", "RFE-002"):
+                _write(
+                    f"{art_dir}/rfe-tasks/{cid}.md",
+                    CHILD_TASK.format(child_id=cid, title=f"Child {cid}"),
+                )
+            r = _run_split(art_dir, url)
+        finally:
+            server.shutdown()
+
+        assert r.returncode == 5, r.stderr + r.stdout
+        assert "systemic Jira failure" in r.stderr
+        # Conflict check (1) + discovery (1): far below a per-child fan-out.
+        assert counter["n"] <= 4, f"{counter['n']} requests"
+
+
 class TestLegacyComments:
     def test_positional_comments_still_map(self, art_dir, jira):
         """Comments written before the id-based format map through the

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -788,6 +788,165 @@ class TestSplitQuarantine:
         assert "rfe-creator-needs-attention" in labels
 
 
+class TestSplitLoopPolicy:
+    """RHAIFIRST-571: per-parent failures continue, systemic ones abort
+    without fan-out, and the breaker stops unclassified streaks."""
+
+    PARENT_TASK_TPL = (
+        "---\nrfe_id: {key}\ntitle: Parent {key}\n"
+        "priority: Major\nstatus: Archived\n---\n\nContent {key}.\n"
+    )
+    PARENT_REVIEW_TPL = (
+        "---\nrfe_id: {key}\nscore: 6\npass: false\n"
+        "recommendation: split\nfeasibility: feasible\n"
+        "auto_revised: false\nneeds_attention: false\n"
+        "scores:\n  what: 2\n  why: 1\n  open_to_how: 2\n"
+        "  not_a_task: 1\n  right_sized: 0\n---\n\nToo big.\n"
+    )
+
+    def _parent(self, jira, art_dir, key, broken=False):
+        jira.create(key, f"Parent {key}", f"Content {key}.")
+        _write(f"{art_dir}/rfe-originals/{key}.md", f"Content {key}.")
+        _write(f"{art_dir}/rfe-tasks/{key}.md", self.PARENT_TASK_TPL.format(key=key))
+        _write(f"{art_dir}/rfe-reviews/{key}-review.md", self.PARENT_REVIEW_TPL.format(key=key))
+        n = key.split("-")[1]
+        if broken:
+            # Archived dead-end intermediary: split_submit collects zero
+            # leaves and exits 4 (per-parent).
+            _write(
+                f"{art_dir}/rfe-tasks/RFE-{n}90.md",
+                f"---\nrfe_id: RFE-{n}90\ntitle: Dead end\n"
+                f"priority: Major\nstatus: Archived\n"
+                f"parent_key: {key}\n---\n\nDead end.\n",
+            )
+        else:
+            _write(
+                f"{art_dir}/rfe-tasks/RFE-{n}01.md",
+                f"---\nrfe_id: RFE-{n}01\ntitle: Child of {key}\n"
+                f"priority: Major\nstatus: Ready\n"
+                f"parent_key: {key}\n---\n\nChild content.\n",
+            )
+
+    def test_per_parent_failure_continues_to_the_next_parent(self, art_dir, jira):
+        """Parent A fails per-parent (exit 4); parent B must still submit."""
+        self._parent(jira, art_dir, "RHAIRFE-1000", broken=True)
+        self._parent(jira, art_dir, "RHAIRFE-2000", broken=False)
+
+        r = _run_submit(art_dir, jira.url)
+        assert r.returncode == 1, r.stdout + r.stderr
+
+        # B's child was created and linked despite A's failure.
+        import urllib.request as _rq
+
+        req = _rq.Request(f"{jira.url}/rest/api/3/issue/RHAIRFE-2000?fields=issuelinks,labels")
+        with _rq.urlopen(req) as resp:
+            parent_b = json.loads(resp.read())
+        links = [
+            link
+            for link in parent_b["fields"].get("issuelinks", [])
+            if link.get("type", {}).get("name") == "Work item split"
+        ]
+        assert len(links) == 1, r.stdout
+        # A was quarantined, B was not.
+        req = _rq.Request(f"{jira.url}/rest/api/3/issue/RHAIRFE-1000?fields=labels")
+        with _rq.urlopen(req) as resp:
+            labels_a = set(json.loads(resp.read())["fields"]["labels"])
+        assert "rfe-creator-split-quarantine" in labels_a
+        assert "rfe-creator-split-quarantine" not in set(parent_b["fields"]["labels"])
+
+    def _stub_script(self, tmp_path, exit_code):
+        """A fake split_submit that logs its invocation and exits."""
+        log = tmp_path / "invocations.log"
+        stub = tmp_path / "stub_split_submit.py"
+        stub.write_text(
+            "import sys\n"
+            f"open({str(log)!r}, 'a').write(sys.argv[1] + chr(10))\n"
+            f"sys.exit({exit_code})\n"
+        )
+        return str(stub), log
+
+    def test_systemic_exit_aborts_without_touching_remaining_parents(
+        self, art_dir, jira, tmp_path, monkeypatch
+    ):
+        for key in ("RHAIRFE-1000", "RHAIRFE-2000", "RHAIRFE-3000"):
+            self._parent(jira, art_dir, key, broken=False)
+        stub, log = self._stub_script(tmp_path, 5)
+        monkeypatch.setenv("RFE_SPLIT_SUBMIT_SCRIPT", stub)
+
+        r = _run_submit(art_dir, jira.url)
+        assert r.returncode == 1
+        assert "systemic Jira failure" in r.stderr
+        assert len(log.read_text().splitlines()) == 1, "remaining parents were attempted"
+        # The parent was never really examined: no quarantine, no flag.
+        import urllib.request as _rq
+
+        req = _rq.Request(f"{jira.url}/rest/api/3/issue/RHAIRFE-1000?fields=labels")
+        with _rq.urlopen(req) as resp:
+            labels = set(json.loads(resp.read())["fields"]["labels"])
+        assert "rfe-creator-split-quarantine" not in labels
+
+    def test_breaker_trips_after_two_consecutive_unclassified_failures(
+        self, art_dir, jira, tmp_path, monkeypatch
+    ):
+        for key in ("RHAIRFE-1000", "RHAIRFE-2000", "RHAIRFE-3000"):
+            self._parent(jira, art_dir, key, broken=False)
+        stub, log = self._stub_script(tmp_path, 7)
+        monkeypatch.setenv("RFE_SPLIT_SUBMIT_SCRIPT", stub)
+
+        r = _run_submit(art_dir, jira.url)
+        assert r.returncode == 1
+        assert "2 consecutive unclassified split failures" in r.stderr
+        assert len(log.read_text().splitlines()) == 2, "breaker did not stop the loop"
+
+    def test_dead_jira_fails_preflight_with_one_message_and_no_fanout(
+        self, art_dir, tmp_path, monkeypatch
+    ):
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        class Deny(BaseHTTPRequestHandler):
+            def _deny(self):
+                self.send_response(401)
+                self.end_headers()
+                self.wfile.write(b"{}")
+
+            do_GET = _deny  # noqa: N815
+            do_POST = _deny  # noqa: N815
+            do_PUT = _deny  # noqa: N815
+
+            def log_message(self, *a):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), Deny)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        url = f"http://127.0.0.1:{server.server_port}"
+        stub, log = self._stub_script(tmp_path, 0)
+        monkeypatch.setenv("RFE_SPLIT_SUBMIT_SCRIPT", stub)
+        try:
+            _write(
+                f"{art_dir}/rfe-tasks/RHAIRFE-1000.md",
+                self.PARENT_TASK_TPL.format(key="RHAIRFE-1000"),
+            )
+            _write(f"{art_dir}/rfe-originals/RHAIRFE-1000.md", "Content RHAIRFE-1000.")
+            _write(
+                f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md",
+                self.PARENT_REVIEW_TPL.format(key="RHAIRFE-1000"),
+            )
+            _write(
+                f"{art_dir}/rfe-tasks/RFE-100001.md",
+                "---\nrfe_id: RFE-100001\ntitle: Child\n"
+                "priority: Major\nstatus: Ready\n"
+                "parent_key: RHAIRFE-1000\n---\n\nChild content.\n",
+            )
+            r = _run_submit(art_dir, url)
+        finally:
+            server.shutdown()
+
+        assert r.returncode == 1
+        assert "Jira preflight failed" in r.stderr
+        assert not log.exists(), "split_submit was invoked despite a dead preflight"
+
+
 class TestSplitConflictDetection:
     """Integration test: split_submit.py detects parent conflict."""
 

--- a/tests/test_submit_integration.py
+++ b/tests/test_submit_integration.py
@@ -877,13 +877,104 @@ class TestSplitLoopPolicy:
         assert r.returncode == 1
         assert "systemic Jira failure" in r.stderr
         assert len(log.read_text().splitlines()) == 1, "remaining parents were attempted"
-        # The parent was never really examined: no quarantine, no flag.
         import urllib.request as _rq
 
+        # The FAILING parent is quarantined: the classify wrapper spans the
+        # phases, so exit 5 can land after real Jira writes (review finding).
         req = _rq.Request(f"{jira.url}/rest/api/3/issue/RHAIRFE-1000?fields=labels")
         with _rq.urlopen(req) as resp:
             labels = set(json.loads(resp.read())["fields"]["labels"])
-        assert "rfe-creator-split-quarantine" not in labels
+        assert "rfe-creator-split-quarantine" in labels
+        fm = _read_frontmatter(f"{art_dir}/rfe-reviews/RHAIRFE-1000-review.md")
+        assert fm["error"] == "split_submit_failed: exit 5"
+        # The never-attempted parents get a LOCAL record only — no Jira flags
+        # (avoiding the fan-out is the point of the abort), but the report
+        # must not count them as successful splits.
+        for key in ("RHAIRFE-2000", "RHAIRFE-3000"):
+            fm = _read_frontmatter(f"{art_dir}/rfe-reviews/{key}-review.md")
+            assert fm["error"].startswith("split_not_attempted:")
+            req = _rq.Request(f"{jira.url}/rest/api/3/issue/{key}?fields=labels")
+            with _rq.urlopen(req) as resp:
+                labels = set(json.loads(resp.read())["fields"]["labels"])
+            assert "rfe-creator-split-quarantine" not in labels
+            assert "rfe-creator-needs-attention" not in labels
+
+    def test_abort_report_counts_skipped_parents_failed_not_split(
+        self, art_dir, jira, tmp_path, monkeypatch
+    ):
+        """The final report after an abort must not claim successful splits
+        for parents that were never attempted (review finding: reproduced
+        results.split == N with zero splits in Jira)."""
+        for key in ("RHAIRFE-1000", "RHAIRFE-2000", "RHAIRFE-3000"):
+            self._parent(jira, art_dir, key, broken=False)
+        stub, log = self._stub_script(tmp_path, 5)
+        monkeypatch.setenv("RFE_SPLIT_SUBMIT_SCRIPT", stub)
+
+        r = _run_submit(
+            art_dir,
+            jira.url,
+            extra_flags=["--generate-report", "--report-timestamp", "20260831-180000"],
+        )
+        assert r.returncode == 1
+
+        report_path = f"{art_dir}/auto-fix-runs/20260831-180000.yaml"
+        assert os.path.exists(report_path), "abort took the report with it"
+        with open(report_path) as f:
+            report = yaml.safe_load(f)
+        assert report["results"]["split"] == 0
+        assert report["results"]["failed"] == 3
+        by_id = {e["id"]: e for e in report["per_rfe"]}
+        assert by_id["RHAIRFE-1000"]["failed_reason"].startswith(
+            "Split submission failed"
+        ) or "exit 5" in str(by_id["RHAIRFE-1000"].get("failed_reason", ""))
+        assert "split_not_attempted" in by_id["RHAIRFE-2000"]["failed_reason"]
+
+    def test_breaker_requires_consecutive_failures(self, art_dir, jira, tmp_path, monkeypatch):
+        """A classified outcome between two unclassified failures proves the
+        classifier is alive — the streak resets (review finding)."""
+        for key in ("RHAIRFE-1000", "RHAIRFE-2000", "RHAIRFE-3000"):
+            self._parent(jira, art_dir, key, broken=False)
+        log = tmp_path / "invocations.log"
+        stub = tmp_path / "stub_split_submit.py"
+        # The middle outcome is a CLASSIFIED refusal (2), not a success:
+        # this is what discriminates "reset on any classified outcome" from
+        # "reset on success only" — a healthy refusal between two signal
+        # deaths proves the classifier is alive.
+        stub.write_text(
+            "import sys\n"
+            f"open({str(log)!r}, 'a').write(sys.argv[1] + chr(10))\n"
+            "sys.exit(2 if sys.argv[1] == 'RHAIRFE-2000' else 7)\n"
+        )
+        monkeypatch.setenv("RFE_SPLIT_SUBMIT_SCRIPT", str(stub))
+
+        r = _run_submit(art_dir, jira.url)
+        assert r.returncode == 1
+        assert "consecutive unclassified" not in r.stderr, "breaker tripped on a broken streak"
+        assert len(log.read_text().splitlines()) == 3
+
+    def test_seam_is_inert_outside_pytest(self, art_dir, jira, tmp_path):
+        """RFE_SPLIT_SUBMIT_SCRIPT must not swap the script in production
+        (review finding): without PYTEST_CURRENT_TEST the real script runs."""
+        self._parent(jira, art_dir, "RHAIRFE-1000", broken=True)
+        stub, log = self._stub_script(tmp_path, 0)
+
+        env = {
+            **os.environ,
+            "JIRA_SERVER": jira.url,
+            "JIRA_USER": "admin",
+            "JIRA_TOKEN": "admin",
+            "RFE_SPLIT_SUBMIT_SCRIPT": str(stub),
+        }
+        env.pop("PYTEST_CURRENT_TEST", None)
+        r = subprocess.run(
+            [sys.executable, SCRIPT, "--artifacts-dir", art_dir],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert not log.exists(), "seam activated outside pytest"
+        # The real script ran and hit the dead-end shape (exit 4 recorded).
+        assert r.returncode == 1
 
     def test_breaker_trips_after_two_consecutive_unclassified_failures(
         self, art_dir, jira, tmp_path, monkeypatch


### PR DESCRIPTION
Implements RHAIFIRST-571. **Stacked on #169** (RHAIFIRST-570) — merge that first; this PR's base is its branch, so GitHub will retarget to `main` when #169 lands.

## Why 565 stopped short

`submit.py` saw one undifferentiated failure bucket from `split_submit` — `jira_utils.api_call_with_retry` is a *retry* classifier, not a *fatal* one. Applying a per-parent policy to a systemic failure costs ~18 parents × ~3 requests × ~21s of backoff and leaves 18 bogus needs-attention flags; applying the systemic policy to a one-off keeps losing the rest of the batch.

## Changes

- **Classification at the source**: `split_submit` maps escaped exceptions to exit **4** (per-parent: a 400 on one child, local artifact shapes, the existing no-children/phase gates) or **5** (systemic: 401/403 immediately, 429/5xx only after retry exhaustion, `URLError`). argparse usage errors exit **64** — they exited 2, indistinguishable from the leaf-cap refusal (the ticket's noted trap).
- **One preflight call** (`GET /myself`) before the loop: a dead token costs one request and one accurate message. Proven by a 401-stub test asserting `split_submit` is never invoked.
- **Loop policy**: 4 → record + quarantine + **continue** (later parents and the regular phase still submit); 5 → record + quarantine the **failing** parent, then abort with no flags on the rest; unclassified codes feed a K=2 **consecutive** breaker that `break`s — never `sys.exit` — so `_finish()` still writes the report. The breaker resets on any *classified* outcome: two isolated signal deaths separated by a healthy refusal are not a streak.
- **Nothing lies anymore**: parents an abort or dead preflight skips get a local-only `split_not_attempted:` review error — no Jira flags (avoiding that fan-out is the abort's point) — so the run report counts them **failed**, not as successful splits; a crashed split (`split_submit_failed:`) counts failed with a `failed_reason`; the HTML separates "Split Failed — May Be Partially Applied" from the refusal banner and keeps a partial parent's real children in the submitted stats; bootstrap's processed-id reader skips `failed_reason`/`blocked_reason` entries for parity with the live snapshot.
- **Retry taxonomy**: `split_refused:`/`split_submit_failed:`/`split_not_attempted:` stay out of the retry batch; an all-non-retryable collection clears the retry file so ERROR_COLLECT routes to REPORT (composes with #162).

## Review

An adversarial multi-agent round on the first commit confirmed 11 findings (3 refuted), including two majors it reproduced live — both baked into the second commit: exit-5 can land **after real Jira writes** (mid-run token death inside phase 2), so the original "no quarantine on systemic" policy let a partial split escape 570's quarantine and get re-decomposed into duplicates by the next nightly; and the abort left the final report claiming `results.split = N` with zero splits in Jira. Also from the round: the `RFE_SPLIT_SUBMIT_SCRIPT` test seam is honored only under pytest (a stray env var must not swap the script in production), and the breaker's consecutiveness is now real.

## Verification

908 tests. Integration against the jira-emulator: per-parent continue (parent B submits despite parent A, A quarantined, B not), systemic abort (one invocation; failing parent quarantined + recorded; skipped parents get local records and **no** Jira flags), abort-report truth (`results.split == 0`, `failed == 3`, report written), breaker trip at 2 and non-trip across a broken streak, dead-Jira preflight (zero invocations), seam inert outside pytest, and a 401 stub proving `split_submit` itself exits 5 within ≤4 requests. 13 mutations across both commits, each killed by a named test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Jira authentication preflight checks before split submissions begin.
  - Improved handling of split submissions by distinguishing recoverable, systemic, refused, and not-attempted outcomes.
  - Reports now clearly identify failed or unsubmitted splits and whether work may be partially submitted.
  - Retry processing now excludes errors that cannot be retried.

- **Bug Fixes**
  - Corrected recovery and reporting so failed or blocked items are not counted as successfully processed.
  - Added safeguards to stop processing during systemic Jira failures and avoid unnecessary request fan-out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->