### PR TITLE
Add weak-draft RFE cases and gate both evals on revision coverage

### DIFF
--- a/eval-initiative.yaml
+++ b/eval-initiative.yaml
@@ -52,7 +52,9 @@ dataset:
       - expected_feasibility (nullable string)
       - expected_alignment (nullable string: strong/partial/weak/not_assessed)
       - known_issues (list)
-      - tags (list)
+      - tags (list): free-form labels; `revision-expected` marks a
+        deliberately weak draft that the revision_coverage judge requires
+        the pipeline to auto-revise (see eval/README.md)
       - difficulty (nullable string)
 
 inputs:
@@ -414,6 +416,197 @@ judges:
           len(errors) == 0,
           "; ".join(errors[:5]) if errors else f"{checked} reviews: auto_revised matches evidence",
       )
+  - name: revision_coverage
+    description: |
+      Verify the run exercised the revise/reassess path. When every draft passes
+      first review, revision_quality scores "the decision not to revise" 4-5 and
+      revision_flag_consistency passes vacuously, so nothing fails when revision
+      coverage is zero. A case tagged `revision-expected` (a deliberately weak
+      draft) passes only with evidence its item was revised; untagged cases
+      pass, but in a multi-item run every case fails when neither it nor the
+      shared run report shows a single revised item, so untagged-but-revised
+      items still count towards run coverage. A single-item run (Harbor task,
+      execution.mode: case) is decided by the tag alone. Reads only shared
+      artifacts, so the identical check runs on both pipelines.
+    check: |
+      import os
+      import re
+
+      import yaml
+
+      TAG = "revision-expected"
+      # What a template leaves under "## Revision History" when nothing happened.
+      EMPTY_HISTORY = {"", "none", "n/a", "no revisions", "no revision"}
+
+      files = outputs.get("files", {})
+      # _modified/ mirrors in-place edits of the same paths; skip them so the
+      # basename indexes below cannot be overwritten by a duplicate.
+      files = {k: v for k, v in files.items() if not k.startswith("_modified/")}
+      reviews = {k: v for k, v in files.items() if k.endswith("-review.md")}
+      if not reviews:
+          return (False, "No review files to check")
+
+      def split_front(content):
+          """(frontmatter dict or None, body) of a ---...--- fronted document."""
+          if not isinstance(content, str):
+              return None, ""
+          if not content.startswith("---"):
+              return None, content
+          # Split on the closing fence only, so a literal --- inside a field
+          # value cannot truncate the frontmatter.
+          end = content.find("\n---", 3)
+          if end == -1:
+              return None, content
+          try:
+              fm = yaml.safe_load(content[3:end]) or {}
+          except yaml.YAMLError:
+              fm = None
+          return (fm if isinstance(fm, dict) else None), content[end + 4:]
+
+      def norm(text):
+          return re.sub(r"\s+", " ", text).strip()
+
+      # Index by basename: the two pipelines use different directory names
+      # (rfe-tasks/rfe-originals vs initiatives/initiative-originals).
+      names = {os.path.basename(k) for k in files}
+      originals = {os.path.basename(k): v for k, v in files.items() if "-originals/" in k}
+      tasks = {
+          os.path.basename(k): v
+          for k, v in files.items()
+          if k.endswith(".md") and "-originals/" not in k and "-reviews/" not in k
+      }
+      # Run-level coverage from the shared run report(s): the report lists every
+      # item of the batch, so any one case can see whether the run revised
+      # anything at all. Merge with OR across reports so a stale report cannot
+      # mask a newer one's evidence.
+      report_revised = {}
+      # Ids listed under an intermediary's `children`; an entry that is nobody's
+      # child is one of the run's input items.
+      report_children = set()
+      for k in sorted(files):
+          v = files[k]
+          if not (k.startswith("artifacts/auto-fix-runs/") and k.endswith(".yaml")):
+              continue
+          # Snapshot files (issue-snapshot-*, initiative-snapshot-*) are fetch
+          # artifacts, not run reports.
+          if "-snapshot-" in os.path.basename(k):
+              continue
+          # Undecodable files arrive as a {"_binary": True} marker, not text.
+          if not isinstance(v, str):
+              continue
+          try:
+              report = yaml.safe_load(v) or {}
+          except yaml.YAMLError:
+              continue
+          # A malformed report must skip this signal, not raise - an uncaught
+          # error drops the whole case from the pass-rate denominator silently.
+          if not isinstance(report, dict):
+              continue
+          entries = []
+          for key in ("per_rfe", "per_initiative"):
+              section = report.get(key)
+              if isinstance(section, list):
+                  entries += section
+          for entry in entries:
+              if not isinstance(entry, dict):
+                  continue
+              item = entry.get("id")
+              if not isinstance(item, str) or not item:
+                  continue
+              rc = entry.get("revision_cycles")
+              if isinstance(rc, bool) or not isinstance(rc, int):
+                  rc = 0
+              before, after = entry.get("before_score"), entry.get("after_score")
+              moved = before is not None and after is not None and before != after
+              revised = rc > 0 or entry.get("auto_revised") is True or moved
+              report_revised[item] = report_revised.get(item, False) or revised
+              kids = entry.get("children")
+              if isinstance(kids, list):
+                  report_children.update(c for c in kids if isinstance(c, str))
+      run_revised = sorted(i for i, r in report_revised.items() if r)
+      # A report describing exactly one input item (its split children, if any,
+      # do not add inputs) is a single-case run: Harbor task or
+      # execution.mode: case. There "the run revised nothing" says nothing
+      # about coverage, so the run-level check below does not apply.
+      single_item_run = len([i for i in report_revised if i not in report_children]) == 1
+      coverage = f"run coverage {len(run_revised)}/{len(report_revised)} report items"
+      if single_item_run:
+          coverage += " (single-item run: tag decides)"
+
+      # Per-case evidence, keyed by item id so a review and its companions merge.
+      evidence = {}
+      for fname, content in sorted(reviews.items()):
+          fm, body = split_front(content)
+          if fm is None:
+              continue
+          item_id = fm.get("rfe_id") or fm.get("initiative_id")
+          # Require a real string id so the dict lookups below cannot raise.
+          if not isinstance(item_id, str) or not item_id:
+              continue
+          found = evidence.setdefault(item_id, [])
+          # Legacy artifacts stored the flag as `revised`.
+          flag = fm["auto_revised"] if "auto_revised" in fm else fm.get("revised")
+          if flag is True:
+              found.append("auto_revised=true")
+          before, score = fm.get("before_score"), fm.get("score")
+          if before is not None and score is not None and before != score:
+              found.append(f"before_score {before} != score {score}")
+          before_scores, cur_scores = fm.get("before_scores"), fm.get("scores")
+          if before_scores is not None and cur_scores is not None and before_scores != cur_scores:
+              found.append("before_scores != scores")
+          # -originals/ is written before an auto-revision edits the task, so an
+          # original whose body differs from the current task is a revision.
+          # Compare bodies only (frontmatter moves for other reasons) with
+          # whitespace normalised so a reflow does not count.
+          orig, task = originals.get(f"{item_id}.md"), tasks.get(f"{item_id}.md")
+          if isinstance(orig, str) and isinstance(task, str):
+              if norm(split_front(orig)[1]) != norm(split_front(task)[1]):
+                  found.append("originals body differs from task")
+          # Written only when a revision removes content.
+          if f"{item_id}-removed-context.yaml" in names or f"{item_id}-removed-context.md" in names:
+              found.append("removed-context companion")
+          # restore() deletes the review-state file once a re-review cycle
+          # completes, so one left on disk is a revision cycle that ran.
+          if f"{item_id}-review-state.json" in names:
+              found.append("leftover review-state file")
+          if report_revised.get(item_id):
+              found.append("run report records a revision")
+          # A Revision History section holding anything but the template's
+          # "none" placeholder was written by a revision (restore() prepends the
+          # saved history, so the placeholder may appear alongside real entries).
+          # The section runs to the next level-1/2 heading: entries may use ###.
+          m = re.search(r"^#{2,3}\s+Revision History\s*$(.*?)(?=^#{1,2}\s|\Z)", body, re.M | re.S)
+          if m:
+              lines = [
+                  re.sub(r"^[\s\-*_>]+|[\s\-*_.]+$", "", ln).lower()
+                  for ln in m.group(1).splitlines()
+              ]
+              if any(ln not in EMPTY_HISTORY for ln in lines):
+                  found.append("non-empty Revision History")
+      if not evidence:
+          return (False, "No review files to check")
+      revised = {i: e for i, e in evidence.items() if e}
+
+      # annotations is the case's dataset annotations.yaml, loaded by the harness
+      # next to files/inputs; a case without one is simply untagged.
+      ann = outputs.get("annotations")
+      tags = ann.get("tags") if isinstance(ann, dict) else None
+      tags = [str(t) for t in tags] if isinstance(tags, list) else []
+      tagged = TAG in tags
+
+      # Loud run-level failure: nothing in the whole run was revised, so the
+      # revise/reassess path went untested and every downstream revision judge
+      # is vacuous. Every case fails on this branch, by design. A missing
+      # report or a multi-item batch with zero revisions fails every case; only
+      # a single-item run is exempt (the tag alone decides it).
+      if not revised and not run_revised and not single_item_run:
+          return (False, f"revise path never exercised: no revision evidence in this case and {coverage}")
+      if tagged and not revised:
+          return (False, f"tagged {TAG} but no revision evidence for {', '.join(sorted(evidence))}; {coverage}")
+      if revised:
+          detail = "; ".join(f"{i}: {', '.join(e)}" for i, e in sorted(revised.items()))
+          return (True, f"revised ({detail}); {coverage}")
+      return (True, f"not revised (untagged); {coverage}")
   - name: pipeline_flow
     description: |
       Verify expected execution flow from stdout: all phases ran,
@@ -687,6 +880,19 @@ thresholds:
     min_pass_rate: 1.0
   revision_flag_consistency:
     min_pass_rate: 1.0
+  # revision_coverage: with 25 cases of which 5 are tagged revision-expected,
+  # 3 of 5 revised leaves 2 failures -> 23/25 = 0.92 (pass); 2 of 5 revised
+  # leaves 3 failures -> 22/25 = 0.88 (fail). The 2-failure slack is shared:
+  # a tagged draft the create step repairs on its own, a tagged draft the
+  # first review rejects or splits instead of revising (correct pipeline
+  # behaviour, but it never enters the revise path and leaves no evidence),
+  # and any case without a review file each consume one failure. Calibrated
+  # offline only; re-tune after the first 25-case run. A multi-item run with
+  # zero revisions fails every case (0.0) on any dataset. Single-item runs
+  # (Harbor tasks, execution.mode: case) skip the run-level check and are
+  # decided by the tag alone. Untagged cases otherwise always pass.
+  revision_coverage:
+    min_pass_rate: 0.92
   pipeline_flow:
     min_pass_rate: 1.0
   architecture_context_used:

--- a/eval-initiative.yaml
+++ b/eval-initiative.yaml
@@ -880,17 +880,18 @@ thresholds:
     min_pass_rate: 1.0
   revision_flag_consistency:
     min_pass_rate: 1.0
-  # revision_coverage: with 25 cases of which 5 are tagged revision-expected,
-  # 3 of 5 revised leaves 2 failures -> 23/25 = 0.92 (pass); 2 of 5 revised
-  # leaves 3 failures -> 22/25 = 0.88 (fail). The 2-failure slack is shared:
-  # a tagged draft the create step repairs on its own, a tagged draft the
-  # first review rejects or splits instead of revising (correct pipeline
-  # behaviour, but it never enters the revise path and leaves no evidence),
-  # and any case without a review file each consume one failure. Calibrated
-  # offline only; re-tune after the first 25-case run. A multi-item run with
-  # zero revisions fails every case (0.0) on any dataset. Single-item runs
-  # (Harbor tasks, execution.mode: case) skip the run-level check and are
-  # decided by the tag alone. Untagged cases otherwise always pass.
+  # revision_coverage: the initiative dataset has 16 cases and no case tagged
+  # revision-expected yet, so a tagged draft can never fail here; the gate
+  # bites only through the run-level rule (a multi-item run with zero
+  # revisions fails every case, 0.0) and through cases without a review
+  # file. At 16 cases 0.92 allows one failing case (15/16 = 0.9375 passes,
+  # 14/16 = 0.875 fails). It passes today on incidental revisions (5 of 16
+  # items revised on 2026-09-04); a model that produces all-clean initiative
+  # drafts fails it by design, and the durable fix is tagged weak-draft
+  # initiative cases (see eval.yaml for the 25-case / 5-tagged arithmetic
+  # this value was calibrated on). Single-item runs (Harbor tasks,
+  # execution.mode: case) skip the run-level check and are decided by the
+  # tag alone. Untagged cases otherwise always pass.
   revision_coverage:
     min_pass_rate: 0.92
   pipeline_flow:

--- a/eval.yaml
+++ b/eval.yaml
@@ -51,7 +51,9 @@ dataset:
       - expected_feasibility (nullable string)
       - known_issues (list)
       - score_tolerance (int, default 1)
-      - tags (list)
+      - tags (list): free-form labels; `revision-expected` marks a
+        deliberately weak draft that the revision_coverage judge requires
+        the pipeline to auto-revise (see eval/README.md)
       - difficulty (nullable string)
 
 inputs:
@@ -410,6 +412,197 @@ judges:
           len(errors) == 0,
           "; ".join(errors[:5]) if errors else f"{checked} reviews: auto_revised matches evidence",
       )
+  - name: revision_coverage
+    description: |
+      Verify the run exercised the revise/reassess path. When every draft passes
+      first review, revision_quality scores "the decision not to revise" 4-5 and
+      revision_flag_consistency passes vacuously, so nothing fails when revision
+      coverage is zero. A case tagged `revision-expected` (a deliberately weak
+      draft) passes only with evidence its item was revised; untagged cases
+      pass, but in a multi-item run every case fails when neither it nor the
+      shared run report shows a single revised item, so untagged-but-revised
+      items still count towards run coverage. A single-item run (Harbor task,
+      execution.mode: case) is decided by the tag alone. Reads only shared
+      artifacts, so the identical check runs on both pipelines.
+    check: |
+      import os
+      import re
+
+      import yaml
+
+      TAG = "revision-expected"
+      # What a template leaves under "## Revision History" when nothing happened.
+      EMPTY_HISTORY = {"", "none", "n/a", "no revisions", "no revision"}
+
+      files = outputs.get("files", {})
+      # _modified/ mirrors in-place edits of the same paths; skip them so the
+      # basename indexes below cannot be overwritten by a duplicate.
+      files = {k: v for k, v in files.items() if not k.startswith("_modified/")}
+      reviews = {k: v for k, v in files.items() if k.endswith("-review.md")}
+      if not reviews:
+          return (False, "No review files to check")
+
+      def split_front(content):
+          """(frontmatter dict or None, body) of a ---...--- fronted document."""
+          if not isinstance(content, str):
+              return None, ""
+          if not content.startswith("---"):
+              return None, content
+          # Split on the closing fence only, so a literal --- inside a field
+          # value cannot truncate the frontmatter.
+          end = content.find("\n---", 3)
+          if end == -1:
+              return None, content
+          try:
+              fm = yaml.safe_load(content[3:end]) or {}
+          except yaml.YAMLError:
+              fm = None
+          return (fm if isinstance(fm, dict) else None), content[end + 4:]
+
+      def norm(text):
+          return re.sub(r"\s+", " ", text).strip()
+
+      # Index by basename: the two pipelines use different directory names
+      # (rfe-tasks/rfe-originals vs initiatives/initiative-originals).
+      names = {os.path.basename(k) for k in files}
+      originals = {os.path.basename(k): v for k, v in files.items() if "-originals/" in k}
+      tasks = {
+          os.path.basename(k): v
+          for k, v in files.items()
+          if k.endswith(".md") and "-originals/" not in k and "-reviews/" not in k
+      }
+      # Run-level coverage from the shared run report(s): the report lists every
+      # item of the batch, so any one case can see whether the run revised
+      # anything at all. Merge with OR across reports so a stale report cannot
+      # mask a newer one's evidence.
+      report_revised = {}
+      # Ids listed under an intermediary's `children`; an entry that is nobody's
+      # child is one of the run's input items.
+      report_children = set()
+      for k in sorted(files):
+          v = files[k]
+          if not (k.startswith("artifacts/auto-fix-runs/") and k.endswith(".yaml")):
+              continue
+          # Snapshot files (issue-snapshot-*, initiative-snapshot-*) are fetch
+          # artifacts, not run reports.
+          if "-snapshot-" in os.path.basename(k):
+              continue
+          # Undecodable files arrive as a {"_binary": True} marker, not text.
+          if not isinstance(v, str):
+              continue
+          try:
+              report = yaml.safe_load(v) or {}
+          except yaml.YAMLError:
+              continue
+          # A malformed report must skip this signal, not raise - an uncaught
+          # error drops the whole case from the pass-rate denominator silently.
+          if not isinstance(report, dict):
+              continue
+          entries = []
+          for key in ("per_rfe", "per_initiative"):
+              section = report.get(key)
+              if isinstance(section, list):
+                  entries += section
+          for entry in entries:
+              if not isinstance(entry, dict):
+                  continue
+              item = entry.get("id")
+              if not isinstance(item, str) or not item:
+                  continue
+              rc = entry.get("revision_cycles")
+              if isinstance(rc, bool) or not isinstance(rc, int):
+                  rc = 0
+              before, after = entry.get("before_score"), entry.get("after_score")
+              moved = before is not None and after is not None and before != after
+              revised = rc > 0 or entry.get("auto_revised") is True or moved
+              report_revised[item] = report_revised.get(item, False) or revised
+              kids = entry.get("children")
+              if isinstance(kids, list):
+                  report_children.update(c for c in kids if isinstance(c, str))
+      run_revised = sorted(i for i, r in report_revised.items() if r)
+      # A report describing exactly one input item (its split children, if any,
+      # do not add inputs) is a single-case run: Harbor task or
+      # execution.mode: case. There "the run revised nothing" says nothing
+      # about coverage, so the run-level check below does not apply.
+      single_item_run = len([i for i in report_revised if i not in report_children]) == 1
+      coverage = f"run coverage {len(run_revised)}/{len(report_revised)} report items"
+      if single_item_run:
+          coverage += " (single-item run: tag decides)"
+
+      # Per-case evidence, keyed by item id so a review and its companions merge.
+      evidence = {}
+      for fname, content in sorted(reviews.items()):
+          fm, body = split_front(content)
+          if fm is None:
+              continue
+          item_id = fm.get("rfe_id") or fm.get("initiative_id")
+          # Require a real string id so the dict lookups below cannot raise.
+          if not isinstance(item_id, str) or not item_id:
+              continue
+          found = evidence.setdefault(item_id, [])
+          # Legacy artifacts stored the flag as `revised`.
+          flag = fm["auto_revised"] if "auto_revised" in fm else fm.get("revised")
+          if flag is True:
+              found.append("auto_revised=true")
+          before, score = fm.get("before_score"), fm.get("score")
+          if before is not None and score is not None and before != score:
+              found.append(f"before_score {before} != score {score}")
+          before_scores, cur_scores = fm.get("before_scores"), fm.get("scores")
+          if before_scores is not None and cur_scores is not None and before_scores != cur_scores:
+              found.append("before_scores != scores")
+          # -originals/ is written before an auto-revision edits the task, so an
+          # original whose body differs from the current task is a revision.
+          # Compare bodies only (frontmatter moves for other reasons) with
+          # whitespace normalised so a reflow does not count.
+          orig, task = originals.get(f"{item_id}.md"), tasks.get(f"{item_id}.md")
+          if isinstance(orig, str) and isinstance(task, str):
+              if norm(split_front(orig)[1]) != norm(split_front(task)[1]):
+                  found.append("originals body differs from task")
+          # Written only when a revision removes content.
+          if f"{item_id}-removed-context.yaml" in names or f"{item_id}-removed-context.md" in names:
+              found.append("removed-context companion")
+          # restore() deletes the review-state file once a re-review cycle
+          # completes, so one left on disk is a revision cycle that ran.
+          if f"{item_id}-review-state.json" in names:
+              found.append("leftover review-state file")
+          if report_revised.get(item_id):
+              found.append("run report records a revision")
+          # A Revision History section holding anything but the template's
+          # "none" placeholder was written by a revision (restore() prepends the
+          # saved history, so the placeholder may appear alongside real entries).
+          # The section runs to the next level-1/2 heading: entries may use ###.
+          m = re.search(r"^#{2,3}\s+Revision History\s*$(.*?)(?=^#{1,2}\s|\Z)", body, re.M | re.S)
+          if m:
+              lines = [
+                  re.sub(r"^[\s\-*_>]+|[\s\-*_.]+$", "", ln).lower()
+                  for ln in m.group(1).splitlines()
+              ]
+              if any(ln not in EMPTY_HISTORY for ln in lines):
+                  found.append("non-empty Revision History")
+      if not evidence:
+          return (False, "No review files to check")
+      revised = {i: e for i, e in evidence.items() if e}
+
+      # annotations is the case's dataset annotations.yaml, loaded by the harness
+      # next to files/inputs; a case without one is simply untagged.
+      ann = outputs.get("annotations")
+      tags = ann.get("tags") if isinstance(ann, dict) else None
+      tags = [str(t) for t in tags] if isinstance(tags, list) else []
+      tagged = TAG in tags
+
+      # Loud run-level failure: nothing in the whole run was revised, so the
+      # revise/reassess path went untested and every downstream revision judge
+      # is vacuous. Every case fails on this branch, by design. A missing
+      # report or a multi-item batch with zero revisions fails every case; only
+      # a single-item run is exempt (the tag alone decides it).
+      if not revised and not run_revised and not single_item_run:
+          return (False, f"revise path never exercised: no revision evidence in this case and {coverage}")
+      if tagged and not revised:
+          return (False, f"tagged {TAG} but no revision evidence for {', '.join(sorted(evidence))}; {coverage}")
+      if revised:
+          detail = "; ".join(f"{i}: {', '.join(e)}" for i, e in sorted(revised.items()))
+          return (True, f"revised ({detail}); {coverage}")
+      return (True, f"not revised (untagged); {coverage}")
   - name: pipeline_flow
     description: |
       Verify expected execution flow from stdout: all phases ran,
@@ -660,6 +853,19 @@ thresholds:
     min_pass_rate: 1.0
   revision_flag_consistency:
     min_pass_rate: 1.0
+  # revision_coverage: with 25 cases of which 5 are tagged revision-expected,
+  # 3 of 5 revised leaves 2 failures -> 23/25 = 0.92 (pass); 2 of 5 revised
+  # leaves 3 failures -> 22/25 = 0.88 (fail). The 2-failure slack is shared:
+  # a tagged draft the create step repairs on its own, a tagged draft the
+  # first review rejects or splits instead of revising (correct pipeline
+  # behaviour, but it never enters the revise path and leaves no evidence),
+  # and any case without a review file each consume one failure. Calibrated
+  # offline only; re-tune after the first 25-case run. A multi-item run with
+  # zero revisions fails every case (0.0) on any dataset. Single-item runs
+  # (Harbor tasks, execution.mode: case) skip the run-level check and are
+  # decided by the tag alone. Untagged cases otherwise always pass.
+  revision_coverage:
+    min_pass_rate: 0.92
   pipeline_flow:
     min_pass_rate: 1.0
   architecture_context_used:

--- a/eval.yaml
+++ b/eval.yaml
@@ -859,8 +859,10 @@ thresholds:
   # a tagged draft the create step repairs on its own, a tagged draft the
   # first review rejects or splits instead of revising (correct pipeline
   # behaviour, but it never enters the revise path and leaves no evidence),
-  # and any case without a review file each consume one failure. Calibrated
-  # offline only; re-tune after the first 25-case run. A multi-item run with
+  # and any case without a review file each consume one failure. Calibrated on
+  # two live 5-case runs (2026-09-07): drafts weak only by wording were
+  # repaired at create time in 4 of 5; drafts with an in-character "no
+  # customer evidence, do not pad" anchor were revised in 5 of 5. A multi-item run with
   # zero revisions fails every case (0.0) on any dataset. Single-item runs
   # (Harbor tasks, execution.mode: case) skip the run-level check and are
   # decided by the tag alone. Untagged cases otherwise always pass.

--- a/eval/README.md
+++ b/eval/README.md
@@ -82,7 +82,9 @@ The `revision_coverage` threshold (`min_pass_rate: 0.92`) tolerates 2 failing ca
 - a weak draft the first review **rejects or splits** instead of revising. `scripts/filter_for_revision.py` never routes `reject`, `autorevise_reject` or `split` recommendations into the revise path, so a correct reject or split leaves no revision evidence; split children are not routed to any case directory in batch mode and count only towards run-level coverage via the report;
 - any case without a review file (`No review files to check`).
 
-The 0.92 value was calibrated offline against runs that predate the weak drafts; record the per-tagged-case outcome (revised / repaired at create / rejected / split) of the first 25-case run and re-tune the threshold against it. A multi-item run in which nothing was revised fails every case (0.0), on either pipeline. Single-item runs (Harbor tasks, `execution.mode: case`), whose run report describes exactly one input item (split children do not add inputs), skip the run-level check and are decided by the tag alone.
+The 0.92 value was calibrated on two live 5-case runs on 2026-09-07 (claude-opus-4-6, `--dry-run`). The first authoring of the five drafts, which relied on rewording weaknesses (a mandated design, a chore framing, a vague ask, an internal requester), was repaired by the create step in 4 of 5 cases (first-pass scores 8-9, only the missing-WHY draft was revised). The second authoring added an in-character evidence anchor to each draft and 5 of 5 were revised (first-pass 5-8, every one failing on `why: 0`, three also on `not_a_task`, `what` or `right_sized`), all five passed re-review, and `revision_coverage` scored 1.0. Re-tune only if a future run shows a different distribution.
+
+**Authoring a weak draft that survives the create step.** The creator and the reviser share a model and a rubric, so any weakness that can be fixed by rewording is fixed at create time and the draft passes first review. The only weakness that survives is one that needs information the input does not contain, stated plainly in the requester's voice: no customer has asked, no support case exists, no internal team should be listed as an affected customer, and the customer and business sections should stay honest rather than padded with generic segments. The assessor awards `why: 1` for any generic or internal segment, so the anchor must close every such route; it awards `why: 0` only when the draft names no beneficiaries and no justification at all.
 
 ### Judges
 
@@ -151,7 +153,7 @@ One case (`case-012`, tagged `sparse-input`) provides minimal context to test sp
 | `run_report_exists` | check | Initiative run report YAML with required fields |
 | `recommendation_consistency` | check | pass/fail aligns with recommendation, infeasible != submit, weak alignment sets needs_attention |
 | `revision_flag_consistency` | check | `auto_revised` agrees with revision evidence (state file, history, moved score, removed-context) |
-| `revision_coverage` | check | Revise path exercised: untagged-but-revised cases count; every case fails when a multi-item run revised nothing (single-item runs: tag alone decides) |
+| `revision_coverage` | check | Revise path exercised (16 cases, no tagged weak drafts yet, so 0.92 allows one failing case): untagged-but-revised cases count; every case fails when a multi-item run revised nothing (single-item runs: tag alone decides) |
 | `pipeline_flow` | check | Phases ran, no fatal tracebacks |
 | `architecture_context_used` | check | Feasibility files used architecture context |
 | `initiative_quality` | LLM | Initiative quality (WHAT/WHY/Scope/HOW/Right-sized) + calibration accuracy |

--- a/eval/README.md
+++ b/eval/README.md
@@ -38,7 +38,7 @@ Each run produces:
 
 ## How it works
 
-The evaluation runs the `rfe.speedrun` skill headlessly against 20 test cases derived from real RHAIRFE Jira issues. Each test case provides a problem statement (prompt + clarifying context), and the pipeline creates, reviews, auto-fixes, and (dry-run) submits RFEs.
+The evaluation runs the `rfe.speedrun` skill headlessly against 25 test cases: 20 derived from real RHAIRFE Jira issues plus 5 deliberately weak drafts (see [Weak-draft cases](#weak-draft-cases)). Each test case provides a problem statement (prompt + clarifying context), and the pipeline creates, reviews, auto-fixes, and (dry-run) submits RFEs.
 
 ### How it was generated
 
@@ -52,7 +52,7 @@ The evaluation runs the `rfe.speedrun` skill headlessly against 20 test cases de
 
 ### Dataset
 
-`eval/dataset/cases/` contains 20 test cases, each with:
+`eval/dataset/cases/` contains 25 test cases, each with:
 
 | File | Purpose |
 |------|---------|
@@ -60,6 +60,29 @@ The evaluation runs the `rfe.speedrun` skill headlessly against 20 test cases de
 | `annotations.yaml` | Expected scores, feasibility/recommendation expectations, test tags |
 
 Input files contain only the fields the skill needs in batch Mode A — no Jira keys or existing RFE content.
+
+#### Weak-draft cases
+
+Cases `case-021` through `case-025` are deliberately weak drafts (`difficulty: hard`) that the pipeline is expected to auto-revise. Their `annotations.yaml` carries `tags: [weak-draft, revision-expected, <mode>]`, where `<mode>` names the flaw the draft carries. Only `revision-expected` has judge semantics: the `revision_coverage` check fails a case tagged with it unless its RFE shows revision evidence. Any one of eight signals counts:
+
+1. `auto_revised: true` in the review frontmatter (or the legacy `revised: true`)
+2. `before_score != score`
+3. `before_scores != scores` (per-criterion breakdown moved)
+4. an `rfe-originals/` body that differs from the current task body (whitespace-normalised)
+5. a removed-context companion (`{id}-removed-context.yaml` or `.md`)
+6. a leftover `{id}-review-state.json` (a re-review cycle ran)
+7. the shared run report recording a revision for the item (`revision_cycles > 0`, `auto_revised: true`, or `before_score != after_score`)
+8. a non-empty Revision History section (anything other than the template's `none` placeholder)
+
+Without these cases every draft passed first review at 8-10, so the revise/reassess path was never exercised: `revision_quality` scored the decision not to revise 4-5 and `revision_flag_consistency` passed vacuously.
+
+The `revision_coverage` threshold (`min_pass_rate: 0.92`) tolerates 2 failing cases out of 25: 3 of 5 weak drafts revised leaves 2 failing cases, 23/25 = 0.92 (pass); 2 of 5 leaves 3, 22/25 = 0.88 (fail). That 2-failure slack is shared by every way a case can fail this check:
+
+- a weak draft the create step repairs on its own (passes first review, no revision);
+- a weak draft the first review **rejects or splits** instead of revising. `scripts/filter_for_revision.py` never routes `reject`, `autorevise_reject` or `split` recommendations into the revise path, so a correct reject or split leaves no revision evidence; split children are not routed to any case directory in batch mode and count only towards run-level coverage via the report;
+- any case without a review file (`No review files to check`).
+
+The 0.92 value was calibrated offline against runs that predate the weak drafts; record the per-tagged-case outcome (revised / repaired at create / rejected / split) of the first 25-case run and re-tune the threshold against it. A multi-item run in which nothing was revised fails every case (0.0), on either pipeline. Single-item runs (Harbor tasks, `execution.mode: case`), whose run report describes exactly one input item (split children do not add inputs), skip the run-level check and are decided by the tag alone.
 
 ### Judges
 
@@ -69,6 +92,8 @@ Input files contain only the fields the skill needs in batch Mode A — no Jira 
 | `frontmatter_valid` | check | YAML schema, score ranges, pass logic consistency |
 | `run_report_exists` | check | Auto-fix YAML run report with required fields |
 | `recommendation_consistency` | check | pass/fail aligns with recommendation, infeasible != submit |
+| `revision_flag_consistency` | check | `auto_revised` agrees with revision evidence (state file, history, moved score, removed-context) |
+| `revision_coverage` | check | Revise path exercised: `revision-expected` cases were revised; every case fails when a multi-item run revised nothing (single-item runs: tag alone decides) |
 | `pipeline_flow` | check | Phases ran, no tracebacks, no Phase 1 deletions |
 | `architecture_context_used` | check | Feasibility files must not indicate missing architecture context |
 | `rfe_quality` | LLM | RFE quality (WHAT/WHY/HOW/task/scope) + calibration accuracy |
@@ -125,6 +150,8 @@ One case (`case-012`, tagged `sparse-input`) provides minimal context to test sp
 | `frontmatter_valid` | check | YAML schema, score ranges, alignment enum, pass logic consistency |
 | `run_report_exists` | check | Initiative run report YAML with required fields |
 | `recommendation_consistency` | check | pass/fail aligns with recommendation, infeasible != submit, weak alignment sets needs_attention |
+| `revision_flag_consistency` | check | `auto_revised` agrees with revision evidence (state file, history, moved score, removed-context) |
+| `revision_coverage` | check | Revise path exercised: untagged-but-revised cases count; every case fails when a multi-item run revised nothing (single-item runs: tag alone decides) |
 | `pipeline_flow` | check | Phases ran, no fatal tracebacks |
 | `architecture_context_used` | check | Feasibility files used architecture context |
 | `initiative_quality` | LLM | Initiative quality (WHAT/WHY/Scope/HOW/Right-sized) + calibration accuracy |

--- a/eval/dataset/cases/case-021-model-registry-version-compare/annotations.yaml
+++ b/eval/dataset/cases/case-021-model-registry-version-compare/annotations.yaml
@@ -1,0 +1,17 @@
+difficulty: hard
+expected_feasibility: null
+expected_pass: null
+expected_recommendation: null
+expected_scores:
+  not_a_task: null
+  open_to_how: null
+  right_sized: null
+  what: null
+  why: null
+expected_total: null
+known_issues: []
+score_tolerance: 1
+tags:
+- weak-draft
+- revision-expected
+- why-missing

--- a/eval/dataset/cases/case-021-model-registry-version-compare/input.yaml
+++ b/eval/dataset/cases/case-021-model-registry-version-compare/input.yaml
@@ -1,0 +1,24 @@
+clarifying_context: 'This came out of me walking a colleague through the registry pages, not out of any customer conversation.
+  Nobody has put it in front of customers, there is nothing in the field-request tracker for it, and we do not have usage
+  numbers for the version details pages, so treat the customer side as unknown for now. It is not tied to a release theme
+  or roadmap item as far as I know. We also have not looked at what other registries or competitor products do here, so there
+  is no competitive or market angle to cite either. Honest status: we just think it would be handy to have. If the customer
+  or business side has to stay blank, leave it blank rather than padding it with generic segments; we would rather the gap
+  be visible than papered over.
+
+
+  What it would do: on the versions table of a registered model you tick two versions and hit Compare. You get a two-column
+  view listing version name, description, author, created and last-updated timestamps, source location or artifact URI, model
+  format name and version, labels, and custom properties. Rows whose values differ are highlighted, and a property present
+  on only one side shows as missing on the other. Read-only, exactly two versions at a time, and only versions of the same
+  registered model.
+
+
+  Not in scope: cross-model or cross-registry comparison, comparing artifact contents or metrics, exporting the diff, or anything
+  in the CLI or Python client. Every field listed is already shown on the individual version details page today, so nothing
+  new needs to be recorded about a version.'
+priority: Minor
+prompt: We'd like a side-by-side compare view for two versions of a registered model in the Model Registry pages of the Dashboard.
+  Today the version details pages are strictly one-at-a-time, so comparing two versions means two browser tabs. It came up
+  while I was walking a colleague through the registry pages and we both thought it would be handy, so I'm filing it before
+  it gets lost.

--- a/eval/dataset/cases/case-022-sticky-session-routing-redis-llm-d/annotations.yaml
+++ b/eval/dataset/cases/case-022-sticky-session-routing-redis-llm-d/annotations.yaml
@@ -1,0 +1,17 @@
+difficulty: hard
+expected_feasibility: null
+expected_pass: null
+expected_recommendation: null
+expected_scores:
+  not_a_task: null
+  open_to_how: null
+  right_sized: null
+  what: null
+  why: null
+expected_total: null
+known_issues: []
+score_tolerance: 1
+tags:
+- weak-draft
+- revision-expected
+- prescriptive-how

--- a/eval/dataset/cases/case-022-sticky-session-routing-redis-llm-d/input.yaml
+++ b/eval/dataset/cases/case-022-sticky-session-routing-redis-llm-d/input.yaml
@@ -1,0 +1,27 @@
+priority: Major
+prompt: We need the llm-d inference scheduler on OpenShift AI to pin every turn of a multi-turn
+  conversation to the same vLLM replica using a Redis Cluster-backed session table, exactly as
+  designed in our field team's prototype (docs.example.com/d/llm-d-sticky-sessions). Rewrite the
+  endpoint picker to look up an x-conversation-id header in Redis, fall back to a consistent-hash
+  ring over the conversation ID on a miss, and expose --session-affinity=strict|prefer|off plus a
+  sessionTtlSeconds field on LLMInferenceService. Please point engineering at that document as the
+  spec rather than describing the outcome generically.
+clarifying_context: 'Where this comes from: two of us on the field engineering team built the
+  sticky-session prototype on our own lab cluster over a couple of quiet weeks, because later turns
+  of a long conversation kept landing on a replica without the cached KV prefix and the tail latency
+  bothered us. To be upfront, no customer has asked for this and we have not shown it to one; there
+  is nothing in the field-request tracker, no support case, and no deal or renewal attached to it.
+  Please keep the customer and business sections of the RFE honest about that rather than padding
+  them with generic segments or industries we have not actually talked to.
+
+  Scope: productize the design in docs.example.com/d/llm-d-sticky-sessions as written. The Redis
+  Cluster session table and the consistent-hash fallback are fixed scope, not options for engineering
+  to evaluate; the design is signed off internally and we are not re-opening routing. The endpoint
+  picker change lives in the llm-d-inference-scheduler repo, keyed on the x-conversation-id header;
+  the KServe controller deploys Redis in the scheduler''s namespace. No prefix-cache scorer changes,
+  no KV offload tiers.
+
+  Success criteria: an operator can read the conversation-to-replica mapping out of the Redis Cluster
+  deployed alongside the scheduler; on a miss or during scale-in the scheduler logs show the request
+  going to the consistent-hash ring; strict mode is the default; the shipped implementation matches
+  the design document section by section, and that conformance is the acceptance bar.'

--- a/eval/dataset/cases/case-023-align-kfp-sdk-with-pipeline-server/annotations.yaml
+++ b/eval/dataset/cases/case-023-align-kfp-sdk-with-pipeline-server/annotations.yaml
@@ -1,0 +1,17 @@
+difficulty: hard
+expected_feasibility: null
+expected_pass: null
+expected_recommendation: null
+expected_scores:
+  not_a_task: null
+  open_to_how: null
+  right_sized: null
+  what: null
+  why: null
+expected_total: null
+known_issues: []
+score_tolerance: 1
+tags:
+- weak-draft
+- revision-expected
+- engineering-chore

--- a/eval/dataset/cases/case-023-align-kfp-sdk-with-pipeline-server/input.yaml
+++ b/eval/dataset/cases/case-023-align-kfp-sdk-with-pipeline-server/input.yaml
@@ -1,0 +1,22 @@
+priority: Normal
+prompt: We need to bump the kfp SDK pinned in the Python workbench images so it matches the version the
+  Data Science Pipelines server ships with in the same RHOAI release; the two have drifted apart again.
+  While we're in there, let's add a CI check that fails the image build whenever the pin doesn't match
+  what the operator deploys, so we stop chasing this every cycle. It's housekeeping rather than a
+  feature, so let's just get it done for the next release.
+clarifying_context: 'Workbench images and the pipelines server are built by different teams on
+  different cadences and nobody owns the kfp pin, so it drifts every release: this time the images
+  are two minors behind the server, last release it was the other way round. The fix is mechanical:
+  pin the kfp and kfp-kubernetes versions the server ships in every Python workbench image that
+  bundles kfp, and add a CI job that reads the version the operator deploys and fails the image build
+  on mismatch. Not decided whether older supported releases or the code-server image are included.
+
+  I want to be straight about the motivation: this is release-engineering hygiene. Nobody outside the
+  build teams has asked for it, there are no support cases or customer conversations behind it, and I
+  am not claiming any user-visible change. I know the RFE template asks for affected customers and a
+  business justification; please leave those honest rather than inventing generic segments or a
+  support-burden story we cannot point to. If that means the RFE looks thin on the business side,
+  that is an accurate picture.
+
+  Success is simply that the kfp and kfp-kubernetes pins in every Python workbench image equal the
+  version the operator deploys, and that an image build with a mismatched pin fails in CI.'

--- a/eval/dataset/cases/case-024-make-guardrails-enterprise-ready/annotations.yaml
+++ b/eval/dataset/cases/case-024-make-guardrails-enterprise-ready/annotations.yaml
@@ -1,0 +1,17 @@
+difficulty: hard
+expected_feasibility: null
+expected_pass: null
+expected_recommendation: null
+expected_scores:
+  not_a_task: null
+  open_to_how: null
+  right_sized: null
+  what: null
+  why: null
+expected_total: null
+known_issues: []
+score_tolerance: 1
+tags:
+- weak-draft
+- revision-expected
+- vague-what

--- a/eval/dataset/cases/case-024-make-guardrails-enterprise-ready/input.yaml
+++ b/eval/dataset/cases/case-024-make-guardrails-enterprise-ready/input.yaml
@@ -1,0 +1,24 @@
+priority: Major
+prompt: Our guardrails story does not feel enterprise-ready. After sitting through the TrustyAI
+  guardrails demo last week my impression is that it reads as a demo rather than something an operations
+  team would put in front of live traffic. We need a production-readiness push that makes guardrails
+  production-grade, more observable, and seamless for operations teams. We do not yet know what the
+  concrete deliverables are.
+clarifying_context: 'This is my own impression coming out of an internal demo, not customer feedback.
+  No customer, prospect or partner has said this to us; there are no pilots stalling on it that I can
+  point to, no account names, no field escalation, and I have not asked the field. I would rather the
+  RFE says that plainly than pad the customer and business sections with generic regulated-industry
+  segments or a competitive angle we have not researched. Treat the customer side as unknown.
+
+  What I mean by not enterprise-ready is hard to pin down, which is part of why I am filing it: the
+  demo felt fragile in ways I could not name precisely. Words that came to mind were "more
+  observable", "less noisy", "simpler to run", but I could not turn any of them into a specific
+  missing capability or behaviour, and several detectors, metrics and dashboard panels already exist.
+
+  Scope: guardrails only, meaning the Guardrails Orchestrator and its detectors as an operations team
+  experiences them. Treat it as a hardening and readiness exercise across the orchestrator and its
+  detectors, not a new capability; one RFE, not several. Not general model serving observability, not
+  evaluation.
+
+  Success criteria: the demo no longer feels pilot-grade. I have no measurable outcome to attach and
+  no acceptance test in mind; I cannot describe done any more precisely than that today.'

--- a/eval/dataset/cases/case-025-pipeline-run-diagnostics-bundle-qe/annotations.yaml
+++ b/eval/dataset/cases/case-025-pipeline-run-diagnostics-bundle-qe/annotations.yaml
@@ -1,0 +1,17 @@
+difficulty: hard
+expected_feasibility: null
+expected_pass: null
+expected_recommendation: null
+expected_scores:
+  not_a_task: null
+  open_to_how: null
+  right_sized: null
+  what: null
+  why: null
+expected_total: null
+known_issues: []
+score_tolerance: 1
+tags:
+- weak-draft
+- revision-expected
+- internal-team-request

--- a/eval/dataset/cases/case-025-pipeline-run-diagnostics-bundle-qe/input.yaml
+++ b/eval/dataset/cases/case-025-pipeline-run-diagnostics-bundle-qe/input.yaml
@@ -1,0 +1,27 @@
+priority: Normal
+prompt: Filing this on behalf of the Data Science Pipelines QE team; this is an internal test-infrastructure
+  ask, not a customer request. Every time a run fails in the nightly interop or upgrade suite, whoever is
+  on triage spends most of the time hunting for driver and executor pod logs, the Argo workflow status and
+  the compiled pipeline spec across two namespaces, and half the time the pods are already gone. We want
+  the pipelines API server to produce one downloadable diagnostics bundle per run, behind an internal
+  feature flag that is off by default and undocumented in this first iteration, so QE can attach it to a
+  bug instead of screenshots.
+clarifying_context: 'The pain is triage time in our nightly interop and upgrade suites: for each failed
+  run someone has to collect the Argo Workflow status, driver and executor pod logs, API server and
+  persistence agent logs, and the compiled pipeline spec by hand from the pipeline namespace and the
+  operator namespace. Pods are often garbage-collected before anyone looks, so a good share of nightly
+  failures get closed as cannot-reproduce.
+
+  What we think we want: a per-run diagnostics tarball. We imagine the persistence agent capturing pod
+  logs at run completion and stashing them next to the run''s artifacts in the object store, with a
+  hidden API server endpoint to fetch the archive. Behind a feature flag, off by default and
+  undocumented in this first iteration.
+
+  On the RFE paperwork: there are no affected customers and no business justification beyond our own
+  triage time. No customer, partner or support case has asked for anything like this; we checked the
+  field-request tracker and it is empty. Please do not list QE, SRE or support as affected customers
+  or dress this up as a customer need; we are the only people who want it right now and the RFE
+  should say so honestly, even if that leaves those sections nearly empty.
+
+  Success for us is a QE engineer attaching a complete bundle to a Jira within a couple of minutes of
+  a failure, without needing cluster access.'

--- a/tests/test_eval_revision_coverage_judge.py
+++ b/tests/test_eval_revision_coverage_judge.py
@@ -98,13 +98,16 @@ def test_both_configs_identical():
 
 
 def test_threshold_arithmetic():
-    # 25 cases, 5 tagged revision-expected: 3 of 5 revised must pass, 2 of 5 must
-    # fail. Guard the float boundary as well as the configured value.
+    # Same value in both configs, different denominators. RFE: 25 cases, 5 tagged
+    # revision-expected, 3 of 5 revised must pass and 2 of 5 must fail.
+    # Initiative: 16 cases, none tagged, one failing case allowed. Guard the float
+    # boundary as well as the configured value.
     for path in (EVAL_YAML, EVAL_INITIATIVE_YAML):
-        threshold = _config(path)["thresholds"][JUDGE]["min_pass_rate"]
-        assert threshold == 0.92
-        assert (25 - 2) / 25 >= threshold  # 3 revised -> 2 failures -> pass
-        assert (25 - 3) / 25 < threshold  # 2 revised -> 3 failures -> fail
+        assert _config(path)["thresholds"][JUDGE]["min_pass_rate"] == 0.92
+    assert (25 - 2) / 25 >= 0.92  # 3 revised -> 2 failures -> pass
+    assert (25 - 3) / 25 < 0.92  # 2 revised -> 3 failures -> fail
+    assert (16 - 1) / 16 >= 0.92  # one failing initiative case -> pass
+    assert (16 - 2) / 16 < 0.92  # two failing initiative cases -> fail
 
 
 # --- Run-level gate: zero revisions anywhere fails every case ----------------

--- a/tests/test_eval_revision_coverage_judge.py
+++ b/tests/test_eval_revision_coverage_judge.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Tests for the ``revision_coverage`` inline-check judge.
+
+The judge body lives inline in both ``eval.yaml`` (rfe.speedrun) and
+``eval-initiative.yaml`` (initiative-speedrun) and the two copies must remain
+byte-identical; ``test_both_configs_identical`` fails the build if they drift.
+The behavioural tests exec the body exactly the way the harness does
+(``def _check(outputs, arguments): <indented body>``, see
+``score._make_inline_check``) against crafted ``outputs`` records. The record
+mirrors what ``score.load_case_record`` builds: ``files`` keyed by path relative
+to the case directory and ``annotations`` loaded from the dataset case's
+``annotations.yaml``.
+"""
+
+import os
+import textwrap
+
+import yaml
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+EVAL_YAML = os.path.join(REPO_ROOT, "eval.yaml")
+EVAL_INITIATIVE_YAML = os.path.join(REPO_ROOT, "eval-initiative.yaml")
+JUDGE = "revision_coverage"
+
+RFE_REVIEWS = "artifacts/rfe-reviews"
+RFE_TASKS = "artifacts/rfe-tasks"
+RFE_ORIGINALS = "artifacts/rfe-originals"
+INIT_REVIEWS = "artifacts/initiative-reviews"
+REPORT = "artifacts/auto-fix-runs/20260101-000000.yaml"
+
+TAGGED = {"tags": ["weak-draft", "revision-expected", "missing-why"], "difficulty": "hard"}
+UNTAGGED = {"tags": [], "difficulty": None}
+
+
+def _config(path):
+    return yaml.safe_load(open(path))
+
+
+def _check_body(config_path):
+    judge = next(j for j in _config(config_path)["judges"] if j["name"] == JUDGE)
+    return judge["check"]
+
+
+def _load_check(config_path=EVAL_YAML):
+    """Compile the inline check body into a callable, mirroring score.py."""
+    body = _check_body(config_path)
+    wrapped = "def _check(outputs, arguments):\n" + textwrap.indent(body, "    ")
+    ns = {"__builtins__": __builtins__}
+    exec(compile(wrapped, f"<check:{JUDGE}>", "exec"), ns)  # noqa: S102 - trusted repo config
+    return ns["_check"]
+
+
+def _review(item_id, id_field="rfe_id", history="none", **frontmatter):
+    frontmatter.setdefault(id_field, item_id)
+    fm = yaml.safe_dump(frontmatter, sort_keys=True)
+    return f"---\n{fm}---\n\n## Verdict\nok\n\n## Revision History\n{history}\n"
+
+
+def _task(item_id, body="## Summary\n\nOriginal body.\n", status="Draft"):
+    return f"---\nrfe_id: {item_id}\nstatus: {status}\n---\n\n{body}"
+
+
+def _report(*entries, key="per_rfe"):
+    return yaml.safe_dump({key: [dict(e) for e in entries]})
+
+
+def _entry(item_id, before=8, after=8, cycles=0, auto_revised=False):
+    return {
+        "id": item_id,
+        "before_score": before,
+        "after_score": after,
+        "revision_cycles": cycles,
+        "auto_revised": auto_revised,
+    }
+
+
+def _run(files, annotations=None):
+    record = {"files": files}
+    if annotations is not None:
+        record["annotations"] = annotations
+    return _load_check()(record, {})
+
+
+# A run in which some OTHER item was revised, so the run-level gate is open and
+# only the per-case/tag logic is under test.
+def _other_revised():
+    return {REPORT: _report(_entry("RFE-9", before=6, after=8, cycles=1, auto_revised=True))}
+
+
+# --- Drift guard: the two configs must carry the identical judge body ---------
+
+
+def test_both_configs_identical():
+    assert _check_body(EVAL_YAML) == _check_body(EVAL_INITIATIVE_YAML), (
+        "revision_coverage has drifted between eval.yaml and eval-initiative.yaml; "
+        "keep the two copies byte-identical."
+    )
+
+
+def test_threshold_arithmetic():
+    # 25 cases, 5 tagged revision-expected: 3 of 5 revised must pass, 2 of 5 must
+    # fail. Guard the float boundary as well as the configured value.
+    for path in (EVAL_YAML, EVAL_INITIATIVE_YAML):
+        threshold = _config(path)["thresholds"][JUDGE]["min_pass_rate"]
+        assert threshold == 0.92
+        assert (25 - 2) / 25 >= threshold  # 3 revised -> 2 failures -> pass
+        assert (25 - 3) / 25 < threshold  # 2 revised -> 3 failures -> fail
+
+
+# --- Run-level gate: zero revisions anywhere fails every case ----------------
+
+
+def test_zero_revision_run_fails_untagged_case():
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-1-review.md": _review(
+                "RFE-1", auto_revised=False, score=9, before_score=9
+            ),
+            REPORT: _report(_entry("RFE-1", 9, 9), _entry("RFE-2", 10, 10)),
+        },
+        UNTAGGED,
+    )
+    assert passed is False
+    assert "never exercised" in msg and "0/2" in msg
+
+
+def test_zero_revision_run_without_report_fails():
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-1-review.md": _review(
+                "RFE-1", auto_revised=False, score=9, before_score=9
+            )
+        },
+        UNTAGGED,
+    )
+    assert passed is False
+    assert "never exercised" in msg
+
+
+def test_untagged_case_passes_when_another_item_was_revised():
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-1-review.md": _review(
+                "RFE-1", auto_revised=False, score=9, before_score=9
+            ),
+            **_other_revised(),
+        },
+        UNTAGGED,
+    )
+    assert passed is True
+    assert "not revised (untagged)" in msg and "1/1" in msg
+
+
+def test_missing_annotations_treated_as_untagged():
+    passed, _ = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-1-review.md": _review(
+                "RFE-1", auto_revised=False, score=9, before_score=9
+            ),
+            **_other_revised(),
+        }
+    )
+    assert passed is True
+
+
+def test_untagged_but_revised_counts_towards_coverage():
+    # The initiative dataset has no revision-expected tags; a revised item must
+    # still open the run-level gate for itself and (via the report) for others.
+    passed, msg = _run(
+        {
+            f"{INIT_REVIEWS}/INIT-4-review.md": _review(
+                "INIT-4", id_field="initiative_id", auto_revised=False, score=8, before_score=6
+            ),
+        },
+        {"tags": ["new-feature"]},
+    )
+    assert passed is True
+    assert "before_score 6 != score 8" in msg
+
+
+# --- Tagged cases need revision evidence -------------------------------------
+
+
+def test_tagged_without_evidence_fails():
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", auto_revised=False, score=9, before_score=9
+            ),
+            f"{RFE_TASKS}/RFE-21.md": _task("RFE-21"),
+            **_other_revised(),
+        },
+        TAGGED,
+    )
+    assert passed is False
+    assert "tagged revision-expected" in msg and "RFE-21" in msg
+
+
+def test_tagged_auto_revised_flag_passes():
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", auto_revised=True, score=8, before_score=8
+            )
+        },
+        TAGGED,
+    )
+    assert passed is True
+    assert "auto_revised=true" in msg
+
+
+def test_tagged_score_moved_passes():
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", auto_revised=False, score=8, before_score=5
+            )
+        },
+        TAGGED,
+    )
+    assert passed is True
+    assert "before_score 5 != score 8" in msg
+
+
+def test_tagged_originals_body_differs_passes():
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", auto_revised=False, score=8, before_score=8
+            ),
+            f"{RFE_ORIGINALS}/RFE-21.md": _task("RFE-21", body="## Summary\n\nWeak body.\n"),
+            f"{RFE_TASKS}/RFE-21.md": _task("RFE-21", body="## Summary\n\nStrengthened body.\n"),
+            **_other_revised(),
+        },
+        TAGGED,
+    )
+    assert passed is True
+    assert "originals body differs" in msg
+
+
+def test_originals_identical_body_is_not_evidence():
+    # Same body, different frontmatter/whitespace: a saved original alone is not
+    # a revision (it is also the fetch baseline for existing issues).
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", auto_revised=False, score=8, before_score=8
+            ),
+            f"{RFE_ORIGINALS}/RFE-21.md": "## Summary\n\nSame   body.\n",
+            f"{RFE_TASKS}/RFE-21.md": _task(
+                "RFE-21", body="## Summary\n\nSame body.\n\n", status="Ready"
+            ),
+            **_other_revised(),
+        },
+        TAGGED,
+    )
+    assert passed is False
+    assert "no revision evidence" in msg
+
+
+def test_tagged_removed_context_companion_passes():
+    for companion in ("RFE-21-removed-context.yaml", "RFE-21-removed-context.md"):
+        passed, msg = _run(
+            {
+                f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                    "RFE-21", auto_revised=False, score=8, before_score=8
+                ),
+                f"{RFE_TASKS}/{companion}": "blocks: []\n",
+            },
+            TAGGED,
+        )
+        assert passed is True
+        assert "removed-context companion" in msg
+
+
+def test_tagged_revision_history_passes():
+    history = "none\n- **Auto-revision (2026-01-01):** Addressed WHY.\nnone"
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", auto_revised=False, score=8, before_score=8, history=history
+            )
+        },
+        TAGGED,
+    )
+    assert passed is True
+    assert "non-empty Revision History" in msg
+
+
+def test_revision_history_subheading_entries_count():
+    # Some revisions record history under a ### sub-heading directly below the
+    # section heading; the section must run to the next ## heading, not stop at ###.
+    history = "### Auto-revision 1 (2026-01-01)\n\n**WHY (0/2 -> 1/2)**: added evidence."
+    content = _review("RFE-21", auto_revised=False, score=8, before_score=8, history=history)
+    content += "\n## Trailing Section\nnone\n"
+    passed, msg = _run({f"{RFE_REVIEWS}/RFE-21-review.md": content}, TAGGED)
+    assert passed is True
+    assert "non-empty Revision History" in msg
+
+
+def test_revision_history_placeholders_are_empty():
+    for history in ("none", "None", "_None_", "N/A", "", "- none"):
+        passed, msg = _run(
+            {
+                f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                    "RFE-21", auto_revised=False, score=8, before_score=8, history=history
+                ),
+                **_other_revised(),
+            },
+            TAGGED,
+        )
+        assert passed is False, history
+        assert "no revision evidence" in msg
+
+
+def test_tagged_run_report_evidence_passes():
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", auto_revised=False, score=8, before_score=8
+            ),
+            REPORT: _report(_entry("RFE-21", 6, 8)),
+        },
+        TAGGED,
+    )
+    assert passed is True
+    assert "run report records a revision" in msg
+
+
+def test_tagged_leftover_review_state_passes():
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", auto_revised=False, score=8, before_score=8
+            ),
+            f"{RFE_REVIEWS}/RFE-21-review-state.json": '{"revision_history": "- cycle 1"}',
+        },
+        TAGGED,
+    )
+    assert passed is True
+    assert "leftover review-state file" in msg
+
+
+def test_any_review_in_case_counts():
+    # Any review present in the case directory counts for the case. Split
+    # children are NOT routed to a case in batch mode (collect.py:_collect_batch
+    # matches RFE-{n:03d} prefixes for n <= case count only, so RFE-026+ land in
+    # no case dir); they reach a case only in single-item runs, where the whole
+    # workspace is the case. In a batch a child's revision is visible solely via
+    # the run report - see test_tagged_split_parent_without_case_evidence_fails.
+    passed, _ = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", auto_revised=False, score=9, before_score=9
+            ),
+            f"{RFE_REVIEWS}/RFE-26-review.md": _review(
+                "RFE-26", auto_revised=True, score=8, before_score=6
+            ),
+        },
+        TAGGED,
+    )
+    assert passed is True
+
+
+def test_tagged_split_parent_without_case_evidence_fails():
+    # A tagged weak draft that the first review split: the parent never enters
+    # the revise path and its children live in no case directory. The child's
+    # revision opens the run-level gate via the report but is not evidence for
+    # the parent's case, so the case fails and consumes one unit of the
+    # threshold's 2-failure slack (documented limitation, pinned here).
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", auto_revised=False, score=9, before_score=9
+            ),
+            REPORT: _report(
+                {
+                    **_entry("RFE-21", 9, 9),
+                    "role": "intermediary",
+                    "recommendation": "split",
+                    "children": ["RFE-26", "RFE-27"],
+                },
+                _entry("RFE-26", 6, 8, cycles=1, auto_revised=True),
+                _entry("RFE-27", 9, 9),
+            ),
+        },
+        TAGGED,
+    )
+    assert passed is False
+    assert "tagged revision-expected" in msg and "1/3" in msg
+
+
+# --- Single-item runs: Harbor tasks and execution.mode: case ------------------
+# The shared run report then describes exactly one input item, so "the run
+# revised nothing" carries no coverage signal and the tag alone decides.
+
+
+def test_single_item_run_untagged_passes():
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-1-review.md": _review(
+                "RFE-1", auto_revised=False, score=9, before_score=9
+            ),
+            REPORT: _report(_entry("RFE-1", 9, 9)),
+        },
+        UNTAGGED,
+    )
+    assert passed is True
+    assert "not revised (untagged)" in msg and "0/1" in msg and "single-item run" in msg
+
+
+def test_single_item_run_tagged_still_fails():
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", auto_revised=False, score=9, before_score=9
+            ),
+            REPORT: _report(_entry("RFE-21", 9, 9)),
+        },
+        TAGGED,
+    )
+    assert passed is False
+    assert "tagged revision-expected" in msg and "0/1" in msg
+
+
+def test_single_item_run_split_without_revision_passes():
+    # The one input was split: the report lists parent + children (3 entries)
+    # but still describes a single input item, so the untagged case passes.
+    # Two independent inputs (test_zero_revision_run_fails_untagged_case) are a
+    # batch and keep failing.
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-1-review.md": _review(
+                "RFE-1", auto_revised=False, score=9, before_score=9
+            ),
+            f"{RFE_REVIEWS}/RFE-2-review.md": _review(
+                "RFE-2", auto_revised=False, score=9, before_score=9
+            ),
+            REPORT: _report(
+                {
+                    **_entry("RFE-1", 9, 9),
+                    "role": "intermediary",
+                    "recommendation": "split",
+                    "children": ["RFE-2", "RFE-3"],
+                },
+                _entry("RFE-2", 9, 9),
+                _entry("RFE-3", 9, 9),
+            ),
+        },
+        UNTAGGED,
+    )
+    assert passed is True
+    assert "0/3" in msg and "single-item run" in msg
+
+
+# --- Robustness: malformed / legacy inputs must never raise --------------------
+# A raising check is recorded as value=None and dropped from the pass-rate
+# denominator, so a crash on a tagged case would silently relax the gate.
+
+
+def test_no_review_files():
+    passed, msg = _run({f"{RFE_TASKS}/RFE-1.md": "body"}, TAGGED)
+    assert passed is False
+    assert "No review files" in msg
+
+
+def test_malformed_inputs_do_not_raise():
+    passed, _ = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-bad-review.md": "---\nrfe_id:\n  - RFE-BAD\n---\n",
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", auto_revised=False, score=8, before_score=6
+            ),
+            f"{RFE_REVIEWS}/RFE-21-review-state.json": "[1, 2]",
+            f"{RFE_ORIGINALS}/RFE-21.md": {"_binary": True, "path": "/x", "name": "RFE-21.md"},
+            "artifacts/auto-fix-runs/list.yaml": "- a\n- b\n",
+            "artifacts/auto-fix-runs/bad.yaml": (
+                "per_rfe: [{id: [1], revision_cycles: '1'}, 7, "
+                "{id: RFE-8, children: 'x'}, {id: RFE-9, children: [1, null]}]\n"
+            ),
+            # load_case_record stores an undecodable file as a marker dict.
+            "artifacts/auto-fix-runs/bin.yaml": {"_binary": True, "path": "/x", "name": "bin.yaml"},
+            "artifacts/auto-fix-runs/issue-snapshot-1.yaml": "issues: []\n",
+        },
+        {"tags": "revision-expected", "difficulty": "hard"},  # tags not a list
+    )
+    assert passed is True
+
+
+def test_legacy_revised_field_honored():
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", revised=True, score=8, before_score=8
+            )
+        },
+        TAGGED,
+    )
+    assert passed is True
+    assert "auto_revised=true" in msg
+
+
+def test_modified_mirror_does_not_shadow_task():
+    # collect.py mirrors in-place edits under _modified/; the mirror must not
+    # overwrite the artifacts/ copy in the basename index.
+    passed, msg = _run(
+        {
+            f"{RFE_REVIEWS}/RFE-21-review.md": _review(
+                "RFE-21", auto_revised=False, score=8, before_score=8
+            ),
+            f"{RFE_ORIGINALS}/RFE-21.md": "## Summary\n\nWeak.\n",
+            f"{RFE_TASKS}/RFE-21.md": _task("RFE-21", body="## Summary\n\nStrong.\n"),
+            f"_modified/{RFE_TASKS}/RFE-21.md": _task("RFE-21", body="## Summary\n\nWeak.\n"),
+        },
+        TAGGED,
+    )
+    assert passed is True
+    assert "originals body differs" in msg


### PR DESCRIPTION
## Summary

The RFE eval could not see the revise path. All 20 existing cases pass first review at 8–10, so the last two runs never revised anything: `revision_quality` scored "the decision not to revise" and `revision_flag_consistency` passed vacuously. That is why the production flag-loss defect fixed in #173 was invisible to the RFE eval.

Two changes, two commits:

1. **Five weak-draft cases** (`case-021`..`case-025`, `difficulty: hard`, tags `weak-draft`, `revision-expected`, `<mode>`): missing WHY, prescriptive HOW, engineering chore, vague WHAT, internal-team request. Fictional organisations only.
2. **`revision_coverage` check judge**, byte-identical in `eval.yaml` and `eval-initiative.yaml`: a `revision-expected` case passes only with revision evidence; in a multi-item run every case fails when nothing in the run was revised; single-item runs are decided by the tag alone. `min_pass_rate: 0.92` requires 3 of the 5 tagged cases to be revised at 25 cases. The initiative dataset passes as-is on its incidental revisions.

## Validation (live, `--dry-run`, claude-opus-4-6, only the five new cases)

| Run | Drafts | First pass | Revised | Re-review | `revision_coverage` | `revision_flag_consistency` | Cost |
|---|---|---|---|---|---|---|---|
| 1 | first authoring (weak by wording only) | 8, 8, 9, 8, 9 | 1 of 5 | 8→9 | 0.2 FAIL | 1.0 | $14.50, 23 min |
| 2 | with evidence anchors (this PR) | 8, 8, 6, 5, 7 | 5 of 5 | 9, 9, 8, 8, 9 | 1.0 PASS | 1.0 | $17.49, 23 min |

Run 2 first-pass failures were diverse: every draft failed on `why: 0`, the chore also on `not_a_task: 0`, the vague ask also on `what: 1` and `right_sized: 1`, the internal request also on `not_a_task: 1`. All five kept `auto_revised: true` after passing re-review, which is #173 verified end to end on the RFE path.

## What the first run taught

The creator and the reviser share a model and a rubric, so any weakness fixable by rewording is fixed at create time: the mandated design was softened to a 1/2, the chore was reframed as a business need, the vague ask was concretized, and internal teams were cast as customer segments (the assessor awards `why: 1` for any generic or internal segment). The only weakness that survives is one that needs information the input does not contain, stated plainly in the requester's voice: no customer has asked, no support case exists, and the customer and business sections must stay honest rather than padded. The README documents this so future weak drafts are authored that way from the start.

## Judge internals

Inline checks see only `outputs` and `arguments` (`score.py` `_make_inline_check`); the harness delivers the case's `annotations.yaml` inside `outputs`, which is how the tag is read. Evidence signals accepted: `auto_revised` (or legacy `revised`), moved `before_score`/`before_scores`, an `-originals/` body that differs from the task, a removed-context companion, a leftover review-state file, the shared run report, a non-empty Revision History. `tests/test_eval_revision_coverage_judge.py` executes the check through the harness's own wrapper and pins that both configs stay identical.

## Follow-ups

- Companion fix in rfe-creator-eval (comment marker per config, so concurrent rfe/initiative runs stop deleting each other's PR comment): https://gitlab.com/redhat/rhel-ai/agentic-ci/rfe-creator-eval/-/merge_requests/8
- After merge, re-run both evals once to record the pre-PR-1 baselines; the RFE means will shift because the new inputs are harder (run 2 alone: `rfe_quality` 4.00, `revision_quality` 4.40).
- The initiative dataset has no tagged weak drafts yet; it passes `revision_coverage` only because its ordinary prompts still get revised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added five new hard evaluation cases covering model version comparison, session affinity, SDK alignment, guardrails readiness, and pipeline diagnostics.
  - Added revision-coverage evaluation to verify that expected draft revisions are completed and supported by evidence.
  - Added support for tagging cases, including those expected to require revision.

- **Documentation**
  - Documented revision evidence signals, coverage thresholds, calibration, and guidance for authoring weak-draft cases.

- **Tests**
  - Added comprehensive validation for revision tracking, coverage rules, split cases, malformed inputs, and legacy data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->