### PR TITLE
Carry auto_revised across re-review and rescan the whole reassess set

### DIFF
--- a/scripts/pipeline_state.py
+++ b/scripts/pipeline_state.py
@@ -305,12 +305,20 @@ def _build_phase_config(pipeline_type):
         "REASSESS_FIXUP": {
             "type": "script",
             "command": fixup_cmd,
-            # Deliberately the revise file, not the reassess file: REASSESS_RESTORE
-            # narrows the reassess set through filter_for_revision into
-            # tmp/pipeline-revise-ids.txt, REASSESS_REVISE revises exactly that
-            # subset, and the fixup must check the same subset. Pinned by
+            # The reassess file, not the revise file. REASSESS_REVIEW recreates
+            # every re-reviewed item's review file, which resets auto_revised to
+            # the schema default (false); REASSESS_RESTORE then narrows the
+            # reassess set through filter_for_revision into
+            # tmp/pipeline-revise-ids.txt for REASSESS_REVISE, so an item that
+            # PASSED after its revision is absent from that file. Scanning only
+            # that subset left exactly those items with auto_revised=false (5 of
+            # 5 revised items in the 2026-09-04 initiative eval; most production
+            # RFEs with a moved score since April), and submit.py derives the
+            # auto-revised Jira label from the flag. preserve_review_state.py
+            # restore carries the flag across the re-review as well; this is the
+            # diff-based safety net. Pinned by
             # tests/test_pipeline_state.py::TestReassessFixupIds.
-            "ids_file": "tmp/pipeline-revise-ids.txt",
+            "ids_file": "tmp/pipeline-reassess-ids.txt",
         },
         # --- Collect + Split ---
         "COLLECT": {"type": "noop"},

--- a/scripts/preserve_review_state.py
+++ b/scripts/preserve_review_state.py
@@ -1,7 +1,10 @@
 """Save and restore cumulative review state across re-assessment cycles.
 
-Saves before_scores and revision history to a JSON state file before
-re-review, then restores them after the new review file is written.
+Saves before_scores, the auto_revised flag and revision history to a JSON
+state file before re-review, then restores them after the new review file is
+written. The re-review recreates the review file from scratch, so the flag
+would otherwise fall back to the schema default (false) for every re-reviewed
+item; submit.py derives the auto-revised Jira label from it.
 
 Usage:
     python3 scripts/preserve_review_state.py save <ID> [<ID> ...]
@@ -74,6 +77,8 @@ def save(rfe_id):
     state = {
         "before_score": data.get("before_score"),
         "before_scores": data.get("before_scores"),
+        # Verified by check_revised.py --batch (FIXUP) before this save runs.
+        "auto_revised": bool(data.get("auto_revised", False)),
         "revision_history": extract_revision_history(rpath),
     }
 
@@ -99,12 +104,17 @@ def restore(rfe_id):
         print(f"SKIP={rfe_id} (no review file to restore into)")
         return
 
-    # Restore before_scores via frontmatter
+    # Restore before_scores and the auto_revised flag via frontmatter
     fm_updates = {}
     if state.get("before_score") is not None:
         fm_updates["before_score"] = state["before_score"]
     if state.get("before_scores"):
         fm_updates["before_scores"] = state["before_scores"]
+    # Only ever raise the flag: the fresh review defaults it to false, and a
+    # revision that happened in an earlier cycle stays a revision. A state file
+    # written before this key existed simply leaves the flag alone.
+    if state.get("auto_revised"):
+        fm_updates["auto_revised"] = True
     if fm_updates:
         update_frontmatter(rpath, fm_updates, _schema(rfe_id))
 

--- a/tests/test_pipeline_state.py
+++ b/tests/test_pipeline_state.py
@@ -1542,9 +1542,10 @@ class TestDispatchLoopE2E:
     def test_last_reassess_cycle_empty_revise(self, tmp_dir, monkeypatch):
         """Last reassess cycle writes empty revise IDs; run-phase handles it.
 
-        Cycle 2 hits the guard in REASSESS_RESTORE that writes empty
-        revise IDs. REASSESS_REVISE/REASSESS_FIXUP still run via the
-        dispatch loop but operate on zero IDs.
+        Cycle 2 hits the guard in REASSESS_RESTORE that writes empty revise
+        IDs, so REASSESS_REVISE has nothing to do. REASSESS_FIXUP still rescans
+        the reassess set: the re-review just recreated those review files, and
+        the fixup is what puts auto_revised back (see TestReassessFixupIds).
         """
         ids = ["RHAIRFE-1001"]
 
@@ -1585,15 +1586,10 @@ class TestDispatchLoopE2E:
         # Should see 3 REASSESS_CHECK (enter cycle 1, enter cycle 2, exit)
         assert phases.count("REASSESS_CHECK") == 3
 
-        # After cycle 2's REASSESS_RESTORE, revise IDs should be empty.
-        # run-phase skips the command entirely when IDs file is empty,
-        # so fixup_commands should only contain calls from earlier cycles
-        # where IDs were present. The last cycle's FIXUP is skipped.
-        # Verify we got fixup calls from cycle 1 (with IDs) but the
-        # total count reflects that the empty-ID cycle was skipped.
-        assert len(fixup_commands) >= 1  # at least cycle 1's FIXUP ran
-        # Cycle 1's fixup should have the ID
-        assert "RHAIRFE-1001" in fixup_commands[0]
+        # First-pass FIXUP (revise IDs) plus one REASSESS_FIXUP per reassess
+        # cycle (reassess IDs) - including cycle 2, whose revise IDs are empty.
+        assert len(fixup_commands) == 3
+        assert all("RHAIRFE-1001" in cmd for cmd in fixup_commands)
 
     def test_dispatch_context_hides_ids_file_for_scripts(self, tmp_dir):
         """dispatch-context must not leak ids_file for script phases."""
@@ -2307,21 +2303,31 @@ class TestValidateIds:
 
 
 class TestReassessFixupIds:
-    """REASSESS_FIXUP must check exactly the subset REASSESS_REVISE revised.
+    """REASSESS_FIXUP rescans every re-reviewed item, not only the re-revised subset.
 
-    REASSESS_RESTORE narrows the reassess set through filter_for_revision into
-    tmp/pipeline-revise-ids.txt; REASSESS_REVISE and REASSESS_FIXUP share that
-    file on purpose. Pointing the fixup at tmp/pipeline-reassess-ids.txt would run
-    check_revised over items nobody revised that cycle (PR #146 proposed exactly
-    that as a "copy-paste fix").
+    REASSESS_REVIEW recreates each re-reviewed item's review file, which resets
+    auto_revised to the schema default (false). REASSESS_RESTORE then narrows the
+    reassess set through filter_for_revision into tmp/pipeline-revise-ids.txt for
+    REASSESS_REVISE, so an item that passes after its revision is absent from that
+    file. Pointing the fixup at the revise file left exactly those items with
+    auto_revised=false (5 of 5 revised items in the 2026-09-04 initiative eval;
+    most production RFEs with a moved score since April 2026), and submit.py
+    derives the auto-revised Jira label from the flag. An earlier version of this
+    class pinned the revise file and called PR #146's reassess-file change wrong;
+    the evidence went the other way.
     """
 
     @pytest.mark.parametrize("ptype", ["rfe", "initiative"])
-    def test_fixup_and_revise_share_the_revise_file(self, ptype):
+    def test_fixup_rescans_the_whole_reassess_set(self, ptype):
         cfg = ps._build_phase_config(ptype)
-        assert cfg["REASSESS_REVISE"]["ids_file"] == "tmp/pipeline-revise-ids.txt"
-        assert cfg["REASSESS_FIXUP"]["ids_file"] == cfg["REASSESS_REVISE"]["ids_file"]
+        assert cfg["REASSESS_FIXUP"]["ids_file"] == "tmp/pipeline-reassess-ids.txt"
         assert cfg["REASSESS_RESTORE"]["ids_file"] == "tmp/pipeline-reassess-ids.txt"
+        assert cfg["REASSESS_REVISE"]["ids_file"] == "tmp/pipeline-revise-ids.txt"
+        # The first-pass FIXUP still checks exactly what REVISE revised: nothing
+        # has recreated those review files yet.
+        assert (
+            cfg["FIXUP"]["ids_file"] == cfg["REVISE"]["ids_file"] == "tmp/pipeline-revise-ids.txt"
+        )
 
     def test_reassess_restore_narrows_into_the_revise_file(self, tmp_dir, monkeypatch):
         write_ids("tmp/pipeline-reassess-ids.txt", ["RHAIRFE-1", "RHAIRFE-2", "RHAIRFE-3"])
@@ -2330,6 +2336,23 @@ class TestReassessFixupIds:
         nxt, _ = ps.advance(make_state(phase="REASSESS_RESTORE", reassess_cycle=1))
         assert nxt == "REASSESS_REVISE"
         assert read_ids("tmp/pipeline-revise-ids.txt") == ["RHAIRFE-2"]
+
+    def test_item_that_passed_after_revision_reaches_the_fixup(self, tmp_dir, monkeypatch):
+        """RHAIRFE-1 passed on re-review (not re-revised); check_revised must still see it."""
+        write_ids("tmp/pipeline-reassess-ids.txt", ["RHAIRFE-1", "RHAIRFE-2"])
+        write_ids("tmp/pipeline-revise-ids.txt", ["RHAIRFE-2"])
+        ps._save_state(make_state(phase="REASSESS_FIXUP", reassess_cycle=1))
+        calls = []
+
+        def fake_run(argv, **kw):
+            calls.append(argv)
+            return type("R", (), {"returncode": 0})()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        ps.cmd_run_phase([])
+        assert len(calls) == 1
+        assert calls[0][:3] == ["python3", "scripts/check_revised.py", "--batch"]
+        assert calls[0][-2:] == ["RHAIRFE-1", "RHAIRFE-2"]
 
 
 # ---------- State values formatted into shell commands ----------

--- a/tests/test_preserve_review_state.py
+++ b/tests/test_preserve_review_state.py
@@ -1,0 +1,141 @@
+"""Tests for scripts/preserve_review_state.py.
+
+The re-review recreates each review file from scratch, so everything cumulative
+(before_scores, the auto_revised flag, revision history) survives only through
+save/restore. An item revised in cycle 1 that passes in cycle 2 is not revised
+again, so nothing else would ever set auto_revised back; the flag drives the
+auto-revised Jira label at submit.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import preserve_review_state as prs  # noqa: E402
+from artifact_utils import read_frontmatter  # noqa: E402
+
+RFE_SCORES = "what: 2\n  why: 0\n  open_to_how: 1\n  not_a_task: 1\n  right_sized: 2"
+INIT_SCORES = "what: 2\n  why: 0\n  scope: 1\n  open_to_how: 1\n  right_sized: 2"
+
+
+def _revised_review(id_field, item_id, scores, auto_revised):
+    """Review as it looks right before REASSESS_SAVE: revised, still failing."""
+    return f"""---
+{id_field}: {item_id}
+score: 6
+pass: false
+recommendation: revise
+feasibility: feasible
+needs_attention: false
+scores:
+  {scores}
+auto_revised: {"true" if auto_revised else "false"}
+before_score: 6
+before_scores:
+  {scores}
+---
+# Review
+
+## Revision History
+- 2026-09-04 (auto-revise): reframed the objective as a business outcome
+"""
+
+
+def _fresh_review(id_field, item_id, scores):
+    """Review as REASSESS_REVIEW writes it: new pass, schema-default flag."""
+    return f"""---
+{id_field}: {item_id}
+score: 9
+pass: true
+recommendation: submit
+feasibility: feasible
+needs_attention: false
+scores:
+  {scores}
+auto_revised: false
+---
+# Review
+
+## Revision History
+"""
+
+
+CASES = [
+    ("RHAIRFE-1", "rfe_id", "artifacts/rfe-reviews", RFE_SCORES),
+    ("INIT-1", "initiative_id", "artifacts/initiative-reviews", INIT_SCORES),
+]
+
+
+@pytest.fixture
+def workdir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    for _, _, reviews_dir, _ in CASES:
+        os.makedirs(reviews_dir)
+    return tmp_path
+
+
+def _write(path, content):
+    with open(path, "w") as f:
+        f.write(content)
+
+
+@pytest.mark.parametrize("item_id,id_field,reviews_dir,scores", CASES)
+def test_save_records_the_verified_flag(workdir, item_id, id_field, reviews_dir, scores):
+    _write(prs.review_path(item_id), _revised_review(id_field, item_id, scores, True))
+    prs.save(item_id)
+    state = json.load(open(prs.state_path(item_id)))
+    assert state["auto_revised"] is True
+    assert state["before_score"] == 6
+    assert "reframed the objective" in state["revision_history"]
+
+
+@pytest.mark.parametrize("item_id,id_field,reviews_dir,scores", CASES)
+def test_restore_carries_the_flag_into_the_fresh_review(
+    workdir, item_id, id_field, reviews_dir, scores
+):
+    _write(prs.review_path(item_id), _revised_review(id_field, item_id, scores, True))
+    prs.save(item_id)
+    # REASSESS_SAVE deletes the review; REASSESS_REVIEW writes a new one.
+    _write(prs.review_path(item_id), _fresh_review(id_field, item_id, scores))
+
+    prs.restore(item_id)
+
+    data, body = read_frontmatter(prs.review_path(item_id))
+    assert data["auto_revised"] is True
+    assert data["score"] == 9  # the new pass is kept
+    assert data["before_score"] == 6
+    assert data["before_scores"]["why"] == 0
+    assert "reframed the objective" in body
+    assert not os.path.exists(prs.state_path(item_id))
+
+
+def test_restore_never_raises_a_flag_that_was_unset(workdir):
+    item_id = "RHAIRFE-2"
+    _write(prs.review_path(item_id), _revised_review("rfe_id", item_id, RFE_SCORES, False))
+    prs.save(item_id)
+    _write(prs.review_path(item_id), _fresh_review("rfe_id", item_id, RFE_SCORES))
+
+    prs.restore(item_id)
+
+    data, _ = read_frontmatter(prs.review_path(item_id))
+    assert data["auto_revised"] is False
+    assert data["before_score"] == 6
+
+
+def test_restore_tolerates_a_state_file_without_the_flag(workdir):
+    """State files written before the flag was saved must still restore cleanly."""
+    item_id = "RHAIRFE-3"
+    _write(prs.review_path(item_id), _fresh_review("rfe_id", item_id, RFE_SCORES))
+    with open(prs.state_path(item_id), "w") as f:
+        json.dump({"before_score": 5, "before_scores": None, "revision_history": ""}, f)
+
+    prs.restore(item_id)
+
+    data, _ = read_frontmatter(prs.review_path(item_id))
+    assert data["auto_revised"] is False
+    assert data["before_score"] == 5
+    assert not os.path.exists(prs.state_path(item_id))


### PR DESCRIPTION
## Summary

Items that were auto-revised and then **passed** on re-review ended with `auto_revised: false`. The flag drives the `*-auto-revised` Jira label (`submit.py:724`) and `revision_cycles` in run reports, so those items shipped unlabeled and were reported as never revised.

**Mechanism (type-independent, since the dispatcher landed in `664a0ad`, 2026-04-08):**

1. `REASSESS_SAVE` deletes the review file; `REASSESS_REVIEW` recreates it with the schema default `auto_revised: false`.
2. `preserve_review_state.py restore` carried only `before_score(s)` and the revision history, not the flag.
3. `REASSESS_FIXUP` rescanned only `tmp/pipeline-revise-ids.txt`, which `REASSESS_RESTORE` narrows to items that *still fail*. A passing item is absent, so nothing ever set the flag back.
4. The split path has no fixup after its re-review at all, so it relied on restore alone.

**Evidence**

- Initiative eval on #172 (2026-09-04): `revision_flag_consistency` 0.6875. The 5 failing cases (INIT-004/010/013/014/015) are exactly the 5 that were revised; each has a restored `before_score`, a restored revision history, a saved original whose body differs by 16–29 lines, and `auto_revised: false` / `revision_cycles: 0`.
- The RFE eval passed the same check at 1.0 only because none of its 20 cases needed a revision (all before == after, no originals).
- Production results repo (`rfe-autofixer-results`, 316 run reports since 2026-03-31): 1361 items with a moved score, **623 with the flag false**, nearly all since mid-April. Recent examples: RHAIRFE-3273, 3238, 3242, 2868, 2752, 3170, 3156.

## Fix (two layers)

- `preserve_review_state.py`: `save` records the flag (already verified by the FIXUP diff before the save), `restore` raises it again on the fresh review and never lowers it. This is the field set `docs/state-machine/pipeline-correctness-reference.md:793` had documented all along, and it also covers the split path.
- `pipeline_state.py`: `REASSESS_FIXUP` reads `tmp/pipeline-reassess-ids.txt` so the diff-based safety net covers every re-reviewed item. This is the change PR #146 proposed. PR #171's `TestReassessFixupIds` pinned the opposite on my wrong reading of the narrowing step; it is rewritten here with the reasoning and a run-phase test showing a passed-after-revision item reaching `check_revised`.

Behavior change worth knowing: the last reassess cycle now runs its fixup over the reassess set instead of skipping on empty revise IDs (the loop test asserts the extra call).

## Tests

- New `tests/test_preserve_review_state.py` (rfe + initiative): save records the flag, restore carries it into a fresh review, never raises an unset flag, tolerates pre-existing state files without the key.
- `TestReassessFixupIds` rewritten; `test_last_reassess_cycle_empty_revise` updated.
- Full suite: 1048 passed. ruff clean.

## Follow-ups (not in this PR)

- Re-run the initiative eval on #172 after this merges to get a valid baseline.
- The RFE eval dataset currently exercises no revision at all, so `revision_quality`/`revision_flag_consistency` are vacuous on the RFE config; it needs a few weak-first-draft cases.
- Backfilling the missing Jira labels on already-submitted items is a separate decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reassessment fixups now process the complete reassessment set, including items that passed review without requiring revision.
  - The auto-revised status is now preserved across re-review cycles, preventing previously flagged items from losing their status.
  - Existing review state remains compatible when restoring records created before this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->