### PR TITLE
Validate pipeline ids before they reach a shell; pin REASSESS_FIXUP's id file

### DIFF
--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -22,6 +22,7 @@ Usage:
 import argparse
 import glob
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -299,6 +300,11 @@ def _build_phase_config(pipeline_type):
         "REASSESS_FIXUP": {
             "type": "script",
             "command": fixup_cmd,
+            # Deliberately the revise file, not the reassess file: REASSESS_RESTORE
+            # narrows the reassess set through filter_for_revision into
+            # tmp/pipeline-revise-ids.txt, REASSESS_REVISE revises exactly that
+            # subset, and the fixup must check the same subset. Pinned by
+            # tests/test_pipeline_state.py::TestReassessFixupIds.
             "ids_file": "tmp/pipeline-revise-ids.txt",
         },
         # --- Collect + Split ---
@@ -401,7 +407,8 @@ def _build_phase_config(pipeline_type):
 
 
 def _get_config(state):
-    """Get PHASE_CONFIG for the pipeline type in the current state."""
+    """Get PHASE_CONFIG for the pipeline type in the current state (validated first)."""
+    _validate_state_values(state)
     return _build_phase_config(state.get("type", "rfe"))
 
 
@@ -442,16 +449,82 @@ def _save_state(state):
         yaml.dump(state, f, default_flow_style=False, sort_keys=False)
 
 
+_VALID_ID_RE = re.compile(r"[A-Z][A-Z0-9]*-[0-9]+")  # ASCII only: \d would admit e.g. RHAIRFE-١
+_START_TIME_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z")
+_ASCII_DIGITS_RE = re.compile(r"[0-9]+")  # str.isdigit() accepts "²", which int() rejects
+
+
+def _validate_ids(ids, source=""):
+    """Reject any id that is not ``<PREFIX>-<digits>`` before it can reach a shell.
+
+    Every id list the pipeline reads — from ``tmp/*-ids.txt`` files or from a
+    decision script's stdout — is interpolated into ``shell=True`` commands or
+    becomes prompt variables and path components (``advance()``,
+    ``cmd_run_phase``, ``_save_originals``), so both are shell-injection and
+    path-traversal vectors. The grammar is
+    deliberately type-neutral: it accepts every local and Jira id shape the
+    pipeline produces (``RFE-001``, ``INIT-004``, ``RHAIRFE-2685``,
+    ``RHOAIENG-9876``) and nothing else. Per-type grammars belong to the type
+    registry (design-proposals/work-item-types-unified.md §3.2); this is the floor.
+    """
+    bad = [i for i in ids if not _VALID_ID_RE.fullmatch(i)]
+    if bad:
+        where = f" in {source}" if source else ""
+        # Show a bounded preview so the failure is diagnosable in a headless log
+        # (these files are written by the pipeline itself from Jira keys), but
+        # never echo a long line back verbatim.
+        preview = [b[:40] + ("…" if len(b) > 40 else "") for b in bad[:5]]
+        print(
+            f"[validate-ids] rejected {len(bad)} invalid id(s){where}: {preview!r}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return ids
+
+
+def _validate_state_values(state):
+    """Reject state values that are formatted into subprocess commands.
+
+    ``cmd_run_phase`` formats ``{start_time}`` and ``{batch_size}`` from
+    ``tmp/pipeline-state.yaml`` into the REPORT command, and the phase table is
+    selected by ``type``. These are formatted into ``shell=True`` commands, so a
+    tampered value could execute; the three fields ``init`` writes are checked
+    before use.
+    """
+    problems = []
+    ptype = state.get("type", "rfe")
+    if not isinstance(ptype, str) or ptype not in PIPELINE_TYPES:
+        problems.append(f"type={ptype!r} is not one of {sorted(PIPELINE_TYPES)}")
+    start_time = state.get("start_time", "")
+    if not isinstance(start_time, str) or not _START_TIME_RE.fullmatch(start_time):
+        problems.append("start_time is not an ISO-8601 UTC timestamp (YYYY-MM-DDTHH:MM:SSZ)")
+    else:
+        try:  # the regex checks shape only; reject impossible dates and clock values
+            datetime.strptime(start_time, "%Y-%m-%dT%H:%M:%SZ")
+        except ValueError:
+            problems.append(f"start_time {start_time!r} is not a real date/time")
+    batch_size = state.get("batch_size", 50)
+    is_int = isinstance(batch_size, int) and not isinstance(batch_size, bool)
+    is_digits = isinstance(batch_size, str) and _ASCII_DIGITS_RE.fullmatch(batch_size)
+    if not (is_int or is_digits) or int(batch_size) < 1:
+        problems.append("batch_size is not a positive integer")
+    if problems:
+        print("[validate-state] refusing to run: " + "; ".join(problems), file=sys.stderr)
+        sys.exit(1)
+    return state
+
+
 def _read_ids(path):
-    """Read IDs from a file, one per line."""
+    """Read IDs from a file, one per line. Invalid ids abort (see _validate_ids)."""
     if not os.path.exists(path):
         return []
     with open(path) as f:
-        return [line.strip() for line in f if line.strip()]
+        return _validate_ids([line.strip() for line in f if line.strip()], source=path)
 
 
 def _write_ids(path, ids):
-    """Write IDs to a file, one per line."""
+    """Write IDs to a file, one per line. Validated first: nothing malformed is persisted."""
+    _validate_ids(ids, source=path)
     os.makedirs(os.path.dirname(path) or "tmp", exist_ok=True)
     with open(path, "w") as f:
         for id_ in ids:
@@ -471,6 +544,7 @@ def _save_originals(ids, pipeline_type):
     check_revised.py --batch can detect whether the revise agent changed
     anything.
     """
+    _validate_ids(ids, source="_save_originals")  # ids become path components below
     t = PIPELINE_TYPES[pipeline_type]
     tasks_dir = t["tasks_dir"]
     originals_dir = tasks_dir.replace("rfe-tasks", "rfe-originals").replace(
@@ -495,14 +569,21 @@ def _run_script(cmd):
     return result.stdout.strip()
 
 
+def _ids_from_output(output, source):
+    """Whitespace-separated ids printed by a decision script, validated."""
+    return _validate_ids(output.split() if output else [], source=source)
+
+
 def _parse_line_ids(output, prefix):
-    """Parse IDs from a KEY=ID1,ID2 output line."""
+    """Parse IDs from a KEY=ID1,ID2 output line, validated."""
     for line in output.splitlines():
         if line.startswith(f"{prefix}="):
             val = line.split("=", 1)[1].strip()
             if not val:
                 return []
-            return [x.strip() for x in val.split(",") if x.strip()]
+            return _validate_ids(
+                [x.strip() for x in val.split(",") if x.strip()], source=f"{prefix}= line"
+            )
     return []
 
 
@@ -536,6 +617,7 @@ def advance(state, dry_run=False):
 
     Returns (next_phase, summary_line).
     """
+    _validate_state_values(state)  # type/start_time/batch_size feed decision-script argv
     phase = state["phase"]
     pipeline_type = state.get("type", "rfe")
     type_flag = f"--type {pipeline_type}"
@@ -556,7 +638,7 @@ def advance(state, dry_run=False):
         if not dry_run:
             active_ids = _read_ids("tmp/pipeline-active-ids.txt")
             out = _run_script(f"python3 scripts/filter_for_revision.py {' '.join(active_ids)}")
-            revise_ids = out.split() if out else []
+            revise_ids = _ids_from_output(out, "filter_for_revision.py output")
             _write_ids("tmp/pipeline-revise-ids.txt", revise_ids)
             if revise_ids:
                 _save_originals(revise_ids, pipeline_type)
@@ -573,7 +655,7 @@ def advance(state, dry_run=False):
                 out = _run_script(
                     f"python3 scripts/filter_for_revision.py {' '.join(reassess_ids)}"
                 )
-                revise_ids = out.split() if out else []
+                revise_ids = _ids_from_output(out, "filter_for_revision.py output")
                 _write_ids("tmp/pipeline-revise-ids.txt", revise_ids)
                 if revise_ids:
                     _save_originals(revise_ids, pipeline_type)
@@ -583,7 +665,7 @@ def advance(state, dry_run=False):
         if not dry_run:
             child_ids = _read_ids("tmp/pipeline-split-children-ids.txt")
             out = _run_script(f"python3 scripts/filter_for_revision.py {' '.join(child_ids)}")
-            revise_ids = out.split() if out else []
+            revise_ids = _ids_from_output(out, "filter_for_revision.py output")
             _write_ids("tmp/pipeline-revise-ids.txt", revise_ids)
             if revise_ids:
                 _save_originals(revise_ids, pipeline_type)
@@ -815,7 +897,7 @@ def cmd_run_phase(args):
     from ids_file if configured, and runs the command. The orchestrator
     never sees the underlying script name.
     """
-    state = _load_state()
+    state = _validate_state_values(_load_state())
     phase = state["phase"]
     config = _get_config(state).get(phase, {"type": "noop"})
     phase_type = config.get("type", "noop")

--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -23,6 +23,7 @@ import argparse
 import glob
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -223,10 +224,14 @@ def _build_phase_config(pipeline_type):
         },
         "SETUP": {
             "type": "script",
-            "command": (
-                f"bash scripts/bootstrap-assess-rfe.sh --type {pipeline_type} &"
-                " bash scripts/fetch-architecture-context.sh & wait"
-            ),
+            # Run concurrently. Exit codes are logged but do not fail the phase:
+            # the previous `a & b & wait` form returned wait's status, which is
+            # always 0, so this preserves behaviour. Fail-fast SETUP belongs to
+            # the registry's validate_types.py --verify gate.
+            "commands": [
+                f"bash scripts/bootstrap-assess-rfe.sh --type {pipeline_type}",
+                "bash scripts/fetch-architecture-context.sh",
+            ],
         },
         "ASSESS": {
             "type": "agent",
@@ -458,10 +463,9 @@ def _validate_ids(ids, source=""):
     """Reject any id that is not ``<PREFIX>-<digits>`` before it can reach a shell.
 
     Every id list the pipeline reads — from ``tmp/*-ids.txt`` files or from a
-    decision script's stdout — is interpolated into ``shell=True`` commands or
-    becomes prompt variables and path components (``advance()``,
-    ``cmd_run_phase``, ``_save_originals``), so both are shell-injection and
-    path-traversal vectors. The grammar is
+    decision script's stdout — becomes subprocess arguments, prompt variables,
+    or path components (``advance()``, ``cmd_run_phase``, ``_save_originals``),
+    so both are argument-injection and path-traversal vectors. The grammar is
     deliberately type-neutral: it accepts every local and Jira id shape the
     pipeline produces (``RFE-001``, ``INIT-004``, ``RHAIRFE-2685``,
     ``RHOAIENG-9876``) and nothing else. Per-type grammars belong to the type
@@ -487,9 +491,9 @@ def _validate_state_values(state):
 
     ``cmd_run_phase`` formats ``{start_time}`` and ``{batch_size}`` from
     ``tmp/pipeline-state.yaml`` into the REPORT command, and the phase table is
-    selected by ``type``. These are formatted into ``shell=True`` commands, so a
-    tampered value could execute; the three fields ``init`` writes are checked
-    before use.
+    selected by ``type``. Commands no longer go through a shell, but a tampered
+    value would still become extra argv tokens (``--start-time x --foo``), so the
+    three fields ``init`` writes are checked before use.
     """
     problems = []
     ptype = state.get("type", "rfe")
@@ -558,9 +562,14 @@ def _save_originals(ids, pipeline_type):
             shutil.copy2(task, orig)
 
 
+def _argv(cmd):
+    """Split a command template into an argument list; nothing goes through a shell."""
+    return shlex.split(cmd)
+
+
 def _run_script(cmd):
-    """Run a script and return stdout lines."""
-    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    """Run a script (given as a string, split with shlex, no shell) and return stdout."""
+    result = subprocess.run(_argv(cmd), capture_output=True, text=True)
     if result.returncode != 0:
         print(f"Script failed (exit code {result.returncode})", file=sys.stderr)
         if result.stderr:
@@ -904,11 +913,23 @@ def cmd_run_phase(args):
     if phase_type != "script":
         print(f"run-phase: phase {phase} is type '{phase_type}', not 'script'", file=sys.stderr)
         sys.exit(1)
-    cmd = config["command"].format_map(state)
+    if config.get("commands"):
+        # Concurrent commands (SETUP). See the phase config for why exit codes
+        # are logged rather than fatal.
+        print(f"[run-phase] {phase}")
+        procs = [(c, subprocess.Popen(_argv(c.format_map(state)))) for c in config["commands"]]
+        for c, proc in procs:
+            rc = proc.wait()
+            if rc != 0:
+                print(f"[run-phase] {phase}: exit {rc} from: {c}", file=sys.stderr)
+        with open(DISPATCH_MARKER, "w") as f:
+            f.write(phase)
+        return
+    argv = _argv(config["command"].format_map(state))
     if config.get("ids_file"):
         ids = _read_ids(config["ids_file"])
         if ids:
-            cmd += " " + " ".join(ids)
+            argv += ids
         else:
             print(f"[run-phase] {phase}: no IDs, skipping")
             # Write dispatch marker and return — nothing to do
@@ -916,7 +937,7 @@ def cmd_run_phase(args):
                 f.write(phase)
             return
     print(f"[run-phase] {phase}")
-    result = subprocess.run(cmd, shell=True)
+    result = subprocess.run(argv)
     if result.returncode != 0:
         sys.exit(result.returncode)
     # Write dispatch marker — advance checks this for script phases

--- a/tests/test_bootstrap_assess.py
+++ b/tests/test_bootstrap_assess.py
@@ -193,5 +193,7 @@ class TestCallersDeclareType:
         from pipeline_state import _build_phase_config
 
         for ptype in PIPELINE_TYPES:
-            command = _build_phase_config(ptype)["SETUP"]["command"]
-            assert f"bootstrap-assess-rfe.sh --type {ptype}" in command
+            setup = _build_phase_config(ptype)["SETUP"]
+            # SETUP runs its bootstrap steps as a concurrent "commands" list.
+            commands = setup.get("commands") or [setup["command"]]
+            assert any(f"bootstrap-assess-rfe.sh --type {ptype}" in c for c in commands)

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -685,7 +685,7 @@ class TestRunPhase:
         with redirect_stdout(buf):
             ps.cmd_run_phase([])
         assert len(calls) == 1
-        assert "generate_run_report.py" in calls[0]
+        assert any("generate_run_report.py" in part for part in calls[0])
         assert "[run-phase] REPORT" in buf.getvalue()
 
     def test_appends_ids(self, tmp_dir, monkeypatch):
@@ -1076,7 +1076,32 @@ class TestDispatchLoopE2E:
 
         # Verify invariant: script phases never expose command or ids_file
         if phase_type == "script":
-            monkeypatch.setattr(subprocess, "run", subprocess_mock)
+            assert "command" not in config, f"command leaked in {phase} config"
+            assert "ids_file" not in config, f"ids_file leaked in {phase} config"
+
+        # Verify invariant: agent phases retain needed fields
+        if phase_type == "agent":
+            assert "prompt" in config, f"prompt missing from {phase} config"
+            assert "ids_file" in config, f"ids_file missing from {phase} config"
+            assert "poll_phase" in config, f"poll_phase missing from {phase} config"
+
+        # Step 2: dispatch based on type
+        if phase_type == "script":
+            # run-phase passes argument lists; the per-test fakes sniff the
+            # command as a string, so hand them the joined form.
+            monkeypatch.setattr(
+                subprocess,
+                "run",
+                lambda cmd, **kw: subprocess_mock(
+                    cmd if isinstance(cmd, str) else " ".join(cmd), **kw
+                ),
+            )
+            # SETUP launches its two commands via Popen; keep the loop hermetic.
+            monkeypatch.setattr(
+                subprocess,
+                "Popen",
+                lambda argv, **kw: type("P", (), {"wait": lambda self: 0})(),
+            )
             buf = io.StringIO()
             with redirect_stdout(buf):
                 ps.cmd_run_phase([])
@@ -2332,7 +2357,7 @@ class TestValidateStateValues:
 
     def test_valid_state_runs(self, tmp_dir, monkeypatch):
         calls = self._run_report(monkeypatch)
-        assert len(calls) == 1 and "generate_run_report.py" in calls[0]
+        assert len(calls) == 1 and any("generate_run_report.py" in p for p in calls[0])
 
     @pytest.mark.parametrize(
         "overrides",
@@ -2366,6 +2391,79 @@ class TestValidateStateValues:
     def test_string_digit_batch_size_is_accepted(self, tmp_dir, monkeypatch):
         calls = self._run_report(monkeypatch, batch_size="25")
         assert len(calls) == 1 and "25" in calls[0]
+
+
+# ---------- No shell anywhere ----------
+
+
+class TestNoShell:
+    """Commands are argument lists; nothing is interpreted by a shell."""
+
+    def test_run_script_uses_argv_without_shell(self, monkeypatch):
+        seen = {}
+
+        def fake_run(cmd, **kw):
+            seen["cmd"], seen["kw"] = cmd, kw
+            return type("R", (), {"returncode": 0, "stdout": "ok\n", "stderr": ""})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert ps._run_script("python3 scripts/filter_for_revision.py RHAIRFE-1 RHAIRFE-2") == "ok"
+        assert seen["cmd"] == [
+            "python3",
+            "scripts/filter_for_revision.py",
+            "RHAIRFE-1",
+            "RHAIRFE-2",
+        ]
+        assert seen["kw"].get("shell") is not True
+
+    def test_run_phase_passes_state_values_as_separate_args(self, tmp_dir, monkeypatch):
+        ps._save_state(make_state(phase="REPORT", start_time="2026-04-09T00:00:00Z", batch_size=50))
+        seen = {}
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: (seen.update(cmd=cmd, kw=kw), type("R", (), {"returncode": 0})())[1],
+        )
+        import io
+        from contextlib import redirect_stdout
+
+        with redirect_stdout(io.StringIO()):
+            ps.cmd_run_phase([])
+        assert isinstance(seen["cmd"], list)
+        assert seen["cmd"][:2] == ["python3", "scripts/generate_run_report.py"]
+        assert seen["cmd"][seen["cmd"].index("--start-time") + 1] == "2026-04-09T00:00:00Z"
+        assert seen["kw"].get("shell") is not True
+
+    def test_setup_runs_both_commands_concurrently_and_logs_failures(
+        self, tmp_dir, monkeypatch, capsys
+    ):
+        ps._save_state(make_state(phase="SETUP"))
+        launched = []
+
+        class FakeProc:
+            def __init__(self, argv):
+                self.argv = argv
+
+            def wait(self):
+                return 3 if any("fetch-architecture-context" in a for a in self.argv) else 0
+
+        monkeypatch.setattr(
+            subprocess, "Popen", lambda argv, **kw: launched.append(argv) or FakeProc(argv)
+        )
+        ps.cmd_run_phase([])  # must not raise: exit codes are logged, not fatal
+        assert [a[:2] for a in launched] == [
+            ["bash", "scripts/bootstrap-assess-rfe.sh"],
+            ["bash", "scripts/fetch-architecture-context.sh"],
+        ]
+        assert all(isinstance(a, list) for a in launched)
+        assert "exit 3 from: bash scripts/fetch-architecture-context.sh" in capsys.readouterr().err
+        assert open(ps.DISPATCH_MARKER).read() == "SETUP"
+
+    def test_no_shell_true_left_in_module(self):
+        import inspect
+
+        src = inspect.getsource(ps)
+        assert "shell=True" not in src.replace("``shell=True``", "")
 
 
 # ---------- Ids parsed from script output are validated too ----------

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -160,7 +160,7 @@ class TestInit:
 
 class TestBatchStart:
     def test_resets_counters(self, tmp_dir):
-        write_ids("tmp/pipeline-batch-1-ids.txt", ["A", "B"])
+        write_ids("tmp/pipeline-batch-1-ids.txt", ["RHAIRFE-1", "RHAIRFE-2"])
         state = make_state(phase="BATCH_START", batch=0, reassess_cycle=2, correction_cycle=1)
         next_phase, _ = ps.advance(state)
         assert next_phase == "FETCH"
@@ -169,10 +169,10 @@ class TestBatchStart:
         assert state["batch"] == 1
 
     def test_copies_batch_ids_to_active(self, tmp_dir):
-        write_ids("tmp/pipeline-batch-1-ids.txt", ["X", "Y", "Z"])
+        write_ids("tmp/pipeline-batch-1-ids.txt", ["RHAIRFE-7", "RHAIRFE-8", "RHAIRFE-9"])
         state = make_state(phase="BATCH_START", batch=0)
         ps.advance(state)
-        assert read_ids("tmp/pipeline-active-ids.txt") == ["X", "Y", "Z"]
+        assert read_ids("tmp/pipeline-active-ids.txt") == ["RHAIRFE-7", "RHAIRFE-8", "RHAIRFE-9"]
 
 
 # ---------- Linear sequences ----------
@@ -219,8 +219,8 @@ class TestLinearSequences:
 class TestReassessLoop:
     def test_reassess_check_enters_loop(self, tmp_dir, monkeypatch):
         """REASSESS_CHECK enters reassess loop when IDs exist and cycle < 2."""
-        write_ids("tmp/pipeline-active-ids.txt", ["A", "B"])
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=A,B\nDONE=")
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1", "RHAIRFE-2"])
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=RHAIRFE-1,RHAIRFE-2\nDONE=")
         state = make_state(phase="REASSESS_CHECK", reassess_cycle=0)
         next_phase, summary = ps.advance(state)
         assert next_phase == "REASSESS_SAVE"
@@ -229,16 +229,16 @@ class TestReassessLoop:
 
     def test_reassess_check_exits_at_max_cycle(self, tmp_dir, monkeypatch):
         """REASSESS_CHECK goes to COLLECT when cycle >= 2."""
-        write_ids("tmp/pipeline-active-ids.txt", ["A"])
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=A\nDONE=")
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=RHAIRFE-1\nDONE=")
         state = make_state(phase="REASSESS_CHECK", reassess_cycle=2)
         next_phase, _ = ps.advance(state)
         assert next_phase == "COLLECT"
 
     def test_reassess_check_exits_when_no_ids(self, tmp_dir, monkeypatch):
         """REASSESS_CHECK goes to COLLECT when no reassess IDs."""
-        write_ids("tmp/pipeline-active-ids.txt", ["A"])
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=\nDONE=A")
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=\nDONE=RHAIRFE-1")
         state = make_state(phase="REASSESS_CHECK", reassess_cycle=0)
         next_phase, _ = ps.advance(state)
         assert next_phase == "COLLECT"
@@ -251,7 +251,7 @@ class TestReassessLoop:
 
     def test_last_cycle_skips_revise(self, tmp_dir, monkeypatch):
         """On cycle 2 (max), REASSESS_RESTORE writes empty revise IDs."""
-        write_ids("tmp/pipeline-reassess-ids.txt", ["A", "B"])
+        write_ids("tmp/pipeline-reassess-ids.txt", ["RHAIRFE-1", "RHAIRFE-2"])
         state = make_state(phase="REASSESS_RESTORE", reassess_cycle=2)
         next_phase, _ = ps.advance(state)
         assert next_phase == "REASSESS_REVISE"
@@ -259,12 +259,12 @@ class TestReassessLoop:
 
     def test_non_last_cycle_filters_for_revision(self, tmp_dir, monkeypatch):
         """On cycle < 2, REASSESS_RESTORE runs filter and writes revise IDs."""
-        write_ids("tmp/pipeline-reassess-ids.txt", ["A", "B"])
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "A")
+        write_ids("tmp/pipeline-reassess-ids.txt", ["RHAIRFE-1", "RHAIRFE-2"])
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "RHAIRFE-1")
         state = make_state(phase="REASSESS_RESTORE", reassess_cycle=1)
         next_phase, _ = ps.advance(state)
         assert next_phase == "REASSESS_REVISE"
-        assert read_ids("tmp/pipeline-revise-ids.txt") == ["A"]
+        assert read_ids("tmp/pipeline-revise-ids.txt") == ["RHAIRFE-1"]
 
 
 class TestReassessFullCycle:
@@ -273,8 +273,8 @@ class TestReassessFullCycle:
     def test_cycle1_revisions_are_reviewed_in_cycle2(self, tmp_dir, monkeypatch):
         """Trace: cycle 1 revises → cycle 2 reviews those revisions."""
         # Cycle 1: REASSESS_CHECK finds IDs, enters loop
-        write_ids("tmp/pipeline-active-ids.txt", ["A", "B"])
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=A,B\nDONE=")
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1", "RHAIRFE-2"])
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=RHAIRFE-1,RHAIRFE-2\nDONE=")
         state = make_state(phase="REASSESS_CHECK", reassess_cycle=0)
         next_phase, _ = ps.advance(state)
         assert next_phase == "REASSESS_SAVE"
@@ -294,11 +294,11 @@ class TestReassessFullCycle:
         assert next_phase == "REASSESS_RESTORE"
 
         # REASSESS_RESTORE: cycle=1 < 2, filters for revision
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "A")
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "RHAIRFE-1")
         state["phase"] = "REASSESS_RESTORE"
         next_phase, _ = ps.advance(state)
         assert next_phase == "REASSESS_REVISE"
-        assert read_ids("tmp/pipeline-revise-ids.txt") == ["A"]  # A needs more work
+        assert read_ids("tmp/pipeline-revise-ids.txt") == ["RHAIRFE-1"]  # RHAIRFE-1 needs more work
 
         # REASSESS_REVISE → REASSESS_FIXUP → REASSESS_CHECK
         state["phase"] = "REASSESS_FIXUP"
@@ -306,7 +306,7 @@ class TestReassessFullCycle:
         assert next_phase == "REASSESS_CHECK"
 
         # Cycle 2: enters loop again
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=A\nDONE=B")
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=RHAIRFE-1\nDONE=RHAIRFE-2")
         state["phase"] = "REASSESS_CHECK"
         next_phase, _ = ps.advance(state)
         assert next_phase == "REASSESS_SAVE"
@@ -336,7 +336,7 @@ class TestReassessFullCycle:
         next_phase, _ = ps.advance(state)
         assert next_phase == "REASSESS_CHECK"
 
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=A\nDONE=")
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=RHAIRFE-1\nDONE=")
         state["phase"] = "REASSESS_CHECK"
         next_phase, _ = ps.advance(state)
         assert next_phase == "COLLECT"  # cycle=2, exits even with reassess IDs
@@ -347,15 +347,15 @@ class TestReassessFullCycle:
 
 class TestReviewToRevise:
     def test_review_filters_active_ids(self, tmp_dir, monkeypatch):
-        write_ids("tmp/pipeline-active-ids.txt", ["A", "B", "C"])
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "A C")
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"])
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "RHAIRFE-1 RHAIRFE-3")
         state = make_state(phase="REVIEW")
         next_phase, _ = ps.advance(state)
         assert next_phase == "REVISE"
-        assert read_ids("tmp/pipeline-revise-ids.txt") == ["A", "C"]
+        assert read_ids("tmp/pipeline-revise-ids.txt") == ["RHAIRFE-1", "RHAIRFE-3"]
 
     def test_review_empty_filter(self, tmp_dir, monkeypatch):
-        write_ids("tmp/pipeline-active-ids.txt", ["A"])
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
         monkeypatch.setattr(ps, "_run_script", lambda cmd: "")
         state = make_state(phase="REVIEW")
         next_phase, _ = ps.advance(state)
@@ -481,20 +481,22 @@ class TestSplitCorrectionCheck:
 
 class TestCollect:
     def test_splits_go_to_split_phase(self, tmp_dir, monkeypatch):
-        write_ids("tmp/pipeline-active-ids.txt", ["A", "B"])
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1", "RHAIRFE-2"])
         monkeypatch.setattr(
-            ps, "_run_script", lambda cmd: "SUBMIT=A\nSPLIT=B\nREVISE=\nREJECT=\nERRORS="
+            ps,
+            "_run_script",
+            lambda cmd: "SUBMIT=RHAIRFE-1\nSPLIT=RHAIRFE-2\nREVISE=\nREJECT=\nERRORS=",
         )
         state = make_state(phase="COLLECT")
         next_phase, summary = ps.advance(state)
         assert next_phase == "SPLIT"
-        assert read_ids("tmp/pipeline-split-ids.txt") == ["B"]
+        assert read_ids("tmp/pipeline-split-ids.txt") == ["RHAIRFE-2"]
         assert "split=1" in summary
 
     def test_no_splits_go_to_batch_done(self, tmp_dir, monkeypatch):
-        write_ids("tmp/pipeline-active-ids.txt", ["A"])
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
         monkeypatch.setattr(
-            ps, "_run_script", lambda cmd: "SUBMIT=A\nSPLIT=\nREVISE=\nREJECT=\nERRORS="
+            ps, "_run_script", lambda cmd: "SUBMIT=RHAIRFE-1\nSPLIT=\nREVISE=\nREJECT=\nERRORS="
         )
         state = make_state(phase="COLLECT")
         next_phase, _ = ps.advance(state)
@@ -560,21 +562,21 @@ class TestErrorCollectAdvance:
 
 class TestBatchDone:
     def test_more_batches(self, tmp_dir, monkeypatch):
-        write_ids("tmp/pipeline-active-ids.txt", ["A"])
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
         monkeypatch.setattr(ps, "_run_script", lambda cmd: "TOTAL=1 PASSED=1")
         state = make_state(phase="BATCH_DONE", batch=1, total_batches=3)
         next_phase, _ = ps.advance(state)
         assert next_phase == "BATCH_START"
 
     def test_last_batch_with_errors(self, tmp_dir, monkeypatch):
-        write_ids("tmp/pipeline-active-ids.txt", ["A"])
-        write_ids("tmp/pipeline-all-ids.txt", ["A", "B"])
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
+        write_ids("tmp/pipeline-all-ids.txt", ["RHAIRFE-1", "RHAIRFE-2"])
 
         def mock_run(cmd):
             if "batch_summary" in cmd:
                 return "TOTAL=1 PASSED=1"
             if "collect_recommendations" in cmd:
-                return "ERRORS=B"
+                return "ERRORS=RHAIRFE-2"
             return ""
 
         monkeypatch.setattr(ps, "_run_script", mock_run)
@@ -583,8 +585,8 @@ class TestBatchDone:
         assert next_phase == "ERROR_COLLECT"
 
     def test_last_batch_no_errors(self, tmp_dir, monkeypatch):
-        write_ids("tmp/pipeline-active-ids.txt", ["A"])
-        write_ids("tmp/pipeline-all-ids.txt", ["A"])
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
+        write_ids("tmp/pipeline-all-ids.txt", ["RHAIRFE-1"])
         monkeypatch.setattr(
             ps,
             "_run_script",
@@ -595,12 +597,12 @@ class TestBatchDone:
         assert next_phase == "REPORT"
 
     def test_no_retry_after_max(self, tmp_dir, monkeypatch):
-        write_ids("tmp/pipeline-active-ids.txt", ["A"])
-        write_ids("tmp/pipeline-all-ids.txt", ["A", "B"])
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
+        write_ids("tmp/pipeline-all-ids.txt", ["RHAIRFE-1", "RHAIRFE-2"])
         monkeypatch.setattr(
             ps,
             "_run_script",
-            lambda cmd: "TOTAL=1 PASSED=1" if "batch_summary" in cmd else "ERRORS=B",
+            lambda cmd: "TOTAL=1 PASSED=1" if "batch_summary" in cmd else "ERRORS=RHAIRFE-2",
         )
         state = make_state(phase="BATCH_DONE", batch=2, total_batches=2, retry_cycle=1)
         next_phase, _ = ps.advance(state)
@@ -976,9 +978,9 @@ class TestSetWave:
 
     def test_set_wave_overwrites_previous(self, tmp_dir):
         """Successive set-wave calls replace the file."""
-        ps.cmd_set_wave(["A", "B", "C"])
-        ps.cmd_set_wave(["X", "Y"])
-        assert read_ids("tmp/pipeline-wave-ids.txt") == ["X", "Y"]
+        ps.cmd_set_wave(["RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"])
+        ps.cmd_set_wave(["RHAIRFE-7", "RHAIRFE-8"])
+        assert read_ids("tmp/pipeline-wave-ids.txt") == ["RHAIRFE-7", "RHAIRFE-8"]
 
     def test_set_wave_no_args_exits(self, tmp_dir):
         """set-wave with no IDs exits with error."""
@@ -1005,13 +1007,13 @@ class TestRevisionReviewInvariant:
 
     def test_main_revise_always_reaches_reassess_review(self, tmp_dir, monkeypatch):
         """Main REVISE → FIXUP → REASSESS_CHECK → REASSESS_REVIEW."""
-        write_ids("tmp/pipeline-active-ids.txt", ["A"])
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
         # FIXUP → REASSESS_CHECK
         state = make_state(phase="FIXUP")
         next_phase, _ = ps.advance(state)
         assert next_phase == "REASSESS_CHECK"
         # REASSESS_CHECK with reassess IDs → enters loop
-        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=A\nDONE=")
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "REASSESS=RHAIRFE-1\nDONE=")
         state["phase"] = "REASSESS_CHECK"
         next_phase, _ = ps.advance(state)
         assert next_phase == "REASSESS_SAVE"
@@ -1025,7 +1027,7 @@ class TestRevisionReviewInvariant:
 
     def test_last_reassess_cycle_cannot_revise(self, tmp_dir):
         """At max cycle, REASSESS_RESTORE produces zero revise IDs."""
-        write_ids("tmp/pipeline-reassess-ids.txt", ["A", "B", "C"])
+        write_ids("tmp/pipeline-reassess-ids.txt", ["RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"])
         state = make_state(phase="REASSESS_RESTORE", reassess_cycle=2)
         ps.advance(state)
         assert read_ids("tmp/pipeline-revise-ids.txt") == []
@@ -1073,17 +1075,6 @@ class TestDispatchLoopE2E:
         phase_type = config.get("type", "noop")
 
         # Verify invariant: script phases never expose command or ids_file
-        if phase_type == "script":
-            assert "command" not in config, f"command leaked in {phase} config"
-            assert "ids_file" not in config, f"ids_file leaked in {phase} config"
-
-        # Verify invariant: agent phases retain needed fields
-        if phase_type == "agent":
-            assert "prompt" in config, f"prompt missing from {phase} config"
-            assert "ids_file" in config, f"ids_file missing from {phase} config"
-            assert "poll_phase" in config, f"poll_phase missing from {phase} config"
-
-        # Step 2: dispatch based on type
         if phase_type == "script":
             monkeypatch.setattr(subprocess, "run", subprocess_mock)
             buf = io.StringIO()
@@ -1160,10 +1151,10 @@ class TestDispatchLoopE2E:
             if "filter_for_revision.py" in cmd:
                 return "RHAIRFE-1001 RHAIRFE-1002"  # 2 need revision
             if "collect_recommendations.py" in cmd and "--reassess" in cmd:
-                return "REASSESS=\nDONE=RHAIRFE-1001 RHAIRFE-1002 RHAIRFE-1003"
+                return "REASSESS=\nDONE=RHAIRFE-1001,RHAIRFE-1002,RHAIRFE-1003"
             if "collect_recommendations.py" in cmd:
                 return (
-                    "SUBMIT=RHAIRFE-1001 RHAIRFE-1002 RHAIRFE-1003\n"
+                    "SUBMIT=RHAIRFE-1001,RHAIRFE-1002,RHAIRFE-1003\n"
                     "SPLIT=\nREVISE=\nREJECT=\nERRORS="
                 )
             if "batch_summary.py" in cmd:
@@ -1223,11 +1214,11 @@ class TestDispatchLoopE2E:
                 reassess_calls["count"] += 1
                 if reassess_calls["count"] <= 2:
                     return "REASSESS=RHAIRFE-1001\nDONE=RHAIRFE-1002"
-                return "REASSESS=\nDONE=RHAIRFE-1001 RHAIRFE-1002"
+                return "REASSESS=\nDONE=RHAIRFE-1001,RHAIRFE-1002"
             if "collect_recommendations.py" in cmd and "--errors" in cmd:
                 return "ERRORS="
             if "collect_recommendations.py" in cmd:
-                return "SUBMIT=RHAIRFE-1001 RHAIRFE-1002\nSPLIT=\nREVISE=\nREJECT=\nERRORS="
+                return "SUBMIT=RHAIRFE-1001,RHAIRFE-1002\nSPLIT=\nREVISE=\nREJECT=\nERRORS="
             if "batch_summary.py" in cmd:
                 return "submit=2"
             return ""
@@ -1290,7 +1281,7 @@ class TestDispatchLoopE2E:
             if "filter_for_revision.py" in cmd:
                 return "RHAIRFE-1001"  # 1 needs revision
             if "collect_recommendations.py" in cmd and "--reassess" in cmd:
-                return "REASSESS=\nDONE=RHAIRFE-1001 RHAIRFE-1002"
+                return "REASSESS=\nDONE=RHAIRFE-1001,RHAIRFE-1002"
             if "collect_recommendations.py" in cmd and "--errors" in cmd:
                 return "ERRORS="
             if "collect_recommendations.py" in cmd:
@@ -1446,14 +1437,14 @@ class TestDispatchLoopE2E:
             if "filter_for_revision.py" in cmd:
                 return ""
             if "collect_recommendations.py" in cmd and "--reassess" in cmd:
-                return "REASSESS=\nDONE=RHAIRFE-1001 RHAIRFE-1002"
+                return "REASSESS=\nDONE=RHAIRFE-1001,RHAIRFE-1002"
             if "collect_recommendations.py" in cmd and "--errors" in cmd:
                 batch_done_calls["count"] += 1
                 if batch_done_calls["count"] == 1:
                     return "ERRORS=RHAIRFE-1002"  # error on first pass
                 return "ERRORS="  # clean on retry
             if "collect_recommendations.py" in cmd:
-                return "SUBMIT=RHAIRFE-1001 RHAIRFE-1002\nSPLIT=\nREVISE=\nREJECT=\nERRORS="
+                return "SUBMIT=RHAIRFE-1001,RHAIRFE-1002\nSPLIT=\nREVISE=\nREJECT=\nERRORS="
             if "batch_summary.py" in cmd:
                 return "submit=2"
             return ""
@@ -1632,11 +1623,11 @@ class TestDispatchLoopE2E:
             if "filter_for_revision.py" in cmd:
                 return ""
             if "collect_recommendations.py" in cmd and "--reassess" in cmd:
-                return "REASSESS=\nDONE=" + " ".join(ids)
+                return "REASSESS=\nDONE=" + ",".join(ids)
             if "collect_recommendations.py" in cmd and "--errors" in cmd:
                 return "ERRORS="
             if "collect_recommendations.py" in cmd:
-                return "SUBMIT=" + " ".join(ids) + "\nSPLIT=\nREVISE=\nREJECT=\nERRORS="
+                return "SUBMIT=" + ",".join(ids) + "\nSPLIT=\nREVISE=\nREJECT=\nERRORS="
             if "batch_summary.py" in cmd:
                 return "submit=3"
             return ""
@@ -1714,16 +1705,16 @@ class TestNextActionNoop:
 
     def test_noop_chain_with_side_effects(self, tmp_dir, monkeypatch):
         """REASSESS_CHECK → COLLECT chains through noops with side-effect scripts."""
-        write_ids("tmp/pipeline-active-ids.txt", ["A"])
-        write_ids("tmp/pipeline-all-ids.txt", ["A"])
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
+        write_ids("tmp/pipeline-all-ids.txt", ["RHAIRFE-1"])
 
         def mock_run_script(cmd):
             if "collect_recommendations.py" in cmd and "--reassess" in cmd:
-                return "REASSESS=\nDONE=A"
+                return "REASSESS=\nDONE=RHAIRFE-1"
             if "collect_recommendations.py" in cmd and "--errors" in cmd:
                 return "ERRORS="
             if "collect_recommendations.py" in cmd:
-                return "SUBMIT=A\nSPLIT=\nREVISE=\nREJECT=\nERRORS="
+                return "SUBMIT=RHAIRFE-1\nSPLIT=\nREVISE=\nREJECT=\nERRORS="
             if "batch_summary.py" in cmd:
                 return "submit=1"
             return ""
@@ -1739,8 +1730,8 @@ class TestNextActionNoop:
 
     def test_multi_batch_noop_chain(self, tmp_dir, monkeypatch):
         """BATCH_DONE → BATCH_START → FETCH chains across batch boundary."""
-        write_ids("tmp/pipeline-active-ids.txt", ["A"])
-        write_ids("tmp/pipeline-batch-2-ids.txt", ["B"])
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
+        write_ids("tmp/pipeline-batch-2-ids.txt", ["RHAIRFE-2"])
 
         def mock_run_script(cmd):
             if "batch_summary.py" in cmd:
@@ -1762,8 +1753,8 @@ class TestNextActionNoop:
     def test_state_saved_per_iteration(self, tmp_dir, monkeypatch):
         """State is saved after each noop advance — verified by checking
         that a crash mid-chain leaves correct phase on disk."""
-        write_ids("tmp/pipeline-batch-1-ids.txt", ["A"])
-        write_ids("tmp/pipeline-active-ids.txt", ["A"])
+        write_ids("tmp/pipeline-batch-1-ids.txt", ["RHAIRFE-1"])
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
 
         advance_calls = {"count": 0}
         original_advance = ps.advance
@@ -1786,7 +1777,7 @@ class TestNextActionScript:
     def test_script_no_marker(self, tmp_dir):
         """Script phase without marker returns run_script."""
         ps._save_state(make_state(phase="FIXUP"))
-        write_ids("tmp/pipeline-revise-ids.txt", ["A"])
+        write_ids("tmp/pipeline-revise-ids.txt", ["RHAIRFE-1"])
         result = _run_next_action()
         assert result["action"] == "run_script"
         assert result["phase"] == "FIXUP"
@@ -1794,19 +1785,19 @@ class TestNextActionScript:
     def test_script_with_correct_marker(self, tmp_dir, monkeypatch):
         """Script phase with matching marker auto-advances past it."""
         ps._save_state(make_state(phase="FIXUP", batch=1))
-        write_ids("tmp/pipeline-revise-ids.txt", ["A"])
-        write_ids("tmp/pipeline-active-ids.txt", ["A"])
-        write_ids("tmp/pipeline-all-ids.txt", ["A"])
+        write_ids("tmp/pipeline-revise-ids.txt", ["RHAIRFE-1"])
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
+        write_ids("tmp/pipeline-all-ids.txt", ["RHAIRFE-1"])
         with open(ps.DISPATCH_MARKER, "w") as f:
             f.write("FIXUP")
 
         def mock_run_script(cmd):
             if "collect_recommendations.py" in cmd and "--reassess" in cmd:
-                return "REASSESS=\nDONE=A"
+                return "REASSESS=\nDONE=RHAIRFE-1"
             if "collect_recommendations.py" in cmd and "--errors" in cmd:
                 return "ERRORS="
             if "collect_recommendations.py" in cmd:
-                return "SUBMIT=A\nSPLIT=\nREVISE=\nREJECT=\nERRORS="
+                return "SUBMIT=RHAIRFE-1\nSPLIT=\nREVISE=\nREJECT=\nERRORS="
             if "batch_summary.py" in cmd:
                 return "submit=1"
             return ""
@@ -1823,7 +1814,7 @@ class TestNextActionScript:
     def test_script_with_stale_marker(self, tmp_dir):
         """Stale marker (wrong phase) is removed and run_script returned."""
         ps._save_state(make_state(phase="FIXUP"))
-        write_ids("tmp/pipeline-revise-ids.txt", ["A"])
+        write_ids("tmp/pipeline-revise-ids.txt", ["RHAIRFE-1"])
         with open(ps.DISPATCH_MARKER, "w") as f:
             f.write("SETUP")  # stale marker from different phase
         result = _run_next_action()
@@ -2206,3 +2197,253 @@ class TestGetPhaseConfigHygiene:
             ps.cmd_get_phase_config([])
         output = buf.getvalue()
         assert "post_verify" not in output
+
+
+# ---------- ID validation ----------
+
+
+class TestValidateIds:
+    """Every id list is interpolated into shell=True commands, so _read_ids validates."""
+
+    def test_accepts_every_id_shape_the_pipeline_produces(self):
+        ids = ["RFE-001", "INIT-004", "RHAIRFE-2685", "RHOAIENG-9876", "RHAISTRAT-42"]
+        assert ps._validate_ids(ids) == ids
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "RHAIRFE-1001; rm -rf /",
+            "RHAIRFE-1001 | cat /etc/passwd",
+            "`id`",
+            "$(whoami)",
+            "../../outside",
+            "not-an-id",
+            "rfe-001",
+            "RHAIRFE-",
+            "-123",
+            "RHAIRFE-1001\n",
+            "RHAIRFE-١",  # Arabic-Indic digit one: \d would accept it, [0-9] must not
+            "RHAIRFE-１",  # fullwidth digit one
+        ],
+    )
+    def test_rejects_shell_metacharacters_traversal_and_arbitrary_strings(self, bad, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            ps._validate_ids(["RHAIRFE-1001", bad], source="tmp/x.txt")
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "[validate-ids]" in err
+        assert "tmp/x.txt" in err
+
+    def test_message_previews_are_bounded(self, capsys):
+        long_bad = "X" * 200
+        with pytest.raises(SystemExit):
+            ps._validate_ids([long_bad])
+        err = capsys.readouterr().err
+        assert "X" * 41 not in err
+        assert "…" in err
+
+    def test_read_ids_validates(self, tmp_dir):
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1001", "$(whoami)"])
+        with pytest.raises(SystemExit) as exc_info:
+            ps._read_ids("tmp/pipeline-active-ids.txt")
+        assert exc_info.value.code == 1
+
+    def test_read_ids_missing_file_is_empty(self, tmp_dir):
+        assert ps._read_ids("tmp/does-not-exist.txt") == []
+
+    def test_run_phase_rejects_before_subprocess(self, tmp_dir, monkeypatch):
+        """Script phases never reach subprocess.run with a bad id in the command."""
+        ps._save_state(make_state(phase="FIXUP"))
+        write_ids("tmp/pipeline-revise-ids.txt", ["RHAIRFE-1001", "$(whoami)"])
+        calls = []
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: (calls.append(cmd), type("R", (), {"returncode": 0})())[1],
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            ps.cmd_run_phase([])
+        assert exc_info.value.code == 1
+        assert calls == []
+
+    def test_next_action_rejects_before_wave_substitution(self, tmp_dir, monkeypatch):
+        """Agent phases never substitute a bad id into pre_script or vars."""
+        ps._save_state(make_state(phase="FETCH", batch=1))
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1001", "../../outside"])
+        ran = []
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: ran.append(cmd) or "")
+        with pytest.raises(SystemExit) as exc_info:
+            ps.cmd_next_action([])
+        assert exc_info.value.code == 1
+        assert ran == []
+
+
+# ---------- REASSESS_FIXUP reads the revised subset ----------
+
+
+class TestReassessFixupIds:
+    """REASSESS_FIXUP must check exactly the subset REASSESS_REVISE revised.
+
+    REASSESS_RESTORE narrows the reassess set through filter_for_revision into
+    tmp/pipeline-revise-ids.txt; REASSESS_REVISE and REASSESS_FIXUP share that
+    file on purpose. Pointing the fixup at tmp/pipeline-reassess-ids.txt would run
+    check_revised over items nobody revised that cycle (PR #146 proposed exactly
+    that as a "copy-paste fix").
+    """
+
+    @pytest.mark.parametrize("ptype", ["rfe", "initiative"])
+    def test_fixup_and_revise_share_the_revise_file(self, ptype):
+        cfg = ps._build_phase_config(ptype)
+        assert cfg["REASSESS_REVISE"]["ids_file"] == "tmp/pipeline-revise-ids.txt"
+        assert cfg["REASSESS_FIXUP"]["ids_file"] == cfg["REASSESS_REVISE"]["ids_file"]
+        assert cfg["REASSESS_RESTORE"]["ids_file"] == "tmp/pipeline-reassess-ids.txt"
+
+    def test_reassess_restore_narrows_into_the_revise_file(self, tmp_dir, monkeypatch):
+        write_ids("tmp/pipeline-reassess-ids.txt", ["RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"])
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "RHAIRFE-2")
+        monkeypatch.setattr(ps, "_save_originals", lambda ids, ptype: None)
+        nxt, _ = ps.advance(make_state(phase="REASSESS_RESTORE", reassess_cycle=1))
+        assert nxt == "REASSESS_REVISE"
+        assert read_ids("tmp/pipeline-revise-ids.txt") == ["RHAIRFE-2"]
+
+
+# ---------- State values formatted into shell commands ----------
+
+
+class TestValidateStateValues:
+    """cmd_run_phase formats start_time/batch_size into the REPORT command."""
+
+    def _run_report(self, monkeypatch, **overrides):
+        fields = {"phase": "REPORT", "start_time": "2026-04-09T00:00:00Z", "batch_size": 50}
+        fields.update(overrides)
+        ps._save_state(make_state(**fields))
+        calls = []
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: (calls.append(cmd), type("R", (), {"returncode": 0})())[1],
+        )
+        import io
+        from contextlib import redirect_stdout
+
+        with redirect_stdout(io.StringIO()):
+            ps.cmd_run_phase([])
+        return calls
+
+    def test_valid_state_runs(self, tmp_dir, monkeypatch):
+        calls = self._run_report(monkeypatch)
+        assert len(calls) == 1 and "generate_run_report.py" in calls[0]
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"start_time": "x; touch /tmp/pwned #"},
+            {"start_time": "2026-04-09T00:00:00Z; id"},
+            {"batch_size": "50; id"},
+            {"batch_size": 5.5},
+            {"batch_size": "²"},  # str.isdigit() is True, int() raises
+            {"batch_size": 0},  # _wave_size would silently make this one id per wave
+            {"batch_size": -1},
+            {"batch_size": "0"},
+            {"type": "rfe; id"},
+            {"type": []},  # unhashable: must be a controlled rejection, not a TypeError
+            {"type": {"rfe": 1}},
+            {"start_time": "2026-02-30T25:61:61Z"},  # shape-valid, impossible values
+            {"start_time": "2026-13-01T00:00:00Z"},
+            {"start_time": ["2026-04-09T00:00:00Z"]},
+        ],
+    )
+    def test_tampered_state_never_reaches_subprocess(self, tmp_dir, monkeypatch, overrides, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            self._run_report(monkeypatch, **overrides)
+        assert exc_info.value.code == 1
+        assert "[validate-state]" in capsys.readouterr().err
+
+    def test_leap_day_and_boundaries_are_accepted(self, tmp_dir, monkeypatch):
+        for ts_ in ("2028-02-29T23:59:59Z", "2026-12-31T00:00:00Z"):
+            assert len(self._run_report(monkeypatch, start_time=ts_)) == 1
+
+    def test_string_digit_batch_size_is_accepted(self, tmp_dir, monkeypatch):
+        calls = self._run_report(monkeypatch, batch_size="25")
+        assert len(calls) == 1 and "25" in calls[0]
+
+
+# ---------- Ids parsed from script output are validated too ----------
+
+
+class TestScriptOutputIsValidated:
+    """Malformed ids in a decision script's stdout abort before any file or path is touched."""
+
+    def _arm(self, tmp_dir, monkeypatch, phase, **state):
+        if phase == "REVIEW":
+            write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1", "RHAIRFE-2"])
+        elif phase == "REASSESS_RESTORE":
+            write_ids("tmp/pipeline-reassess-ids.txt", ["RHAIRFE-1", "RHAIRFE-2"])
+            state.setdefault("reassess_cycle", 1)
+        elif phase == "SPLIT_REVIEW":
+            write_ids("tmp/pipeline-split-children-ids.txt", ["RFE-002", "RFE-003"])
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: "RHAIRFE-1 ../../tmp/x")
+        saved = []
+        monkeypatch.setattr(ps, "_save_originals", lambda ids, ptype: saved.append(ids))
+        return make_state(phase=phase, **state), saved
+
+    @pytest.mark.parametrize("phase", ["REVIEW", "REASSESS_RESTORE", "SPLIT_REVIEW"])
+    def test_malformed_filter_output_exits_before_save_originals(
+        self, tmp_dir, monkeypatch, phase, capsys
+    ):
+        state, saved = self._arm(tmp_dir, monkeypatch, phase)
+        with pytest.raises(SystemExit) as exc_info:
+            ps.advance(state)
+        assert exc_info.value.code == 1
+        assert saved == []
+        assert not os.path.exists("tmp/pipeline-revise-ids.txt")
+        assert "filter_for_revision.py output" in capsys.readouterr().err
+
+    def test_parse_line_ids_validates(self, capsys):
+        assert ps._parse_line_ids("REASSESS=RHAIRFE-1,RHAIRFE-2\nDONE=", "REASSESS") == [
+            "RHAIRFE-1",
+            "RHAIRFE-2",
+        ]
+        assert ps._parse_line_ids("REASSESS=\nDONE=", "REASSESS") == []
+        with pytest.raises(SystemExit):
+            ps._parse_line_ids("REASSESS=RHAIRFE-1,$(id)", "REASSESS")
+        assert "REASSESS= line" in capsys.readouterr().err
+
+    def test_write_ids_refuses_malformed_and_writes_nothing(self, tmp_dir):
+        with pytest.raises(SystemExit):
+            ps._write_ids("tmp/pipeline-x-ids.txt", ["RHAIRFE-1", "../../y"])
+        assert not os.path.exists("tmp/pipeline-x-ids.txt")
+
+    def test_save_originals_refuses_path_components(self, tmp_dir):
+        with pytest.raises(SystemExit):
+            ps._save_originals(["../../etc/passwd"], "rfe")
+
+
+# ---------- Tampered state never reaches decision-script argv ----------
+
+
+class TestStateValidatedBeforeDecisionScripts:
+    def test_advance_rejects_tampered_type_before_run_script(self, tmp_dir, monkeypatch, capsys):
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
+        ran = []
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: ran.append(cmd) or "")
+        with pytest.raises(SystemExit) as exc_info:
+            ps.advance(make_state(phase="REVIEW", type="rfe --extra-option"))
+        assert exc_info.value.code == 1
+        assert ran == []
+        assert "[validate-state]" in capsys.readouterr().err
+
+    def test_next_action_rejects_tampered_type_before_any_script(self, tmp_dir, monkeypatch):
+        ps._save_state(make_state(phase="FETCH", batch=1, type="rfe --extra-option"))
+        write_ids("tmp/pipeline-active-ids.txt", ["RHAIRFE-1"])
+        ran = []
+        monkeypatch.setattr(ps, "_run_script", lambda cmd: ran.append(cmd) or "")
+        with pytest.raises(SystemExit) as exc_info:
+            ps.cmd_next_action([])
+        assert exc_info.value.code == 1
+        assert ran == []
+
+    def test_get_config_validates(self):
+        with pytest.raises(SystemExit):
+            ps._get_config(make_state(type="initiative; id"))
+        assert "REPORT" in ps._get_config(make_state(type="initiative"))


### PR DESCRIPTION
## Description

Relates to #146 (RHAIFIRST-320), which stays open for rework — this PR carries the part of it that is worth landing now, generalized, and records why one of its changes was not taken.

**1. Validate ids in `_read_ids`.** Every id list `pipeline_state.py` reads is interpolated into `shell=True` commands (`advance()`, `cmd_run_phase`, `pre_script`/`vars` substitution), so a `tmp/*-ids.txt` file is a shell-injection and path-traversal vector. `_read_ids` now validates against a type-neutral grammar `<PREFIX>-<digits>` — every local and Jira id shape the pipeline produces (`RFE-001`, `INIT-004`, `RHAIRFE-2685`, `RHOAIENG-9876`) and nothing else — and aborts with a `[validate-ids]` message naming the file. Differences from #146: its regex was RFE-only (`^(RFE-\d+|RHAIRFE-\d+)$`, which would reject every initiative id on main), and it validated at two call sites, leaving `advance()` uncovered.

**2. Pin `REASSESS_FIXUP`'s `ids_file` — #146's change there is not a fix.** `REASSESS_RESTORE` narrows the reassess set through `filter_for_revision` into `tmp/pipeline-revise-ids.txt`; `REASSESS_REVISE` revises exactly that subset; `REASSESS_FIXUP` must run `check_revised` over the same subset. Switching it to `tmp/pipeline-reassess-ids.txt` would check items nobody revised that cycle. The phase config now says so in a comment, and `TestReassessFixupIds` pins it for both types plus the narrowing behaviour of `advance()`.

**Not carried over:** #146's rewrite of every `PHASE_CONFIG` entry into list form. The same outcome (no shell anywhere) is reached in the second commit by splitting at the two execution sites instead, leaving the string templates for the type registry to regenerate.

Test fixtures that used placeholder ids (`A`, `B`, `X`, `Y`) now use `RHAIRFE-N` so they pass validation; behaviour under test is unchanged.

## How Has This Been Tested?

- `python3 -m pytest tests/ -k "not integration"`: 901 passed (51 new: `TestValidateIds`, `TestReassessFixupIds`, `TestValidateStateValues`, `TestNoShell`, `TestScriptOutputIsValidated`, `TestStateValidatedBeforeDecisionScripts`).
- Integration suite (jira-emulator) run locally; see the CI checks.
- `ruff check` / `ruff format --check` clean.
- Manual: `printf 'RHAIRFE-1\n$(whoami)\n' > tmp/pipeline-active-ids.txt` followed by `python3 scripts/pipeline_state.py next-action` on a FETCH-phase state exits 1 with `[validate-ids] rejected 1 invalid id(s) in tmp/pipeline-active-ids.txt: ['$(whoami)']` and runs nothing.

## Review follow-ups (CodeRabbit, 2026-09-04)

All folded into the two commits above (commit 1: id and state validation; commit 2: shell removal). Kept here as the review trail.

- **ASCII digits** — `\d` is Unicode-aware in Python, so `RHAIRFE-١` passed; the grammar is now `[A-Z][A-Z0-9]*-[0-9]+`, with Arabic-Indic and fullwidth digit tests.
- **Bounded log preview** — the `[validate-ids]` message shows at most five rejected values truncated to 40 characters, so a malformed line is diagnosable without being echoed verbatim.
- **State values formatted into the REPORT command** — `cmd_run_phase` formats `{start_time}` and `{batch_size}` from `tmp/pipeline-state.yaml` and selects the phase table by `type`; `_validate_state_values` now checks all three before use (a tampered value would otherwise become extra argv tokens).
- **`shell=True` removed from both execution sites** (the outside-diff major). No command template uses any shell feature, so `_run_script` and `cmd_run_phase` now split the template with `shlex` and pass argument lists. SETUP's `a & b & wait` becomes a `commands` list launched concurrently with `Popen`; exit codes are logged but not fatal, which is exactly what the old form did (`wait` with no arguments always returns 0), so behaviour is preserved — fail-fast SETUP belongs to the extensibility plan's `validate_types.py --verify` gate. A test asserts no `shell=True` remains in the module. This is done without #146's 573-line `PHASE_CONFIG` rewrite: the string templates stay, so the registry-driven launcher (design-proposals/work-item-types-unified.md §10 PR-2) can still regenerate them.
- **Ids parsed from script output are validated too** (second CodeRabbit review, outside-diff major). `_read_ids` covered ids read from files, but ids parsed from a decision script's stdout did not pass through it: the three `filter_for_revision.py` sites in `advance()` split the output straight into `_write_ids` and `_save_originals` (which builds paths from ids — a CWE-22 traversal), and `_parse_line_ids` fed `REASSESS`/`SPLIT`/`ERRORS` ids to `_write_ids` the same way. Validation now happens at every boundary where ids enter the pipeline: `_ids_from_output`, `_parse_line_ids`, `_write_ids` (backstop) and `_save_originals` itself. Regression tests drive `advance()` at all three sites with malformed output and assert it exits before `_save_originals` runs and before the revise file is written. The dispatch-loop fixtures had space-separated `KEY=` lines while the real scripts emit comma-separated lists (`collect_recommendations.py:72-84`); they now use the real format.
- **State validated before `advance()` and the phase-table lookup** (third CodeRabbit review, outside-diff major). `_validate_state_values` ran only in `cmd_run_phase`; `advance()` formats `state["type"]` into the `--type` flag of the decision scripts and `cmd_next_action` runs `pre_script`/`post_verify` from the phase table, so a modified state file could still inject *arguments* (CWE-88) even with no shell. It now runs at the top of `advance()` and inside `_get_config()`, which every phase-table consumer goes through; tests assert a tampered `type` never reaches `_run_script` from either path.
- **Validator hardening** (fourth CodeRabbit review, three findings on `_validate_state_values` itself): `start_time` is parsed with `strptime` after the shape regex, so `2026-02-30T25:61:61Z` is rejected; a non-string `type` (`type: []`) is a controlled `[validate-state]` rejection instead of a `TypeError` at the `PIPELINE_TYPES` membership test; `batch_size` strings must be ASCII digits (`str.isdigit()` accepts `"²"`, which `int()` rejects in `_wave_size`). Leap days and year boundaries stay accepted.
- **Positive `batch_size`** (fifth CodeRabbit review, minor): the integer branch accepted `0` and negatives and the string branch `"0"`, which `_wave_size` silently turns into one id per wave; `batch_size` must now be a positive integer, with tests for `0`, `-1` and `"0"`.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rejects malformed or unsafe pipeline IDs, state values, and decision-script outputs before processing or file creation.
  * Prevents invalid data from reaching pipeline commands and reassessment workflows.
  * Runs setup steps concurrently and reports individual command failures without interrupting the phase.
  * Improves command handling to prevent unintended shell interpretation.

* **Tests**
  * Expanded coverage for validation, state handling, command execution, setup configuration, and end-to-end pipeline scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->






