### PR TITLE
Schemas, phase checks and the forked pairs adopt the registry (design PR-2b)

### DIFF
--- a/docs/type-provider-guide.md
+++ b/docs/type-provider-guide.md
@@ -5,11 +5,14 @@ authoritative text lives. Design: `design-proposals/work-item-types-unified.md` 
 §3.2.1 (binding override), §3.3 (gates), §3.4 (provider obligations), §3.5 (discovery), §3.7
 (cross-type chain).
 
-**Status (PR-2a): 18 scripts read the registry at import** — the "Adoption status" table in
-[`types/README.md`](../types/README.md) lists them and what is still pending. Every per-type
-value a pending script still carries is pinned by test to its descriptor projection; each
-adoption deletes its pin (design §10). Adopted scripts use descriptor values only; the effective
-binding override is not consulted until PR-3.
+**Status (PR-2b): 21 scripts read the registry at import** — the "Adoption status" table in
+[`types/README.md`](../types/README.md) lists them and what is still pending. Since PR-2b the
+artifact schemas (`artifact_utils.SCHEMAS`), the scan / rename / parse helpers and the poll phase
+table (`check_review_progress.PHASE_CHECKS`) are projections too, so a registered type gets its
+`<type>-task` / `<type>-review` schemas, its `<poll_prefix><phase>` rows and the generics without
+a code change. Every per-type value a pending script still carries is pinned by test to its
+descriptor projection; each adoption deletes its pin (design §10). Adopted scripts use descriptor
+values only; the effective binding override is not consulted until PR-3.
 
 ## The surface, in one table
 
@@ -22,7 +25,7 @@ binding override is not consulted until PR-3.
 | Validator (gates 1–3) | `scripts/validate_types.py` (`make lint` runs gate 1) |
 | Anti-regression prefix lint and its ratchet baseline | `scripts/lint_prefix_predicates.py`, `tests/data/prefix_predicate_baseline.json` (only ever shrinks) |
 | Recorded gaps (R1): what the v1 vocabulary cannot say | `NOT EXPRESSIBLE AT V1` comments in `tests/fixtures/types/epic/type.yaml`; `not_expressible_at_v1` in `tests/fixtures/types/strategy-inputs.yaml` |
-| Contract tests | `tests/test_type_registry.py`, `tests/test_validate_types.py`, `tests/test_lint_prefix_predicates.py`, `tests/test_type_registry_pins.py` |
+| Contract tests | `tests/test_type_registry.py`, `tests/test_validate_types.py`, `tests/test_lint_prefix_predicates.py`, `tests/test_type_registry_pins.py`; `tests/test_schemas_golden.py` pins the derived artifact schemas byte for byte |
 
 ## Adding a type
 
@@ -44,6 +47,17 @@ Rules that are easy to trip:
 - **Second-requester rule.** New vocabulary is promoted only when a second type needs it. Tiers, in
   order: descriptor data → declarative rule → a companion skill in your own repo consuming the
   declared-stable script CLIs → core PR.
+- **Schemas need every schema fact.** `artifact_utils.SCHEMAS` derives `<type>-task` /
+  `<type>-review` from `identity.{tracker,id_field,local_id_pattern}`,
+  `conventions.parent_key_patterns`, `schema.task.priority.enum` and `schema.review.score_fields`
+  (plus the optional `schema.{task,review}.extra_fields`). Gate 1 does not require all of them,
+  so a drop-in that omits one is registered but gets no schemas (and no `frontmatter.py` path
+  entry): every read / write / validate against it fails with "Unknown schema type" instead of
+  the import failing. That tolerance is for drop-in roots only — a type under `types/` itself is
+  built unconditionally, and a missing fact fails the import with a `KeyError` naming the field.
+  `check_review_progress.PHASE_CHECKS` applies the same rule to `dirs.{tasks,reviews}` and
+  `pipeline.poll_prefix`: a drop-in without them polls no phase. Copying `types/rfe/` keeps them
+  all.
 - **Frozen strings (R7).** `conventions.labels.rubric_pass`, `conventions.removed_context_preamble`
   and the `{key}-strategy.md` attachment convention are consumed downstream; change them only with
   a migration note.

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -123,7 +123,9 @@ def _id_pattern(desc):
     ``^(RFE-\\d+|RHAIRFE-\\d+)$``. Prefixes are used verbatim (not re.escape'd), exactly as
     the hand-written literals were: upper-case letters plus the trailing dash, none of which
     is a regex metacharacter."""
-    alternatives = [desc.local_id_pattern.strip("^$")]
+    # Drop only the outer anchors: strip("^$") would also eat a pattern's own trailing
+    # characters (e.g. a literal \$ before the closing anchor) and produce an invalid regex.
+    alternatives = [desc.local_id_pattern.removeprefix("^").removesuffix("$")]
     alternatives += [prefix + r"\d+" for prefix in desc.key_prefixes]
     return "^(" + "|".join(alternatives) + ")$"
 

--- a/scripts/artifact_utils.py
+++ b/scripts/artifact_utils.py
@@ -4,13 +4,26 @@ Owns all structured metadata for RFE artifacts. Scripts and skills use this
 module instead of regex-parsing markdown prose.
 
 Frontmatter is stored as YAML between --- delimiters at the top of markdown files.
+
+Per-type facts — the id field's name and grammar, the artifact dirs, the score fields
+and the extra schema fields — come from the work-item type registry
+(``types/<name>/type.yaml`` through ``type_registry``). SCHEMAS and the scan / rename /
+parse entry points are projections over it; the historical per-type names
+(scan_task_files, rename_to_jira_key, parse_child_artifact and their initiative twins)
+remain as thin wrappers over the generics that take a ``type_registry.Descriptor``.
 """
 
+import copy
 import os
 import re
 import sys
 
 import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import type_registry
+
+_TYPES = type_registry.load()
 
 
 def read_ids_file(path):
@@ -56,21 +69,88 @@ def resolve_ids(positional, ids_file):
 #   pattern:  regex pattern the value must match (optional, strings only)
 #   default:  default value when not provided (optional)
 #   fields:   nested schema for type="dict" (optional)
+#
+# SCHEMAS holds "<type>-task" and "<type>-review" for every registered type, in registry
+# order (rfe first): that key order is the `frontmatter.py schema` choices order. The base
+# fields and the shared vocabularies below are the artifact contract, identical for every
+# type; what differs per type is read from its descriptor — identity.id_field (the id
+# field's NAME), identity.local_id_pattern + the tracker key_prefixes (its grammar),
+# conventions.parent_key_patterns, schema.task.priority.enum, schema.task.extra_fields
+# (rfe: size), schema.review.score_fields (scores / before_scores) and
+# schema.review.extra_fields (initiative: alignment). tests/test_schemas_golden.py pins
+# the derived dicts byte for byte to tests/data/schemas-golden.json.
 
-SCHEMAS = {
-    "rfe-task": {
-        "rfe_id": {
+_STATUS_ENUM = ["Draft", "Ready", "Submitted", "Archived"]
+_RECOMMENDATION_ENUM = ["submit", "revise", "split", "reject", "autorevise_reject"]
+_FEASIBILITY_ENUM = ["feasible", "infeasible", "indeterminate"]
+
+# The descriptor fields a type must declare to get a task and a review schema. Both shipped
+# types declare them all (validate_types.py gate 1 and tests/test_schemas_golden.py hold that).
+# A drop-in root (RFE_CREATOR_EXTRA_TYPES, dev/test only) may register a partial descriptor,
+# and the registry loader does not run the JSON-Schema gate — such a type is simply absent
+# from SCHEMAS (and from frontmatter.py's path table) instead of breaking the import of every
+# script that uses this module. The tolerance is for drop-ins only: a type under the
+# registry's own root (types/) is built unconditionally, so an edit that drops one of these
+# facts from a shipped descriptor fails this import with the loader's KeyError naming the
+# field, instead of surfacing as "Unknown schema type" from the first read or write.
+_SCHEMA_FACTS = (
+    "identity.tracker",
+    "identity.id_field",
+    "identity.local_id_pattern",
+    "conventions.parent_key_patterns",
+    "schema.task.priority.enum",
+    "schema.review.score_fields",
+)
+
+_SHIPPED_ROOT = _TYPES.root.resolve()
+
+
+def _is_shipped(desc):
+    """True when ``desc`` was loaded from the registry's own root rather than a drop-in root."""
+    return desc.path is not None and desc.path.is_relative_to(_SHIPPED_ROOT)
+
+
+def _declares_schemas(desc):
+    """True when ``desc`` carries every field the task/review schemas are derived from. A
+    shipped type always counts, so a missing fact fails at import (see _SCHEMA_FACTS)."""
+    if _is_shipped(desc):
+        return True
+    return all(desc.get(dotted, None) is not None for dotted in _SCHEMA_FACTS)
+
+
+def _id_pattern(desc):
+    """The id field's grammar: the local draft id or a tracker key, e.g.
+    ``^(RFE-\\d+|RHAIRFE-\\d+)$``. Prefixes are used verbatim (not re.escape'd), exactly as
+    the hand-written literals were: upper-case letters plus the trailing dash, none of which
+    is a regex metacharacter."""
+    alternatives = [desc.local_id_pattern.strip("^$")]
+    alternatives += [prefix + r"\d+" for prefix in desc.key_prefixes]
+    return "^(" + "|".join(alternatives) + ")$"
+
+
+def _parent_key_pattern(desc):
+    """``^(a|b|c)$`` over ``conventions.parent_key_patterns`` — joining reproduces today's
+    literal for both shipped types (rfe: RFE-/RHAIRFE-; initiative: RHAISTRAT-/RHOAIENG-/
+    INIT-, the task schema's wider list of PR-1 decision Q14; validate_batch_input.py's
+    narrower batch pattern is reconciled in PR-3)."""
+    return "^(" + "|".join(desc.get("conventions.parent_key_patterns")) + ")$"
+
+
+def _id_fields(desc):
+    """The identity fields every task and review schema opens with."""
+    return {
+        desc.id_field: {
             "type": "string",
             "required": True,
-            "pattern": r"^(RFE-\d+|RHAIRFE-\d+)$",
+            "pattern": _id_pattern(desc),
         },
         # Pre-submission id, persisted at rename time. Renaming overwrites
-        # rfe_id with the Jira key, and this is the only durable record of
+        # the id field with the Jira key, and this is the only durable record of
         # which local draft a submitted item came from.
         "local_id": {
             "type": "string",
             "required": False,
-            "pattern": r"^RFE-\d+$",
+            "pattern": desc.local_id_pattern,
             "default": None,
         },
         # Self-describing artifact fields (design-proposals/work-item-types-unified.md
@@ -80,257 +160,81 @@ SCHEMAS = {
         # re-derived from an id prefix. Both are declared WITHOUT a `default` key on
         # purpose (PR-1 decision Q4): apply_defaults writes only fields that carry
         # `default`, so existing artifacts stay byte-identical until a writer sets
-        # them (PR-3 writes `type:`). No writer sets them in PR-1.
+        # them (PR-3 writes `type:`). No writer sets them yet.
         "type": {"type": "string", "required": False},
         "tracker_ref": {"type": "string", "required": False},
-        "title": {
-            "type": "string",
-            "required": True,
-        },
-        "priority": {
-            "type": "string",
-            "required": True,
-            "enum": ["Blocker", "Critical", "Major", "Normal", "Minor", "Undefined"],
-        },
-        "size": {
-            "type": "string",
-            "required": False,
-            "enum": ["S", "M", "L", "XL"],
-            "default": None,
-        },
-        "status": {
-            "type": "string",
-            "required": True,
-            "enum": ["Draft", "Ready", "Submitted", "Archived"],
-        },
-        "parent_key": {
-            "type": "string",
-            "required": False,
-            "pattern": r"^(RFE-\d+|RHAIRFE-\d+)$",
-            "default": None,
-        },
-        "original_labels": {
-            "type": "list",
-            "required": False,
-            "default": None,
-        },
-    },
-    "rfe-review": {
-        "rfe_id": {
-            "type": "string",
-            "required": True,
-            "pattern": r"^(RFE-\d+|RHAIRFE-\d+)$",
-        },
-        # Pre-submission id, persisted at rename time. Renaming overwrites
-        # rfe_id with the Jira key, and this is the only durable record of
-        # which local draft a submitted item came from.
-        "local_id": {
-            "type": "string",
-            "required": False,
-            "pattern": r"^RFE-\d+$",
-            "default": None,
-        },
-        # Self-describing artifact fields; see the rfe-task comment. No default on purpose.
-        "type": {"type": "string", "required": False},
-        "tracker_ref": {"type": "string", "required": False},
-        "score": {
-            "type": "int",
-            "required": True,
-        },
-        "pass": {
-            "type": "bool",
-            "required": True,
-        },
-        "recommendation": {
-            "type": "string",
-            "required": True,
-            "enum": ["submit", "revise", "split", "reject", "autorevise_reject"],
-        },
-        "feasibility": {
-            "type": "string",
-            "required": True,
-            "enum": ["feasible", "infeasible", "indeterminate"],
-        },
-        "auto_revised": {
-            "type": "bool",
-            "required": True,
-            "default": False,
-        },
-        "needs_attention": {
-            "type": "bool",
-            "required": True,
-            "default": False,
-        },
-        "scores": {
-            "type": "dict",
-            "required": True,
-            "fields": {
-                "what": {"type": "int", "required": True},
-                "why": {"type": "int", "required": True},
-                "open_to_how": {"type": "int", "required": True},
-                "not_a_task": {"type": "int", "required": True},
-                "right_sized": {"type": "int", "required": True},
+    }
+
+
+def _extra_fields(desc, dotted):
+    """The type's own field specs (``schema.task.extra_fields`` / ``schema.review.extra_fields``),
+    deep-copied so SCHEMAS never aliases registry data. Spec key order is the descriptor's."""
+    return {name: copy.deepcopy(spec) for name, spec in (desc.get(dotted, None) or {}).items()}
+
+
+def _task_schema(desc):
+    """The ``<type>-task`` schema. Field order: id, local_id, type, tracker_ref, title,
+    priority, the type's extra fields (rfe: size), status, parent_key, original_labels."""
+    schema = _id_fields(desc)
+    schema["title"] = {"type": "string", "required": True}
+    schema["priority"] = {
+        "type": "string",
+        "required": True,
+        "enum": list(desc.get("schema.task.priority.enum")),
+    }
+    schema.update(_extra_fields(desc, "schema.task.extra_fields"))
+    schema["status"] = {"type": "string", "required": True, "enum": list(_STATUS_ENUM)}
+    schema["parent_key"] = {
+        "type": "string",
+        "required": False,
+        "pattern": _parent_key_pattern(desc),
+        "default": None,
+    }
+    schema["original_labels"] = {"type": "list", "required": False, "default": None}
+    return schema
+
+
+def _review_schema(desc):
+    """The ``<type>-review`` schema. Field order: id, local_id, type, tracker_ref, the shared
+    review fields (scores / before_scores nested over ``schema.review.score_fields``), then
+    the type's extra fields appended last (initiative: alignment, whose default is the
+    string "not_assessed" so an item with no RHAISTRAT parent reads the same here as in
+    its alignment file)."""
+    scores = {name: {"type": "int", "required": True} for name in desc.score_fields}
+    schema = _id_fields(desc)
+    schema.update(
+        {
+            "score": {"type": "int", "required": True},
+            "pass": {"type": "bool", "required": True},
+            "recommendation": {
+                "type": "string",
+                "required": True,
+                "enum": list(_RECOMMENDATION_ENUM),
             },
-        },
-        "error": {
-            "type": "string",
-            "required": False,
-            "default": None,
-        },
-        "before_score": {
-            "type": "int",
-            "required": False,
-            "default": None,
-        },
-        "needs_attention_reason": {
-            "type": "string",
-            "required": False,
-            "default": None,
-        },
-        "before_scores": {
-            "type": "dict",
-            "required": False,
-            "default": None,
-            "fields": {
-                "what": {"type": "int", "required": True},
-                "why": {"type": "int", "required": True},
-                "open_to_how": {"type": "int", "required": True},
-                "not_a_task": {"type": "int", "required": True},
-                "right_sized": {"type": "int", "required": True},
+            "feasibility": {"type": "string", "required": True, "enum": list(_FEASIBILITY_ENUM)},
+            "auto_revised": {"type": "bool", "required": True, "default": False},
+            "needs_attention": {"type": "bool", "required": True, "default": False},
+            "scores": {"type": "dict", "required": True, "fields": scores},
+            "error": {"type": "string", "required": False, "default": None},
+            "before_score": {"type": "int", "required": False, "default": None},
+            "needs_attention_reason": {"type": "string", "required": False, "default": None},
+            "before_scores": {
+                "type": "dict",
+                "required": False,
+                "default": None,
+                "fields": copy.deepcopy(scores),
             },
-        },
-    },
-    "initiative-task": {
-        "initiative_id": {
-            "type": "string",
-            "required": True,
-            "pattern": r"^(INIT-\d+|RHOAIENG-\d+)$",
-        },
-        "local_id": {
-            "type": "string",
-            "required": False,
-            "pattern": r"^INIT-\d+$",
-            "default": None,
-        },
-        # Self-describing artifact fields; see the rfe-task comment. No default on purpose.
-        "type": {"type": "string", "required": False},
-        "tracker_ref": {"type": "string", "required": False},
-        "title": {
-            "type": "string",
-            "required": True,
-        },
-        "priority": {
-            "type": "string",
-            "required": True,
-            "enum": ["Blocker", "Critical", "Major", "Normal", "Minor", "Undefined"],
-        },
-        "status": {
-            "type": "string",
-            "required": True,
-            "enum": ["Draft", "Ready", "Submitted", "Archived"],
-        },
-        "parent_key": {
-            "type": "string",
-            "required": False,
-            "pattern": r"^(RHAISTRAT-\d+|RHOAIENG-\d+|INIT-\d+)$",
-            "default": None,
-        },
-        "original_labels": {
-            "type": "list",
-            "required": False,
-            "default": None,
-        },
-    },
-    "initiative-review": {
-        "initiative_id": {
-            "type": "string",
-            "required": True,
-            "pattern": r"^(INIT-\d+|RHOAIENG-\d+)$",
-        },
-        "local_id": {
-            "type": "string",
-            "required": False,
-            "pattern": r"^INIT-\d+$",
-            "default": None,
-        },
-        # Self-describing artifact fields; see the rfe-task comment. No default on purpose.
-        "type": {"type": "string", "required": False},
-        "tracker_ref": {"type": "string", "required": False},
-        "score": {
-            "type": "int",
-            "required": True,
-        },
-        "pass": {
-            "type": "bool",
-            "required": True,
-        },
-        "recommendation": {
-            "type": "string",
-            "required": True,
-            "enum": ["submit", "revise", "split", "reject", "autorevise_reject"],
-        },
-        "feasibility": {
-            "type": "string",
-            "required": True,
-            "enum": ["feasible", "infeasible", "indeterminate"],
-        },
-        "auto_revised": {
-            "type": "bool",
-            "required": True,
-            "default": False,
-        },
-        "needs_attention": {
-            "type": "bool",
-            "required": True,
-            "default": False,
-        },
-        "scores": {
-            "type": "dict",
-            "required": True,
-            "fields": {
-                "what": {"type": "int", "required": True},
-                "why": {"type": "int", "required": True},
-                "scope": {"type": "int", "required": True},
-                "open_to_how": {"type": "int", "required": True},
-                "right_sized": {"type": "int", "required": True},
-            },
-        },
-        "error": {
-            "type": "string",
-            "required": False,
-            "default": None,
-        },
-        "before_score": {
-            "type": "int",
-            "required": False,
-            "default": None,
-        },
-        "needs_attention_reason": {
-            "type": "string",
-            "required": False,
-            "default": None,
-        },
-        "before_scores": {
-            "type": "dict",
-            "required": False,
-            "default": None,
-            "fields": {
-                "what": {"type": "int", "required": True},
-                "why": {"type": "int", "required": True},
-                "scope": {"type": "int", "required": True},
-                "open_to_how": {"type": "int", "required": True},
-                "right_sized": {"type": "int", "required": True},
-            },
-        },
-        "alignment": {
-            "type": "string",
-            "required": False,
-            "enum": ["strong", "partial", "weak", "not_assessed"],
-            # Defaults to not_assessed, not null, so an Initiative with no
-            # RHAISTRAT parent reads the same here as in its alignment file.
-            "default": "not_assessed",
-        },
-    },
+        }
+    )
+    schema.update(_extra_fields(desc, "schema.review.extra_fields"))
+    return schema
+
+
+SCHEMAS = {
+    f"{desc.name}-{kind}": build(desc)
+    for desc in _TYPES
+    if _declares_schemas(desc)
+    for kind, build in (("task", _task_schema), ("review", _review_schema))
 }
 
 
@@ -397,7 +301,7 @@ def validate(data, schema_type):
 
     Args:
         data: dict of frontmatter fields
-        schema_type: one of "rfe-task", "rfe-review"
+        schema_type: a key of SCHEMAS ("rfe-task", "rfe-review", ...)
 
     Returns:
         list of error strings (empty if valid)
@@ -659,7 +563,7 @@ def write_frontmatter(path, data, schema_type):
     Args:
         path: file path
         data: dict of frontmatter fields
-        schema_type: one of "rfe-task", "rfe-review"
+        schema_type: a key of SCHEMAS ("rfe-task", "rfe-review", ...)
 
     Raises:
         ValidationError: if data fails schema validation
@@ -750,53 +654,11 @@ def _is_companion_file(filename):
     )
 
 
-def find_artifact_file(artifacts_dir, identifier):
-    """Find the main artifact file for a given RFE ID or Jira key.
-
-    Matches:
-    - RFE-NNN.md (local pre-submission)
-    - RHAIRFE-NNNN.md (Jira-keyed)
-
-    Excludes companion files (-comments.md, -removed-context.md).
-    Excludes archived artifacts (status: Archived in frontmatter).
-
-    Args:
-        artifacts_dir: path to artifacts directory
-        identifier: RFE-NNN or RHAIRFE-NNNN
-
-    Returns:
-        Full path to artifact file, or None if not found.
-    """
-    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
-    if not os.path.isdir(tasks_dir):
-        return None
-
-    for filename in sorted(os.listdir(tasks_dir)):
-        if not filename.endswith(".md"):
-            continue
-        if _is_companion_file(filename):
-            continue
-
-        # Match by Jira key (exact: RHAIRFE-1595.md)
-        if identifier.startswith("RHAIRFE-"):
-            if filename == f"{identifier}.md":
-                path = os.path.join(tasks_dir, filename)
-                # Check if archived
-                data, _ = read_frontmatter(path)
-                if data.get("status") == "Archived":
-                    continue
-                return path
-
-        # Match by local RFE ID (exact: RFE-001.md, legacy: RFE-001-slug.md)
-        if identifier.startswith("RFE-"):
-            if filename == f"{identifier}.md" or filename.startswith(identifier + "-"):
-                path = os.path.join(tasks_dir, filename)
-                data, _ = read_frontmatter(path)
-                if data.get("status") == "Archived":
-                    continue
-                return path
-
-    return None
+def _type_for(identifier):
+    """The descriptor that owns ``identifier`` (``TypeRegistry.detect``), else rfe — the
+    default branch of the prefix sniffs this replaces (anything that was not INIT-/RHOAIENG-
+    went to the rfe dirs)."""
+    return _TYPES.detect(identifier) or _TYPES.get("rfe")
 
 
 def find_task_file_including_archived(
@@ -825,9 +687,10 @@ def find_task_file_including_archived(
 
 
 def find_artifact_file_including_archived(artifacts_dir, identifier):
-    """Like find_artifact_file but includes archived artifacts (RFE-only)."""
+    """Find an RFE task file by ID, including archived tasks (rfe-only wrapper)."""
+    rfe = _TYPES.get("rfe")
     return find_task_file_including_archived(
-        artifacts_dir, identifier, "rfe-tasks", "RHAIRFE-", "RFE-"
+        artifacts_dir, identifier, rfe.dirs("bare")["tasks"], rfe.write_prefix, rfe.local_prefix
     )
 
 
@@ -847,32 +710,10 @@ def find_removed_context_yaml_in(
 
 def find_removed_context_yaml(artifacts_dir, identifier):
     """Find the removed-context YAML file for a given RFE/initiative ID or Jira key."""
-    if identifier.startswith("INIT-") or identifier.startswith("RHOAIENG-"):
-        return find_removed_context_yaml_in(
-            artifacts_dir, identifier, "initiatives", "RHOAIENG-", "INIT-"
-        )
-    return find_removed_context_yaml_in(artifacts_dir, identifier, "rfe-tasks", "RHAIRFE-", "RFE-")
-
-
-def find_removed_context_file(artifacts_dir, identifier):
-    """Find the removed-context file for a given RFE ID or Jira key."""
-    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
-    if not os.path.isdir(tasks_dir):
-        return None
-
-    for filename in sorted(os.listdir(tasks_dir)):
-        if not filename.endswith("-removed-context.md"):
-            continue
-
-        if identifier.startswith("RHAIRFE-"):
-            if filename == f"{identifier}-removed-context.md":
-                return os.path.join(tasks_dir, filename)
-
-        if identifier.startswith("RFE-"):
-            if filename == f"{identifier}-removed-context.md":
-                return os.path.join(tasks_dir, filename)
-
-    return None
+    desc = _type_for(identifier)
+    return find_removed_context_yaml_in(
+        artifacts_dir, identifier, desc.dirs("bare")["tasks"], desc.write_prefix, desc.local_prefix
+    )
 
 
 def render_removed_context_comment(yaml_path, preamble):
@@ -900,12 +741,10 @@ def render_removed_context_comment(yaml_path, preamble):
 def find_review_file(artifacts_dir, identifier):
     """Find the review file for a given RFE/initiative ID or Jira key.
 
-    Looks in the appropriate reviews directory for {identifier}-review.md.
+    Looks in the reviews directory of the type that owns ``identifier`` (rfe when no
+    type does) for {identifier}-review.md.
     """
-    if identifier.startswith("RHOAIENG-") or identifier.startswith("INIT-"):
-        reviews_dir = os.path.join(artifacts_dir, "initiative-reviews")
-    else:
-        reviews_dir = os.path.join(artifacts_dir, "rfe-reviews")
+    reviews_dir = os.path.join(artifacts_dir, _type_for(identifier).dirs("bare")["reviews"])
 
     if not os.path.isdir(reviews_dir):
         return None
@@ -918,53 +757,20 @@ def find_review_file(artifacts_dir, identifier):
     return None
 
 
-def scan_task_files(artifacts_dir):
-    """Scan all RFE task files and return their frontmatter.
-
-    Returns:
-        list of (path, frontmatter_dict) tuples, sorted by rfe_id.
-        Files without valid frontmatter are skipped with a warning.
-    """
-    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
-    if not os.path.isdir(tasks_dir):
+def _scan_dir(directory, schema_type, accept):
+    """(path, validated frontmatter) for every file in ``directory`` that ``accept`` admits,
+    in sorted filename order; files without valid frontmatter are skipped with a warning."""
+    if not os.path.isdir(directory):
         return []
 
     results = []
-    for filename in sorted(os.listdir(tasks_dir)):
-        if not filename.endswith(".md"):
-            continue
-        if _is_companion_file(filename):
+    for filename in sorted(os.listdir(directory)):
+        if not accept(filename):
             continue
 
-        path = os.path.join(tasks_dir, filename)
+        path = os.path.join(directory, filename)
         try:
-            data, _ = read_frontmatter_validated(path, "rfe-task")
-            results.append((path, data))
-        except (ValidationError, Exception) as e:
-            print(f"Warning: skipping {filename}: {e}", file=sys.stderr)
-
-    return sorted(results, key=lambda x: x[1].get("rfe_id", ""))
-
-
-def scan_review_files(artifacts_dir):
-    """Scan all RFE review files and return their frontmatter.
-
-    Returns:
-        list of (path, frontmatter_dict) tuples.
-        Files without valid frontmatter are skipped with a warning.
-    """
-    reviews_dir = os.path.join(artifacts_dir, "rfe-reviews")
-    if not os.path.isdir(reviews_dir):
-        return []
-
-    results = []
-    for filename in sorted(os.listdir(reviews_dir)):
-        if not filename.endswith("-review.md"):
-            continue
-
-        path = os.path.join(reviews_dir, filename)
-        try:
-            data, _ = read_frontmatter_validated(path, "rfe-review")
+            data, _ = read_frontmatter_validated(path, schema_type)
             results.append((path, data))
         except (ValidationError, Exception) as e:
             print(f"Warning: skipping {filename}: {e}", file=sys.stderr)
@@ -972,158 +778,185 @@ def scan_review_files(artifacts_dir):
     return results
 
 
-def scan_initiative_task_files(artifacts_dir):
-    """Scan all Initiative task files and return their frontmatter.
+def scan_tasks(artifacts_dir, desc):
+    """Scan the task files of one work-item type and return their frontmatter.
+
+    Args:
+        artifacts_dir: path to artifacts directory
+        desc: a ``type_registry.Descriptor``; its ``dirs.tasks`` is scanned and every
+            ``.md`` that is not a companion file is validated against ``<type>-task``.
 
     Returns:
-        list of (path, frontmatter_dict) tuples, sorted by initiative_id.
+        list of (path, frontmatter_dict) tuples, sorted by the type's id field.
         Files without valid frontmatter are skipped with a warning.
     """
-    initiatives_dir = os.path.join(artifacts_dir, "initiatives")
-    if not os.path.isdir(initiatives_dir):
-        return []
+    tasks_dir = os.path.join(artifacts_dir, desc.dirs("bare")["tasks"])
+    results = _scan_dir(
+        tasks_dir,
+        f"{desc.name}-task",
+        lambda filename: filename.endswith(".md") and not _is_companion_file(filename),
+    )
+    id_field = desc.id_field
+    return sorted(results, key=lambda x: x[1].get(id_field, ""))
 
-    results = []
-    for filename in sorted(os.listdir(initiatives_dir)):
-        if not filename.endswith(".md"):
-            continue
-        if _is_companion_file(filename):
-            continue
 
-        path = os.path.join(initiatives_dir, filename)
-        try:
-            data, _ = read_frontmatter_validated(path, "initiative-task")
-            results.append((path, data))
-        except (ValidationError, Exception) as e:
-            print(f"Warning: skipping {filename}: {e}", file=sys.stderr)
+def scan_task_files(artifacts_dir):
+    """Scan all RFE task files — ``scan_tasks`` for the rfe type (sorted by rfe_id)."""
+    return scan_tasks(artifacts_dir, _TYPES.get("rfe"))
 
-    return sorted(results, key=lambda x: x[1].get("initiative_id", ""))
+
+def scan_initiative_task_files(artifacts_dir):
+    """Scan all Initiative task files — ``scan_tasks`` for the initiative type (sorted by
+    initiative_id)."""
+    return scan_tasks(artifacts_dir, _TYPES.get("initiative"))
+
+
+def scan_reviews(artifacts_dir, desc):
+    """Scan the ``*-review.md`` files of one work-item type and return their frontmatter.
+
+    Returns:
+        list of (path, frontmatter_dict) tuples in filename order.
+        Files without valid frontmatter are skipped with a warning.
+    """
+    reviews_dir = os.path.join(artifacts_dir, desc.dirs("bare")["reviews"])
+    return _scan_dir(
+        reviews_dir, f"{desc.name}-review", lambda filename: filename.endswith("-review.md")
+    )
+
+
+def scan_review_files(artifacts_dir):
+    """Scan all RFE review files — ``scan_reviews`` for the rfe type (rebuild_index's input)."""
+    return scan_reviews(artifacts_dir, _TYPES.get("rfe"))
 
 
 # ─── File Renaming (post-submit) ───────────────────────────────────────────────
 
 
-def rename_to_jira_key(artifacts_dir, rfe_id, jira_key):
-    """Rename RFE-NNN.md files to RHAIRFE-NNNN.md after submission.
+def _rename_error_label(desc):
+    """The prefix of the rename ValueError text: the per-type function name the message has
+    always carried — "rename_to_jira_key" for rfe, "rename_initiative_to_jira_key" for
+    initiative. A grandfathered, name-keyed projection (like pipeline.poll_prefix being ''
+    for rfe): the rfe name has no type infix, every other type gets rename_<type>_to_jira_key.
+    """
+    return "rename_to_jira_key" if desc.name == "rfe" else f"rename_{desc.name}_to_jira_key"
 
-    Renames the task file, companion files, and review file.
-    Updates rfe_id in frontmatter to the new Jira key.
+
+def _review_to_rename(reviews_dir, item_id, desc):
+    """The review file ``rename_to_tracker_key`` renames, or None.
+
+    rfe tolerates legacy slug-suffixed names (``RFE-001-slug-review.md``): the first
+    ``{item_id}-*-review.md`` in directory order is taken, as rename_to_jira_key always
+    did. Every other type renames exactly ``{item_id}-review.md``, as
+    rename_initiative_to_jira_key always did. The tolerance is not a descriptor fact, so it
+    stays keyed on the type name until the PR-3 resolution ladder (frontmatter ``type:`` on
+    every artifact) decides whether legacy names are honoured for every type or retired.
+    """
+    if desc.name == "rfe":
+        for filename in list(os.listdir(reviews_dir)):
+            if filename.startswith(item_id + "-") and filename.endswith("-review.md"):
+                return os.path.join(reviews_dir, filename)
+        return None
+    old_review = os.path.join(reviews_dir, f"{item_id}-review.md")
+    return old_review if os.path.isfile(old_review) else None
+
+
+def rename_to_tracker_key(artifacts_dir, item_id, tracker_key, desc):
+    """Rename a submitted item's files from its local id to its tracker key.
+
+    ``RFE-NNN.md`` -> ``RHAIRFE-NNNN.md`` (``INIT-NNN.md`` -> ``RHOAIENG-NNNN.md``): the
+    task file, its companion files and the review file under the type's ``dirs``. The
+    task file's frontmatter becomes ``{<id_field>: tracker_key, status: Submitted,
+    local_id: item_id}`` and the review file's ``{<id_field>: tracker_key, local_id:
+    item_id}``.
 
     Args:
         artifacts_dir: path to artifacts directory
-        rfe_id: e.g. "RFE-001"
-        jira_key: e.g. "RHAIRFE-1600"
+        item_id: e.g. "RFE-001" — must match ``identity.local_id_pattern``
+        tracker_key: e.g. "RHAIRFE-1600" — must be the type's write prefix + digits
+        desc: a ``type_registry.Descriptor``
     """
-    # Both ids become path components below. rfe_id comes from validated
-    # frontmatter, but jira_key arrives from a Jira API response — reject
+    # Both ids become path components below. item_id comes from validated
+    # frontmatter, but tracker_key arrives from a Jira API response — reject
     # anything that is not the documented shape before touching the fs.
-    if not re.fullmatch(r"RFE-\d+", rfe_id):
-        raise ValueError(f"rename_to_jira_key: invalid local id {rfe_id!r}")
-    if not re.fullmatch(r"RHAIRFE-\d+", jira_key):
-        raise ValueError(f"rename_to_jira_key: invalid Jira key {jira_key!r}")
+    # The key is checked against the WRITE prefix (key_prefixes[0]) alone, not the
+    # key_prefixes union design §10 item 2 names for the forked pairs' guards: the key an
+    # item is renamed TO is always the one its tracker binding creates under. Identical
+    # today (both shipped types declare a single prefix); PR-3, where key_prefixes gains
+    # read prefixes, decides whether a rename target may carry one of those.
+    label = _rename_error_label(desc)
+    if not re.fullmatch(desc.local_id_pattern, item_id):
+        raise ValueError(f"{label}: invalid local id {item_id!r}")
+    if not re.fullmatch(desc.write_prefix + r"\d+", tracker_key):
+        raise ValueError(f"{label}: invalid Jira key {tracker_key!r}")
 
-    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
-    reviews_dir = os.path.join(artifacts_dir, "rfe-reviews")
+    dirs = desc.dirs("bare")
+    tasks_dir = os.path.join(artifacts_dir, dirs["tasks"])
+    reviews_dir = os.path.join(artifacts_dir, dirs["reviews"])
+    id_field = desc.id_field
 
     # Rename task file and companions
     if os.path.isdir(tasks_dir):
         for filename in list(os.listdir(tasks_dir)):
-            if not (filename == f"{rfe_id}.md" or filename.startswith(rfe_id + "-")):
+            if not (filename == f"{item_id}.md" or filename.startswith(item_id + "-")):
                 continue
             if not (filename.endswith(".md") or filename.endswith(".yaml")):
                 continue
 
             old_path = os.path.join(tasks_dir, filename)
 
+            # Companions must be matched before the fallback: anything that
+            # reaches the else branch is renamed to {tracker_key}.md, which is
+            # also the main task file's new name, so an unhandled companion
+            # silently overwrites it. The suffix map is type-agnostic: a
+            # -comments.md is renamed for every type (companions.comments only
+            # says whether the fetch step produces one).
             if filename.endswith("-comments.md"):
-                new_name = f"{jira_key}-comments.md"
+                new_name = f"{tracker_key}-comments.md"
             elif filename.endswith("-removed-context.yaml"):
-                new_name = f"{jira_key}-removed-context.yaml"
+                new_name = f"{tracker_key}-removed-context.yaml"
             elif filename.endswith("-removed-context.md"):
-                new_name = f"{jira_key}-removed-context.md"
+                new_name = f"{tracker_key}-removed-context.md"
             else:
-                new_name = f"{jira_key}.md"
+                new_name = f"{tracker_key}.md"
 
             new_path = os.path.join(tasks_dir, new_name)
             os.rename(old_path, new_path)
 
             # Update frontmatter on main task file
-            if new_name == f"{jira_key}.md":
+            if new_name == f"{tracker_key}.md":
                 update_frontmatter(
                     new_path,
-                    {"rfe_id": jira_key, "status": "Submitted", "local_id": rfe_id},
-                    "rfe-task",
+                    {id_field: tracker_key, "status": "Submitted", "local_id": item_id},
+                    f"{desc.name}-task",
                 )
 
     # Rename review file
     if os.path.isdir(reviews_dir):
-        for filename in list(os.listdir(reviews_dir)):
-            if filename.startswith(rfe_id + "-") and filename.endswith("-review.md"):
-                old_path = os.path.join(reviews_dir, filename)
-                new_path = os.path.join(reviews_dir, f"{jira_key}-review.md")
-                os.rename(old_path, new_path)
+        old_review = _review_to_rename(reviews_dir, item_id, desc)
+        if old_review is not None:
+            new_review = os.path.join(reviews_dir, f"{tracker_key}-review.md")
+            os.rename(old_review, new_review)
+            update_frontmatter(
+                new_review, {id_field: tracker_key, "local_id": item_id}, f"{desc.name}-review"
+            )
 
-                # Update frontmatter
-                update_frontmatter(new_path, {"rfe_id": jira_key, "local_id": rfe_id}, "rfe-review")
-                break
+
+def rename_to_jira_key(artifacts_dir, rfe_id, jira_key):
+    """Rename RFE-NNN.md files to RHAIRFE-NNNN.md after submission —
+    ``rename_to_tracker_key`` for the rfe type.
+
+    Args:
+        artifacts_dir: path to artifacts directory
+        rfe_id: e.g. "RFE-001"
+        jira_key: e.g. "RHAIRFE-1600"
+    """
+    rename_to_tracker_key(artifacts_dir, rfe_id, jira_key, _TYPES.get("rfe"))
 
 
 def rename_initiative_to_jira_key(artifacts_dir, initiative_id, jira_key):
-    """Rename INIT-NNN.md files to RHOAIENG-NNNN.md after submission.
-
-    Renames the task file, companion files, and review file.
-    Updates initiative_id in frontmatter to the new Jira key.
-    """
-    if not re.fullmatch(r"INIT-\d+", initiative_id):
-        raise ValueError(f"rename_initiative_to_jira_key: invalid local id {initiative_id!r}")
-    if not re.fullmatch(r"RHOAIENG-\d+", jira_key):
-        raise ValueError(f"rename_initiative_to_jira_key: invalid Jira key {jira_key!r}")
-
-    initiatives_dir = os.path.join(artifacts_dir, "initiatives")
-    reviews_dir = os.path.join(artifacts_dir, "initiative-reviews")
-
-    if os.path.isdir(initiatives_dir):
-        for filename in list(os.listdir(initiatives_dir)):
-            if not (filename == f"{initiative_id}.md" or filename.startswith(initiative_id + "-")):
-                continue
-            if not (filename.endswith(".md") or filename.endswith(".yaml")):
-                continue
-
-            old_path = os.path.join(initiatives_dir, filename)
-
-            # Companions must be matched before the fallback: anything that
-            # reaches the else branch is renamed to {jira_key}.md, which is
-            # also the main task file's new name, so an unhandled companion
-            # silently overwrites it.
-            if filename.endswith("-comments.md"):
-                new_name = f"{jira_key}-comments.md"
-            elif filename.endswith("-removed-context.yaml"):
-                new_name = f"{jira_key}-removed-context.yaml"
-            elif filename.endswith("-removed-context.md"):
-                new_name = f"{jira_key}-removed-context.md"
-            else:
-                new_name = f"{jira_key}.md"
-
-            new_path = os.path.join(initiatives_dir, new_name)
-            os.rename(old_path, new_path)
-
-            if new_name == f"{jira_key}.md":
-                update_frontmatter(
-                    new_path,
-                    {"initiative_id": jira_key, "status": "Submitted", "local_id": initiative_id},
-                    "initiative-task",
-                )
-
-    if os.path.isdir(reviews_dir):
-        old_review = os.path.join(reviews_dir, f"{initiative_id}-review.md")
-        if os.path.isfile(old_review):
-            new_review = os.path.join(reviews_dir, f"{jira_key}-review.md")
-            os.rename(old_review, new_review)
-            update_frontmatter(
-                new_review,
-                {"initiative_id": jira_key, "local_id": initiative_id},
-                "initiative-review",
-            )
+    """Rename INIT-NNN.md files to RHOAIENG-NNNN.md after submission —
+    ``rename_to_tracker_key`` for the initiative type."""
+    rename_to_tracker_key(artifacts_dir, initiative_id, jira_key, _TYPES.get("initiative"))
 
 
 # ─── Index Rebuilding ───────────────────────────────────────────────────────────
@@ -1132,19 +965,21 @@ def rename_initiative_to_jira_key(artifacts_dir, initiative_id, jira_key):
 def rebuild_index(artifacts_dir):
     """Rebuild artifacts/rfes.md from frontmatter across task and review files.
 
-    Scans rfe-tasks/ for task metadata and rfe-reviews/ for review scores.
-    Generates a summary table.
+    The index is the rfe type's (``index.enabled``; the initiative descriptor has none):
+    scans rfe-tasks/ for task metadata and rfe-reviews/ for review scores and generates
+    a summary table. The Size column is the rfe task schema's extra field.
 
     Returns:
         The generated markdown string.
     """
+    id_field = _TYPES.get("rfe").id_field
     tasks = scan_task_files(artifacts_dir)
     reviews = scan_review_files(artifacts_dir)
 
-    # Build review lookup by rfe_id
+    # Build review lookup by id
     review_by_id = {}
     for _, review_data in reviews:
-        review_by_id[review_data["rfe_id"]] = review_data
+        review_by_id[review_data[id_field]] = review_data
 
     lines = [
         "# RFE Summary",
@@ -1154,7 +989,7 @@ def rebuild_index(artifacts_dir):
     ]
 
     for _, task_data in tasks:
-        rfe_id = task_data["rfe_id"]
+        rfe_id = task_data[id_field]
         title = task_data.get("title", "Untitled")
         priority = task_data.get("priority", "—")
         size = task_data.get("size") or "—"
@@ -1192,53 +1027,62 @@ def rebuild_index(artifacts_dir):
 # ─── Legacy Compatibility ──────────────────────────────────────────────────────
 
 
-def parse_child_artifact(path):
-    """Parse a child RFE markdown file.
+def parse_child(path, desc):
+    """Parse a child item markdown file of one work-item type.
 
     Returns: (title, priority, full_markdown, cleaned_markdown)
     - full_markdown: original content (for archival comment)
     - cleaned_markdown: metadata stripped (for Jira description)
 
-    Reads title and priority from frontmatter if available,
-    falls back to parsing markdown content.
+    Title and priority are read from frontmatter. rfe alone keeps the pre-frontmatter
+    markdown fallbacks parse_child_artifact always had: a ``# RFE-NNN: Title`` heading
+    (built from ``identity.local_prefix``) when the title is missing or empty, a
+    ``**Priority**: X`` line when the priority is, else "Untitled" / "Normal". Every other
+    type reads ``data.get("title", "Untitled")`` / ``data.get("priority", "Normal")`` as
+    parse_child_initiative always did. The fallback is not a descriptor fact, so it stays
+    keyed on the type name until the PR-3 resolution ladder (frontmatter ``type:`` on
+    every artifact) decides whether legacy markdown children are parsed for every type or
+    the fallback is retired.
     """
     from jira_utils import strip_metadata
 
     with open(path, encoding="utf-8") as f:
         content = f.read()
 
-    data, body = read_frontmatter(path)
+    data, _ = read_frontmatter(path)
 
-    if data.get("title"):
-        title = data["title"]
-    else:
-        title_match = re.match(r"^#\s+RFE-\d+:\s+(.+)$", content, re.MULTILINE)
-        title = title_match.group(1).strip() if title_match else "Untitled"
+    if desc.name == "rfe":
+        if data.get("title"):
+            title = data["title"]
+        else:
+            heading = r"^#\s+" + desc.local_prefix + r"\d+:\s+(.+)$"
+            title_match = re.match(heading, content, re.MULTILINE)
+            title = title_match.group(1).strip() if title_match else "Untitled"
 
-    if data.get("priority"):
-        priority = data["priority"]
+        if data.get("priority"):
+            priority = data["priority"]
+        else:
+            priority_match = re.search(r"^\*\*Priority\*\*:\s*(.+)$", content, re.MULTILINE)
+            priority = priority_match.group(1).strip() if priority_match else "Normal"
     else:
-        priority_match = re.search(r"^\*\*Priority\*\*:\s*(.+)$", content, re.MULTILINE)
-        priority = priority_match.group(1).strip() if priority_match else "Normal"
+        title = data.get("title", "Untitled")
+        priority = data.get("priority", "Normal")
 
     cleaned = strip_metadata(content)
     return title, priority, content, cleaned
 
 
-def parse_child_initiative(path):
-    """Parse a child Initiative markdown file.
+def parse_child_artifact(path):
+    """Parse a child RFE markdown file — ``parse_child`` for the rfe type.
 
     Returns: (title, priority, full_markdown, cleaned_markdown)
     """
-    from jira_utils import strip_metadata
+    return parse_child(path, _TYPES.get("rfe"))
 
-    with open(path, encoding="utf-8") as f:
-        content = f.read()
 
-    data, body = read_frontmatter(path)
+def parse_child_initiative(path):
+    """Parse a child Initiative markdown file — ``parse_child`` for the initiative type.
 
-    title = data.get("title", "Untitled")
-    priority = data.get("priority", "Normal")
-
-    cleaned = strip_metadata(content)
-    return title, priority, content, cleaned
+    Returns: (title, priority, full_markdown, cleaned_markdown)
+    """
+    return parse_child(path, _TYPES.get("initiative"))

--- a/scripts/check_conflicts.py
+++ b/scripts/check_conflicts.py
@@ -31,22 +31,18 @@ import os
 import sys
 
 import type_registry
-from artifact_utils import scan_initiative_task_files, scan_task_files
+from artifact_utils import scan_tasks
 from jira_utils import check_description_conflict, require_env
 
 _TYPES = type_registry.load()
 
-# The task scanners are still a forked pair in artifact_utils (they collapse into one generic
-# later in the PR-2 series), so they are the one entry selected by type name rather than read
-# from the descriptor. A registered type without a scanner gets None and is refused in main().
-_SCAN_FNS = {"rfe": scan_task_files, "initiative": scan_initiative_task_files}
-
 # Derived from the type registry (design work-item-types-unified.md §10 item 2): the bare dir
 # form (Q13), identity.id_field and the descriptor write prefix identity.<tracker>.key_prefixes[0].
+# The task tree itself is read by artifact_utils.scan_tasks over the same descriptor, so every
+# registered type — shipped or drop-in — is scanned from its own dirs.tasks.
 _TYPE_CONFIG = {
     name: {
         "originals_dir": _TYPES.get(name).dirs(form="bare")["originals"],
-        "scan_fn": _SCAN_FNS.get(name),
         "id_field": _TYPES.get(name).id_field,
         "jira_prefix": _TYPES.get(name).key_prefixes[0],
     }
@@ -66,9 +62,6 @@ def main():
     args = parser.parse_args()
 
     tc = _TYPE_CONFIG[args.type]
-    if tc["scan_fn"] is None:
-        print(f"Error: no task scanner is registered for type {args.type!r}.", file=sys.stderr)
-        sys.exit(2)
 
     server, user, token = require_env()
     if not all([server, user, token]):
@@ -77,7 +70,7 @@ def main():
 
     originals_dir = os.path.join(args.artifacts_dir, tc["originals_dir"])
 
-    tasks = tc["scan_fn"](args.artifacts_dir)
+    tasks = scan_tasks(args.artifacts_dir, _TYPES.get(args.type))
     jira_items = []
     for task_path, task_data in tasks:
         item_id = task_data[tc["id_field"]]

--- a/scripts/check_review_progress.py
+++ b/scripts/check_review_progress.py
@@ -3,6 +3,12 @@
 Reports completion status for a list of RFE IDs based on the current phase.
 Supports ``--wait`` mode which sleeps internally so the caller does not need
 to parse ``NEXT_POLL`` values.
+
+``PHASE_CHECKS`` (poll phase -> expected output path) is a projection of
+``types/<t>/type.yaml``: ``pipeline.poll_prefix`` + phase base -> ``dirs`` x the
+phase's file convention, with one row per ``pipeline.dimensions[]`` entry
+(design work-item-types-unified.md §10 item 2). verify_phase.py derives its
+phase tables from the same descriptors.
 """
 
 import argparse
@@ -12,28 +18,83 @@ import time
 
 import yaml
 
-sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import type_registry
 from artifact_utils import read_frontmatter
 
-PHASE_CHECKS = {
-    "fetch": lambda id: f"artifacts/rfe-tasks/{id}.md",
-    # Same path as "fetch", but a stricter check — see check_id(). Create agents
-    # write the task file first and set frontmatter in a later tool call, so
-    # existence alone would release the barrier mid-write.
-    "create": lambda id: f"artifacts/rfe-tasks/{id}.md",
-    "assess": lambda id: f"tmp/rfe-assess/single/{id}.result.md",
-    "feasibility": lambda id: f"artifacts/rfe-reviews/{id}-feasibility.md",
-    "review": lambda id: f"artifacts/rfe-reviews/{id}-review.md",
-    "revise": lambda id: f"artifacts/rfe-reviews/{id}-review.md",
-    "split": lambda id: f"artifacts/rfe-reviews/{id}-split-status.yaml",
-    "initiative-split": lambda id: f"artifacts/initiative-reviews/{id}-split-status.yaml",
-    "initiative-fetch": lambda id: f"artifacts/initiatives/{id}.md",
-    "initiative-assess": lambda id: f"tmp/rfe-assess/single/{id}.result.md",
-    "initiative-feasibility": lambda id: f"artifacts/initiative-reviews/{id}-feasibility.md",
-    "initiative-review": lambda id: f"artifacts/initiative-reviews/{id}-review.md",
-    "initiative-revise": lambda id: f"artifacts/initiative-reviews/{id}-review.md",
-    "initiative-alignment": lambda id: f"artifacts/initiative-reviews/{id}-alignment.md",
+_TYPES = type_registry.load()
+
+# Type-neutral assess staging dir (design §10: kept byte-stable for every type).
+ASSESS_STAGING = "tmp/rfe-assess/single"
+
+# PR #148 gave rfe.speedrun a Phase-1 "create" barrier; no other pipeline polls one, so the row
+# stays rfe-only (an `initiative-create` row would change the --phase choices text). PR-5's
+# generic speedrun body gives every type a create barrier keyed on dirs.tasks + id_field, and
+# this grandfather goes with it.
+_CREATE_BARRIER_TYPES = ("rfe",)
+
+# Key order is CLI surface: argparse renders the --phase/--also-phase choices from it, so each
+# type's rows are emitted in the order the literal table had. The rfe block is the generic
+# order of _phase_rows(); the initiative block was appended split-first and gained alignment
+# last when that dimension landed. Neither order is a descriptor fact, hence this table; a
+# type without an entry (a drop-in) gets the generic order.
+_LEGACY_ROW_ORDER = {
+    "initiative": ("split", "fetch", "assess", "feasibility", "review", "revise", "alignment"),
 }
+
+# The descriptor fields a type must declare to be polled. Both shipped types declare them
+# (validate_types.py gate 1 requires dirs and pipeline.poll_prefix); a drop-in root
+# (RFE_CREATOR_EXTRA_TYPES, dev/test only) may register a partial descriptor, and the registry
+# loader does not run the JSON-Schema gate — such a type contributes no rows, exactly as it
+# contributes no artifact_utils.SCHEMAS entry, instead of breaking the import of the poll
+# script every pipeline barrier runs.
+_PHASE_FACTS = ("dirs.tasks", "dirs.reviews", "pipeline.poll_prefix")
+
+
+def _polls(desc):
+    """True when ``desc`` carries every field its phase rows are derived from."""
+    return all(desc.get(dotted, None) is not None for dotted in _PHASE_FACTS)
+
+
+def _phase_rows(desc):
+    """phase base -> (id -> expected output path) for one type: ``dirs`` x the pipeline phases,
+    plus one ``<reviews>/<id>-<name>.md`` row per ``pipeline.dimensions`` entry."""
+    dirs = desc.dirs()
+    rows = {"fetch": lambda id: f"{dirs['tasks']}/{id}.md"}
+    if desc.name in _CREATE_BARRIER_TYPES:
+        # Same path as "fetch", but a stricter check — see check_id(). Create agents
+        # write the task file first and set frontmatter in a later tool call, so
+        # existence alone would release the barrier mid-write.
+        rows["create"] = lambda id: f"{dirs['tasks']}/{id}.md"
+    rows["assess"] = lambda id: f"{ASSESS_STAGING}/{id}.result.md"
+    for dimension in desc.get("pipeline.dimensions", []):
+        name = dimension["name"]
+        rows[name] = lambda id, name=name: f"{dirs['reviews']}/{id}-{name}.md"
+    rows["review"] = lambda id: f"{dirs['reviews']}/{id}-review.md"
+    rows["revise"] = lambda id: f"{dirs['reviews']}/{id}-review.md"
+    rows["split"] = lambda id: f"{dirs['reviews']}/{id}-split-status.yaml"
+    legacy = _LEGACY_ROW_ORDER.get(desc.name, ())
+    order = [base for base in legacy if base in rows] + [b for b in rows if b not in legacy]
+    return {base: rows[base] for base in order}
+
+
+def _build_phase_table():
+    """``PHASE_CHECKS`` plus its inverse, poll phase -> (type name, phase base), which
+    check_id() uses to pick the check mode and the owning type's id field."""
+    checks = {}
+    owners = {}
+    for name in _TYPES.names():
+        desc = _TYPES.get(name)
+        if not _polls(desc):
+            continue
+        poll_prefix = desc.get("pipeline.poll_prefix")
+        for base, path_fn in _phase_rows(desc).items():
+            checks[f"{poll_prefix}{base}"] = path_fn
+            owners[f"{poll_prefix}{base}"] = (name, base)
+    return checks, owners
+
+
+PHASE_CHECKS, _PHASE_OWNER = _build_phase_table()
 
 
 def check_id(phase, rfe_id):
@@ -41,7 +102,11 @@ def check_id(phase, rfe_id):
     path = PHASE_CHECKS[phase](rfe_id)
     if not os.path.exists(path):
         return "pending"
-    if phase == "create":
+    # The check mode follows the phase base for every type: create -> frontmatter_valid,
+    # review -> score_present, revise -> revised_or_split, anything else -> exists. A phase
+    # patched into PHASE_CHECKS without an owner (tests) keeps the exists mode.
+    type_name, base = _PHASE_OWNER.get(phase, (None, None))
+    if base == "create":
         # Every not-yet-good state is "pending", never "error". The --wait loop
         # exits on pending == 0 and never consults the error count, so an
         # "error" here would release the barrier on the very file it rejected.
@@ -52,13 +117,14 @@ def check_id(phase, rfe_id):
             return "pending"
         # read_frontmatter returns {} for a file with no frontmatter block yet,
         # which is a half-written file, not a finished one. The id has to be
-        # the one asked about: a task file carrying a different rfe_id is not
-        # this ID's create output, and accepting it would break the
-        # one-RFE-per-preallocated-ID contract the barrier exists to enforce.
-        if not data or data.get("rfe_id") != rfe_id:
+        # the one asked about: a task file carrying a different id (the owning
+        # type's identity.id_field) is not this ID's create output, and
+        # accepting it would break the one-item-per-preallocated-ID contract
+        # the barrier exists to enforce.
+        if not data or data.get(_TYPES.get(type_name).id_field) != rfe_id:
             return "pending"
         return "completed"
-    if phase in ("review", "initiative-review"):
+    if base == "review":
         try:
             data, _ = read_frontmatter(path)
         except Exception:
@@ -69,7 +135,7 @@ def check_id(phase, rfe_id):
             return "pending"
         if data.get("error"):
             return "error"
-    if phase in ("revise", "initiative-revise"):
+    if base == "revise":
         try:
             data, _ = read_frontmatter(path)
         except Exception:
@@ -131,6 +197,12 @@ def _detect_fast(explicit_flag):
     """Return True if fast-poll should be used."""
     if explicit_flag:
         return True
+    # The interactive skills write tmp/<pipeline.state_prefix><stage>-config.yaml. This list
+    # is deliberately still the literal: the descriptor projection (state_prefix x stages)
+    # would ADD tmp/initiative-speedrun-config.yaml, which initiative-speedrun writes but this
+    # allowlist never polled, so interactive initiative speedruns would start auto-enabling
+    # fast polling. That drift is fixed on purpose by a separate change, not by this
+    # behavior-neutral migration.
     for cfg in (
         "tmp/review-config.yaml",
         "tmp/split-config.yaml",

--- a/scripts/check_review_progress.py
+++ b/scripts/check_review_progress.py
@@ -50,6 +50,9 @@ _LEGACY_ROW_ORDER = {
 # script every pipeline barrier runs.
 _PHASE_FACTS = ("dirs.tasks", "dirs.reviews", "pipeline.poll_prefix")
 
+# Phase bases the engine owns; a pipeline.dimensions entry may not reuse them.
+ENGINE_PHASES = frozenset({"fetch", "create", "assess", "review", "revise", "split"})
+
 
 def _polls(desc):
     """True when ``desc`` carries every field its phase rows are derived from."""
@@ -67,8 +70,17 @@ def _phase_rows(desc):
         # existence alone would release the barrier mid-write.
         rows["create"] = lambda id: f"{dirs['tasks']}/{id}.md"
     rows["assess"] = lambda id: f"{ASSESS_STAGING}/{id}.result.md"
+    seen = set()
     for dimension in desc.get("pipeline.dimensions", []):
         name = dimension["name"]
+        # A dimension named like an engine phase would silently replace that phase's
+        # row and make the barrier watch the wrong file; refuse at table build.
+        if name in ENGINE_PHASES or name in seen:
+            raise ValueError(
+                f"{desc.name}: pipeline.dimensions name {name!r} collides with an engine phase "
+                f"or another dimension (reserved: {', '.join(sorted(ENGINE_PHASES))})"
+            )
+        seen.add(name)
         rows[name] = lambda id, name=name: f"{dirs['reviews']}/{id}-{name}.md"
     rows["review"] = lambda id: f"{dirs['reviews']}/{id}-review.md"
     rows["revise"] = lambda id: f"{dirs['reviews']}/{id}-review.md"

--- a/scripts/collect_children.py
+++ b/scripts/collect_children.py
@@ -8,7 +8,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import type_registry
-from artifact_utils import resolve_ids, scan_initiative_task_files, scan_task_files
+from artifact_utils import resolve_ids, scan_tasks
 
 _TYPES = type_registry.load()
 
@@ -34,14 +34,11 @@ def main():
 
     artifacts_dir = os.path.join(os.getcwd(), "artifacts")
 
-    # The scan pair is still forked in artifact_utils (it collapses into one generic keyed on
-    # dirs.tasks/schema.task in a later PR); select it by type name, read the id field from
-    # the registry.
-    if args.type == "initiative":
-        tasks = scan_initiative_task_files(artifacts_dir)
-    else:
-        tasks = scan_task_files(artifacts_dir)
-    id_field = _TYPES.get(args.type).id_field
+    # The type's descriptor names the task tree (dirs.tasks, validated as <type>-task) and the
+    # id field (identity.id_field); scan_tasks reads the former, the loop below the latter.
+    desc = _TYPES.get(args.type)
+    tasks = scan_tasks(artifacts_dir, desc)
+    id_field = desc.id_field
 
     # Build parent -> children mapping
     children_by_parent = {pid: [] for pid in parent_ids}

--- a/scripts/frontmatter.py
+++ b/scripts/frontmatter.py
@@ -33,6 +33,8 @@ import json
 import os
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import type_registry
 from artifact_utils import (
     SCHEMAS,
     ValidationError,
@@ -43,6 +45,20 @@ from artifact_utils import (
     update_frontmatter,
     write_frontmatter,
 )
+
+_TYPES = type_registry.load()
+
+# Path component -> schema name, from every type's ``dirs``: registry order, each type's
+# reviews dir tested before its tasks dir (rfe-reviews/, rfe-tasks/, initiative-reviews/,
+# initiatives/ — the order the hand-written table had). A substring test, so both
+# ``artifacts/rfe-tasks/X.md`` and a bare ``rfe-tasks/X.md`` resolve. Only types that
+# contribute schemas take part (a partial drop-in descriptor has no SCHEMAS entries).
+_SCHEMA_BY_DIR = [
+    (f"{desc.dirs('bare')[dir_key]}/", f"{desc.name}-{kind}")
+    for desc in _TYPES
+    for dir_key, kind in (("reviews", "review"), ("tasks", "task"))
+    if f"{desc.name}-{kind}" in SCHEMAS
+]
 
 
 def _coerce_value(value_str, field_spec):
@@ -74,15 +90,10 @@ def _coerce_value(value_str, field_spec):
 
 
 def _detect_schema_type(path):
-    """Detect schema type from file path."""
-    if "/rfe-reviews/" in path or "rfe-reviews/" in path:
-        return "rfe-review"
-    if "/rfe-tasks/" in path or "rfe-tasks/" in path:
-        return "rfe-task"
-    if "/initiative-reviews/" in path or "initiative-reviews/" in path:
-        return "initiative-review"
-    if "/initiatives/" in path or "initiatives/" in path:
-        return "initiative-task"
+    """Detect schema type from file path (the ``dirs.reviews`` / ``dirs.tasks`` component)."""
+    for needle, schema_type in _SCHEMA_BY_DIR:
+        if needle in path:
+            return schema_type
     return None
 
 

--- a/scripts/frontmatter.py
+++ b/scripts/frontmatter.py
@@ -48,17 +48,27 @@ from artifact_utils import (
 
 _TYPES = type_registry.load()
 
+
 # Path component -> schema name, from every type's ``dirs``: registry order, each type's
 # reviews dir tested before its tasks dir (rfe-reviews/, rfe-tasks/, initiative-reviews/,
 # initiatives/ — the order the hand-written table had). A substring test, so both
 # ``artifacts/rfe-tasks/X.md`` and a bare ``rfe-tasks/X.md`` resolve. Only types that
 # contribute schemas take part (a partial drop-in descriptor has no SCHEMAS entries).
-_SCHEMA_BY_DIR = [
-    (f"{desc.dirs('bare')[dir_key]}/", f"{desc.name}-{kind}")
-    for desc in _TYPES
-    for dir_key, kind in (("reviews", "review"), ("tasks", "task"))
-    if f"{desc.name}-{kind}" in SCHEMAS
-]
+def _schema_by_dir(types, schemas):
+    """Build the path-component -> schema-name table (see the comment above)."""
+    table = []
+    for desc in types:
+        for dir_key, kind in (("reviews", "review"), ("tasks", "task")):
+            # A drop-in may contribute schemas without declaring every directory; skip
+            # the missing key instead of failing the import of every frontmatter write.
+            bare = desc.get(f"dirs.{dir_key}", None)
+            if bare is None or f"{desc.name}-{kind}" not in schemas:
+                continue
+            table.append((f"{desc.dirs('bare')[dir_key]}/", f"{desc.name}-{kind}"))
+    return table
+
+
+_SCHEMA_BY_DIR = _schema_by_dir(_TYPES, SCHEMAS)
 
 
 def _coerce_value(value_str, field_spec):

--- a/scripts/generate_run_report.py
+++ b/scripts/generate_run_report.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 from datetime import datetime, timezone
+from functools import partial
 
 import yaml
 
@@ -16,8 +17,7 @@ from artifact_utils import (
     find_review_file,
     read_frontmatter,
     resolve_ids,
-    scan_initiative_task_files,
-    scan_task_files,
+    scan_tasks,
 )
 
 DEFAULT_ARTIFACTS_DIR = os.path.join(os.getcwd(), "artifacts")
@@ -27,11 +27,6 @@ DEFAULT_ARTIFACTS_DIR = os.path.join(os.getcwd(), "artifacts")
 # §10 item 2). Deliberately the DESCRIPTOR values, not the effective binding: deployment
 # overrides land with resolve() in a later PR.
 _TYPES = type_registry.load()
-
-# The forked task scanners, selected by type name. The artifact_utils pair collapses into
-# one generic keyed on dirs.tasks + identity.id_field in a later PR; until then a type
-# without an entry here has no scanner.
-_SCAN_TASKS = {"rfe": scan_task_files, "initiative": scan_initiative_task_files}
 
 
 def _type_config(desc):
@@ -45,7 +40,9 @@ def _type_config(desc):
         # rfe's empty prefix is grandfathered (the report file is named by the run id alone).
         "output_prefix": desc.get("snapshot.report_prefix", ""),
         "extra_entry_fields": list(desc.get("reporting.run_report.extra_entry_fields", [])),
-        "scan_tasks": _SCAN_TASKS.get(desc.name),
+        # artifact_utils.scan_tasks bound to this descriptor (dirs.tasks, validated as
+        # <type>-task, sorted by identity.id_field); called as scan_tasks(artifacts_dir).
+        "scan_tasks": partial(scan_tasks, desc=desc),
         "id_field": desc.id_field,
         # parent_key values that mean "split from"; see split_children_map. The local
         # prefix plus the tracker key prefixes — NOT conventions.parent_key_patterns, which

--- a/scripts/validate_types.py
+++ b/scripts/validate_types.py
@@ -271,6 +271,10 @@ def path_messages(desc, repo_root):
         seen_names = set()
         for dim in dimensions:
             dname = dim.get("name") if isinstance(dim, dict) else None
+            # Only strings take part: a malformed name (list, mapping, number) is the
+            # JSON-Schema check's finding, and an unhashable one must not raise here.
+            if not isinstance(dname, str):
+                continue
             if dname in engine_phases:
                 messages.append(f"pipeline.dimensions name {dname!r} collides with an engine phase")
             elif dname in seen_names:

--- a/scripts/validate_types.py
+++ b/scripts/validate_types.py
@@ -267,6 +267,15 @@ def path_messages(desc, repo_root):
 
     dimensions = _opt(desc, "pipeline.dimensions") or []
     if isinstance(dimensions, list):
+        engine_phases = {"fetch", "create", "assess", "review", "revise", "split"}
+        seen_names = set()
+        for dim in dimensions:
+            dname = dim.get("name") if isinstance(dim, dict) else None
+            if dname in engine_phases:
+                messages.append(f"pipeline.dimensions name {dname!r} collides with an engine phase")
+            elif dname in seen_names:
+                messages.append(f"pipeline.dimensions name {dname!r} is declared twice")
+            seen_names.add(dname)
         for i, dim in enumerate(dimensions):
             if isinstance(dim, dict):
                 missing(f"pipeline.dimensions[{i}].prompt", dim.get("prompt"), want_file=True)

--- a/tests/data/prefix_predicate_baseline.json
+++ b/tests/data/prefix_predicate_baseline.json
@@ -1,5 +1,4 @@
 {
-  "scripts/artifact_utils.py": 29,
   "scripts/batch_summary.py": 1,
   "scripts/bootstrap_snapshot.py": 2,
   "scripts/cleanup_partial_split.py": 1,

--- a/tests/data/schemas-golden.json
+++ b/tests/data/schemas-golden.json
@@ -1,0 +1,394 @@
+{
+  "rfe-task": {
+    "rfe_id": {
+      "type": "string",
+      "required": true,
+      "pattern": "^(RFE-\\d+|RHAIRFE-\\d+)$"
+    },
+    "local_id": {
+      "type": "string",
+      "required": false,
+      "pattern": "^RFE-\\d+$",
+      "default": null
+    },
+    "type": {
+      "type": "string",
+      "required": false
+    },
+    "tracker_ref": {
+      "type": "string",
+      "required": false
+    },
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "priority": {
+      "type": "string",
+      "required": true,
+      "enum": [
+        "Blocker",
+        "Critical",
+        "Major",
+        "Normal",
+        "Minor",
+        "Undefined"
+      ]
+    },
+    "size": {
+      "type": "string",
+      "required": false,
+      "enum": [
+        "S",
+        "M",
+        "L",
+        "XL"
+      ],
+      "default": null
+    },
+    "status": {
+      "type": "string",
+      "required": true,
+      "enum": [
+        "Draft",
+        "Ready",
+        "Submitted",
+        "Archived"
+      ]
+    },
+    "parent_key": {
+      "type": "string",
+      "required": false,
+      "pattern": "^(RFE-\\d+|RHAIRFE-\\d+)$",
+      "default": null
+    },
+    "original_labels": {
+      "type": "list",
+      "required": false,
+      "default": null
+    }
+  },
+  "rfe-review": {
+    "rfe_id": {
+      "type": "string",
+      "required": true,
+      "pattern": "^(RFE-\\d+|RHAIRFE-\\d+)$"
+    },
+    "local_id": {
+      "type": "string",
+      "required": false,
+      "pattern": "^RFE-\\d+$",
+      "default": null
+    },
+    "type": {
+      "type": "string",
+      "required": false
+    },
+    "tracker_ref": {
+      "type": "string",
+      "required": false
+    },
+    "score": {
+      "type": "int",
+      "required": true
+    },
+    "pass": {
+      "type": "bool",
+      "required": true
+    },
+    "recommendation": {
+      "type": "string",
+      "required": true,
+      "enum": [
+        "submit",
+        "revise",
+        "split",
+        "reject",
+        "autorevise_reject"
+      ]
+    },
+    "feasibility": {
+      "type": "string",
+      "required": true,
+      "enum": [
+        "feasible",
+        "infeasible",
+        "indeterminate"
+      ]
+    },
+    "auto_revised": {
+      "type": "bool",
+      "required": true,
+      "default": false
+    },
+    "needs_attention": {
+      "type": "bool",
+      "required": true,
+      "default": false
+    },
+    "scores": {
+      "type": "dict",
+      "required": true,
+      "fields": {
+        "what": {
+          "type": "int",
+          "required": true
+        },
+        "why": {
+          "type": "int",
+          "required": true
+        },
+        "open_to_how": {
+          "type": "int",
+          "required": true
+        },
+        "not_a_task": {
+          "type": "int",
+          "required": true
+        },
+        "right_sized": {
+          "type": "int",
+          "required": true
+        }
+      }
+    },
+    "error": {
+      "type": "string",
+      "required": false,
+      "default": null
+    },
+    "before_score": {
+      "type": "int",
+      "required": false,
+      "default": null
+    },
+    "needs_attention_reason": {
+      "type": "string",
+      "required": false,
+      "default": null
+    },
+    "before_scores": {
+      "type": "dict",
+      "required": false,
+      "default": null,
+      "fields": {
+        "what": {
+          "type": "int",
+          "required": true
+        },
+        "why": {
+          "type": "int",
+          "required": true
+        },
+        "open_to_how": {
+          "type": "int",
+          "required": true
+        },
+        "not_a_task": {
+          "type": "int",
+          "required": true
+        },
+        "right_sized": {
+          "type": "int",
+          "required": true
+        }
+      }
+    }
+  },
+  "initiative-task": {
+    "initiative_id": {
+      "type": "string",
+      "required": true,
+      "pattern": "^(INIT-\\d+|RHOAIENG-\\d+)$"
+    },
+    "local_id": {
+      "type": "string",
+      "required": false,
+      "pattern": "^INIT-\\d+$",
+      "default": null
+    },
+    "type": {
+      "type": "string",
+      "required": false
+    },
+    "tracker_ref": {
+      "type": "string",
+      "required": false
+    },
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "priority": {
+      "type": "string",
+      "required": true,
+      "enum": [
+        "Blocker",
+        "Critical",
+        "Major",
+        "Normal",
+        "Minor",
+        "Undefined"
+      ]
+    },
+    "status": {
+      "type": "string",
+      "required": true,
+      "enum": [
+        "Draft",
+        "Ready",
+        "Submitted",
+        "Archived"
+      ]
+    },
+    "parent_key": {
+      "type": "string",
+      "required": false,
+      "pattern": "^(RHAISTRAT-\\d+|RHOAIENG-\\d+|INIT-\\d+)$",
+      "default": null
+    },
+    "original_labels": {
+      "type": "list",
+      "required": false,
+      "default": null
+    }
+  },
+  "initiative-review": {
+    "initiative_id": {
+      "type": "string",
+      "required": true,
+      "pattern": "^(INIT-\\d+|RHOAIENG-\\d+)$"
+    },
+    "local_id": {
+      "type": "string",
+      "required": false,
+      "pattern": "^INIT-\\d+$",
+      "default": null
+    },
+    "type": {
+      "type": "string",
+      "required": false
+    },
+    "tracker_ref": {
+      "type": "string",
+      "required": false
+    },
+    "score": {
+      "type": "int",
+      "required": true
+    },
+    "pass": {
+      "type": "bool",
+      "required": true
+    },
+    "recommendation": {
+      "type": "string",
+      "required": true,
+      "enum": [
+        "submit",
+        "revise",
+        "split",
+        "reject",
+        "autorevise_reject"
+      ]
+    },
+    "feasibility": {
+      "type": "string",
+      "required": true,
+      "enum": [
+        "feasible",
+        "infeasible",
+        "indeterminate"
+      ]
+    },
+    "auto_revised": {
+      "type": "bool",
+      "required": true,
+      "default": false
+    },
+    "needs_attention": {
+      "type": "bool",
+      "required": true,
+      "default": false
+    },
+    "scores": {
+      "type": "dict",
+      "required": true,
+      "fields": {
+        "what": {
+          "type": "int",
+          "required": true
+        },
+        "why": {
+          "type": "int",
+          "required": true
+        },
+        "scope": {
+          "type": "int",
+          "required": true
+        },
+        "open_to_how": {
+          "type": "int",
+          "required": true
+        },
+        "right_sized": {
+          "type": "int",
+          "required": true
+        }
+      }
+    },
+    "error": {
+      "type": "string",
+      "required": false,
+      "default": null
+    },
+    "before_score": {
+      "type": "int",
+      "required": false,
+      "default": null
+    },
+    "needs_attention_reason": {
+      "type": "string",
+      "required": false,
+      "default": null
+    },
+    "before_scores": {
+      "type": "dict",
+      "required": false,
+      "default": null,
+      "fields": {
+        "what": {
+          "type": "int",
+          "required": true
+        },
+        "why": {
+          "type": "int",
+          "required": true
+        },
+        "scope": {
+          "type": "int",
+          "required": true
+        },
+        "open_to_how": {
+          "type": "int",
+          "required": true
+        },
+        "right_sized": {
+          "type": "int",
+          "required": true
+        }
+      }
+    },
+    "alignment": {
+      "type": "string",
+      "required": false,
+      "enum": [
+        "strong",
+        "partial",
+        "weak",
+        "not_assessed"
+      ],
+      "default": "not_assessed"
+    }
+  }
+}

--- a/tests/test_artifact_utils.py
+++ b/tests/test_artifact_utils.py
@@ -9,16 +9,29 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from artifact_utils import (
+    _TYPES,
     SCHEMAS,
     ValidationError,
     _body_without_frontmatter,
     _looks_like_frontmatter_block,
     _migrate_fields,
     apply_defaults,
+    find_artifact_file_including_archived,
+    find_removed_context_yaml,
+    find_review_file,
+    parse_child,
+    parse_child_artifact,
+    parse_child_initiative,
     read_frontmatter,
     read_frontmatter_validated,
     rename_initiative_to_jira_key,
     rename_to_jira_key,
+    rename_to_tracker_key,
+    scan_initiative_task_files,
+    scan_review_files,
+    scan_reviews,
+    scan_task_files,
+    scan_tasks,
     update_frontmatter,
     validate,
     write_frontmatter,
@@ -883,3 +896,468 @@ class TestRenameInitiativeToJiraKey:
         assert os.path.exists("artifacts/initiatives/RHOAIENG-1234-removed-context.yaml")
         assert os.path.exists("artifacts/initiatives/RHOAIENG-1234-removed-context.md")
         assert os.path.exists("artifacts/initiatives/RHOAIENG-1234.md")
+
+
+# ── Registry-derived generics (PR-2b) ────────────────────────────────────────
+#
+# scan_tasks / rename_to_tracker_key / parse_child take a type_registry.Descriptor; the
+# historical per-type names are thin wrappers over them. Each test below pins one
+# behaviour the pre-registry twins had, so the collapse stays behaviour-neutral per type.
+
+RFE = _TYPES.get("rfe")
+INITIATIVE = _TYPES.get("initiative")
+
+
+def _tree(files):
+    """Write ``{relative path: text}`` under the cwd and return a sorted snapshot helper."""
+    for rel, text in files.items():
+        _write(rel, text)
+
+
+def _snapshot(root):
+    """{relative path: bytes} of every file under ``root``."""
+    out = {}
+    for dirpath, _, filenames in os.walk(root):
+        for name in filenames:
+            path = os.path.join(dirpath, name)
+            with open(path, "rb") as f:
+                out[os.path.relpath(path, root)] = f.read()
+    return out
+
+
+def _task_fm(id_field, ident, **extra):
+    fields = {id_field: ident, "title": f"Title {ident}", "priority": "Major", "status": "Ready"}
+    fields.update(extra)
+    return "---\n" + "".join(f"{k}: {v}\n" for k, v in fields.items()) + "---\nBody.\n"
+
+
+class TestScanGenerics:
+    def _populate(self):
+        _tree(
+            {
+                # rfe: two tasks written out of id order, a companion, an archived one,
+                # an unparseable one and a non-.md stray
+                "artifacts/rfe-tasks/RHAIRFE-1595.md": _task_fm("rfe_id", "RHAIRFE-1595"),
+                "artifacts/rfe-tasks/RFE-002.md": _task_fm("rfe_id", "RFE-002"),
+                "artifacts/rfe-tasks/RFE-001.md": _task_fm("rfe_id", "RFE-001", status="Archived"),
+                "artifacts/rfe-tasks/RFE-001-comments.md": "No comments found.\n",
+                "artifacts/rfe-tasks/RFE-001-removed-context.yaml": "blocks: []\n",
+                "artifacts/rfe-tasks/RFE-003.md": "---\nbogus: 1\n---\n",
+                "artifacts/rfe-tasks/notes.txt": "x\n",
+                # initiative: mirror shape
+                "artifacts/initiatives/RHOAIENG-9.md": _task_fm("initiative_id", "RHOAIENG-9"),
+                "artifacts/initiatives/INIT-002.md": _task_fm("initiative_id", "INIT-002"),
+                "artifacts/initiatives/INIT-001.md": _task_fm(
+                    "initiative_id", "INIT-001", status="Archived"
+                ),
+                "artifacts/initiatives/INIT-001-comments.md": "No comments found.\n",
+                "artifacts/initiatives/INIT-003.md": "---\nbogus: 1\n---\n",
+            }
+        )
+
+    def test_wrappers_equal_the_generic(self, tmp_dir, capsys):
+        self._populate()
+        assert scan_task_files("artifacts") == scan_tasks("artifacts", RFE)
+        assert scan_initiative_task_files("artifacts") == scan_tasks("artifacts", INITIATIVE)
+        err = capsys.readouterr().err
+        assert err.count("Warning: skipping RFE-003.md:") == 2  # wrapper + generic
+        assert err.count("Warning: skipping INIT-003.md:") == 2
+
+    def test_sorted_by_the_type_id_field_and_archived_kept(self, tmp_dir, capsys):
+        """Scanning never filters on status; archived items sort with the rest."""
+        self._populate()
+        rfe_ids = [d["rfe_id"] for _, d in scan_task_files("artifacts")]
+        assert rfe_ids == ["RFE-001", "RFE-002", "RHAIRFE-1595"]
+        init_ids = [d["initiative_id"] for _, d in scan_initiative_task_files("artifacts")]
+        assert init_ids == ["INIT-001", "INIT-002", "RHOAIENG-9"]
+        capsys.readouterr()
+
+    def test_companions_and_non_markdown_are_skipped(self, tmp_dir, capsys):
+        self._populate()
+        paths = [os.path.basename(p) for p, _ in scan_task_files("artifacts")]
+        assert "RFE-001-comments.md" not in paths
+        assert "notes.txt" not in paths
+        assert "RFE-003.md" not in paths  # invalid frontmatter -> warning, skipped
+        assert "Warning: skipping RFE-003.md:" in capsys.readouterr().err
+
+    def test_missing_dir_is_empty(self, tmp_dir):
+        assert scan_tasks("artifacts", RFE) == []
+        assert scan_tasks("artifacts", INITIATIVE) == []
+        assert scan_reviews("artifacts", RFE) == []
+
+    def test_scan_reviews_generic_and_rfe_wrapper(self, tmp_dir):
+        write_frontmatter(
+            "artifacts/rfe-reviews/RFE-001-review.md",
+            {**VALID_REVIEW_FM, "rfe_id": "RFE-001"},
+            "rfe-review",
+        )
+        _write("artifacts/rfe-reviews/RFE-001-feasibility.md", "not a review\n")
+        write_frontmatter(
+            "artifacts/initiative-reviews/INIT-001-review.md",
+            VALID_INITIATIVE_REVIEW_FM.copy(),
+            "initiative-review",
+        )
+        rfe_found = scan_review_files("artifacts")
+        assert rfe_found == scan_reviews("artifacts", RFE)
+        assert [os.path.basename(p) for p, _ in rfe_found] == ["RFE-001-review.md"]
+        init_found = scan_reviews("artifacts", INITIATIVE)
+        assert [d["initiative_id"] for _, d in init_found] == ["INIT-001"]
+
+
+class TestRenameGenerics:
+    def _populate(self, root):
+        _tree(
+            {
+                f"{root}/rfe-tasks/RFE-001.md": _task_fm("rfe_id", "RFE-001"),
+                f"{root}/rfe-tasks/RFE-001-comments.md": "comments\n",
+                f"{root}/rfe-tasks/RFE-001-removed-context.yaml": "blocks: []\n",
+                f"{root}/rfe-tasks/RFE-001-removed-context.md": "legacy\n",
+                f"{root}/rfe-tasks/RFE-0010.md": _task_fm("rfe_id", "RFE-0010"),
+                f"{root}/rfe-reviews/RFE-001-feasibility.md": "feasibility\n",
+                f"{root}/initiatives/INIT-001.md": _task_fm("initiative_id", "INIT-001"),
+                f"{root}/initiatives/INIT-001-comments.md": "comments\n",
+                f"{root}/initiatives/INIT-001-removed-context.yaml": "blocks: []\n",
+                f"{root}/initiative-reviews/INIT-001-feasibility.md": "feasibility\n",
+            }
+        )
+        write_frontmatter(
+            f"{root}/rfe-reviews/RFE-001-review.md",
+            {**VALID_REVIEW_FM, "rfe_id": "RFE-001"},
+            "rfe-review",
+        )
+        write_frontmatter(
+            f"{root}/initiative-reviews/INIT-001-review.md",
+            VALID_INITIATIVE_REVIEW_FM.copy(),
+            "initiative-review",
+        )
+
+    def test_wrappers_produce_the_same_tree_as_the_generic(self, tmp_dir):
+        self._populate("a")
+        self._populate("b")
+        rename_to_jira_key("a", "RFE-001", "RHAIRFE-99999")
+        rename_initiative_to_jira_key("a", "INIT-001", "RHOAIENG-99999")
+        rename_to_tracker_key("b", "RFE-001", "RHAIRFE-99999", RFE)
+        rename_to_tracker_key("b", "INIT-001", "RHOAIENG-99999", INITIATIVE)
+        assert _snapshot("a") == _snapshot("b")
+        renamed = set(_snapshot("a"))
+        assert {
+            "rfe-tasks/RHAIRFE-99999.md",
+            "rfe-tasks/RHAIRFE-99999-comments.md",
+            "rfe-tasks/RHAIRFE-99999-removed-context.yaml",
+            "rfe-tasks/RHAIRFE-99999-removed-context.md",
+            "rfe-tasks/RFE-0010.md",  # RFE-001 is not a prefix of RFE-0010-
+            "rfe-reviews/RHAIRFE-99999-review.md",
+            "rfe-reviews/RFE-001-feasibility.md",  # not a -review.md
+            "initiatives/RHOAIENG-99999.md",
+            "initiatives/RHOAIENG-99999-comments.md",
+            "initiatives/RHOAIENG-99999-removed-context.yaml",
+            "initiative-reviews/RHOAIENG-99999-review.md",
+            "initiative-reviews/INIT-001-feasibility.md",
+        } == renamed
+        task, _ = read_frontmatter("a/rfe-tasks/RHAIRFE-99999.md")
+        assert (task["rfe_id"], task["status"], task["local_id"]) == (
+            "RHAIRFE-99999",
+            "Submitted",
+            "RFE-001",
+        )
+        review, _ = read_frontmatter("a/rfe-reviews/RHAIRFE-99999-review.md")
+        assert (review["rfe_id"], review["local_id"]) == ("RHAIRFE-99999", "RFE-001")
+        init, _ = read_frontmatter("a/initiatives/RHOAIENG-99999.md")
+        assert (init["initiative_id"], init["status"], init["local_id"]) == (
+            "RHOAIENG-99999",
+            "Submitted",
+            "INIT-001",
+        )
+
+    def test_guard_messages_keep_the_per_type_function_name(self, tmp_dir):
+        """The ValueError text always named the per-type function; it still does."""
+        os.makedirs("artifacts/rfe-tasks")
+        os.makedirs("artifacts/initiatives")
+        cases = [
+            (RFE, "../RFE-001", "RHAIRFE-1", "rename_to_jira_key: invalid local id '../RFE-001'"),
+            (RFE, "RFE-001", "RHAIRFE-1/x", "rename_to_jira_key: invalid Jira key 'RHAIRFE-1/x'"),
+            (RFE, "INIT-001", "RHAIRFE-1", "rename_to_jira_key: invalid local id 'INIT-001'"),
+            (RFE, "RFE-001", "RHOAIENG-1", "rename_to_jira_key: invalid Jira key 'RHOAIENG-1'"),
+            (
+                INITIATIVE,
+                "INIT-001x",
+                "RHOAIENG-1",
+                "rename_initiative_to_jira_key: invalid local id 'INIT-001x'",
+            ),
+            (
+                INITIATIVE,
+                "INIT-001",
+                "RHOAIENG-1/../2",
+                "rename_initiative_to_jira_key: invalid Jira key 'RHOAIENG-1/../2'",
+            ),
+        ]
+        wrappers = {"rfe": rename_to_jira_key, "initiative": rename_initiative_to_jira_key}
+        for desc, item_id, key, message in cases:
+            with pytest.raises(ValueError) as generic:
+                rename_to_tracker_key("artifacts", item_id, key, desc)
+            with pytest.raises(ValueError) as wrapper:
+                wrappers[desc.name]("artifacts", item_id, key)
+            assert str(generic.value) == message
+            assert str(wrapper.value) == message
+        # The guards run before any filesystem access: nothing was created or renamed.
+        assert os.listdir("artifacts/rfe-tasks") == []
+        assert os.listdir("artifacts/initiatives") == []
+
+    def test_rfe_tolerates_a_legacy_slug_review_name(self, tmp_dir):
+        """rename_to_jira_key scanned for ``RFE-001-*-review.md``; the generic still does
+        for rfe."""
+        os.makedirs("artifacts/rfe-tasks")
+        write_frontmatter(
+            "artifacts/rfe-reviews/RFE-001-some-slug-review.md",
+            {**VALID_REVIEW_FM, "rfe_id": "RFE-001"},
+            "rfe-review",
+        )
+        rename_to_tracker_key("artifacts", "RFE-001", "RHAIRFE-7", RFE)
+        assert sorted(os.listdir("artifacts/rfe-reviews")) == ["RHAIRFE-7-review.md"]
+        review, _ = read_frontmatter("artifacts/rfe-reviews/RHAIRFE-7-review.md")
+        assert (review["rfe_id"], review["local_id"]) == ("RHAIRFE-7", "RFE-001")
+
+    def test_initiative_renames_only_the_exact_review_name(self, tmp_dir):
+        """rename_initiative_to_jira_key looked up ``INIT-001-review.md`` exactly; a slug
+        name is left alone (and nothing is renamed when it is the only candidate)."""
+        os.makedirs("artifacts/initiatives")
+        write_frontmatter(
+            "artifacts/initiative-reviews/INIT-001-some-slug-review.md",
+            VALID_INITIATIVE_REVIEW_FM.copy(),
+            "initiative-review",
+        )
+        rename_to_tracker_key("artifacts", "INIT-001", "RHOAIENG-7", INITIATIVE)
+        assert os.listdir("artifacts/initiative-reviews") == ["INIT-001-some-slug-review.md"]
+
+    def test_missing_dirs_are_tolerated(self, tmp_dir):
+        os.makedirs("artifacts")
+        rename_to_tracker_key("artifacts", "RFE-001", "RHAIRFE-1", RFE)
+        rename_to_tracker_key("artifacts", "INIT-001", "RHOAIENG-1", INITIATIVE)
+        assert os.listdir("artifacts") == []
+
+
+class TestParseChildGenerics:
+    LEGACY = "# RFE-001: Legacy title\n\n**Priority**: Critical\n\n## Problem\n\nText.\n"
+
+    def test_wrappers_equal_the_generic(self, tmp_dir):
+        _write("artifacts/rfe-tasks/RFE-001.md", _task_fm("rfe_id", "RFE-001"))
+        _write("artifacts/initiatives/INIT-001.md", _task_fm("initiative_id", "INIT-001"))
+        assert parse_child_artifact("artifacts/rfe-tasks/RFE-001.md") == parse_child(
+            "artifacts/rfe-tasks/RFE-001.md", RFE
+        )
+        assert parse_child_initiative("artifacts/initiatives/INIT-001.md") == parse_child(
+            "artifacts/initiatives/INIT-001.md", INITIATIVE
+        )
+        title, priority, full, cleaned = parse_child_artifact("artifacts/rfe-tasks/RFE-001.md")
+        assert (title, priority) == ("Title RFE-001", "Major")
+        assert full.startswith("---\n") and "Body." in cleaned
+
+    def test_rfe_markdown_fallbacks(self, tmp_dir):
+        """No frontmatter: the ``# RFE-NNN: Title`` heading and the ``**Priority**:`` line
+        are parsed; an empty file yields the defaults."""
+        _write("legacy.md", self.LEGACY)
+        _write("empty.md", "")
+        assert parse_child("legacy.md", RFE)[:2] == ("Legacy title", "Critical")
+        assert parse_child_artifact("legacy.md")[:2] == ("Legacy title", "Critical")
+        assert parse_child("empty.md", RFE)[:2] == ("Untitled", "Normal")
+
+    def test_rfe_falls_back_when_frontmatter_fields_are_empty(self, tmp_dir):
+        _write("t.md", "---\ntitle: ''\npriority: null\n---\n" + self.LEGACY)
+        # The heading is no longer at offset 0 (re.match), so only the priority line hits.
+        assert parse_child("t.md", RFE)[:2] == ("Untitled", "Critical")
+
+    def test_initiative_has_no_markdown_fallback(self, tmp_dir):
+        """parse_child_initiative never parsed markdown: a legacy-shaped file (even with
+        the initiative prefix) yields the defaults, and present-but-null fields are
+        returned as they are."""
+        _write("legacy.md", self.LEGACY.replace("RFE-001", "INIT-001"))
+        assert parse_child("legacy.md", INITIATIVE)[:2] == ("Untitled", "Normal")
+        assert parse_child_initiative("legacy.md")[:2] == ("Untitled", "Normal")
+        _write("t.md", "---\ntitle: ''\npriority: null\n---\n" + self.LEGACY)
+        assert parse_child("t.md", INITIATIVE)[:2] == ("", None)
+
+
+class TestLookupsUseDetect:
+    """find_review_file / find_removed_context_yaml route by TypeRegistry.detect(); every
+    id that is not INIT-/RHOAIENG- (incl. a peer pipeline's RHAISTRAT- key and a malformed
+    local id) keeps going to the rfe dirs, exactly like the prefix sniff they replace."""
+
+    IDS = [
+        ("RFE-001", "rfe"),
+        ("RHAIRFE-1595", "rfe"),
+        ("RHAISTRAT-42", "rfe"),
+        ("RFE-x", "rfe"),
+        ("", "rfe"),
+        ("INIT-001", "initiative"),
+        ("RHOAIENG-1234", "initiative"),
+        ("INIT-x", "initiative"),
+    ]
+
+    def test_find_review_file(self, tmp_dir):
+        dirs = {"rfe": "rfe-reviews", "initiative": "initiative-reviews"}
+        for ident, _ in self.IDS:
+            for d in dirs.values():
+                _write(f"artifacts/{d}/{ident}-review.md", "---\nx: 1\n---\n")
+        for ident, owner in self.IDS:
+            expected = os.path.join("artifacts", dirs[owner], f"{ident}-review.md")
+            assert find_review_file("artifacts", ident) == expected, ident
+        assert find_review_file("artifacts", "RFE-404") is None
+        assert find_review_file("nowhere", "RFE-001") is None
+
+    def test_find_removed_context_yaml(self, tmp_dir):
+        dirs = {"rfe": "rfe-tasks", "initiative": "initiatives"}
+        for ident, _ in self.IDS:
+            for d in dirs.values():
+                _write(f"artifacts/{d}/{ident}-removed-context.yaml", "blocks: []\n")
+        for ident, owner in self.IDS:
+            path = find_removed_context_yaml("artifacts", ident)
+            if ident in ("RHAISTRAT-42", ""):
+                # rfe dir, but the inner prefix test (RHAIRFE-/RFE-) rejects the id
+                assert path is None, ident
+            else:
+                assert path == os.path.join(
+                    "artifacts", dirs[owner], f"{ident}-removed-context.yaml"
+                ), ident
+
+    def test_archived_lookup_wrapper_is_rfe_only(self, tmp_dir):
+        _write("artifacts/rfe-tasks/RFE-001.md", _task_fm("rfe_id", "RFE-001", status="Archived"))
+        _write("artifacts/rfe-tasks/RHAIRFE-1.md", _task_fm("rfe_id", "RHAIRFE-1"))
+        _write("artifacts/initiatives/INIT-001.md", _task_fm("initiative_id", "INIT-001"))
+        assert find_artifact_file_including_archived("artifacts", "RFE-001") == os.path.join(
+            "artifacts", "rfe-tasks", "RFE-001.md"
+        )
+        assert find_artifact_file_including_archived("artifacts", "RHAIRFE-1") == os.path.join(
+            "artifacts", "rfe-tasks", "RHAIRFE-1.md"
+        )
+        assert find_artifact_file_including_archived("artifacts", "INIT-001") is None
+
+
+class TestSchemasFollowTheRegistry:
+    def test_every_type_has_a_task_and_a_review_schema(self):
+        for desc in _TYPES:
+            assert f"{desc.name}-task" in SCHEMAS
+            assert f"{desc.name}-review" in SCHEMAS
+            assert desc.id_field in SCHEMAS[f"{desc.name}-task"]
+            assert desc.id_field in SCHEMAS[f"{desc.name}-review"]
+            assert list(SCHEMAS[f"{desc.name}-review"]["scores"]["fields"]) == desc.score_fields
+
+    def test_extra_fields_are_copies_not_registry_aliases(self):
+        size = SCHEMAS["rfe-task"]["size"]
+        assert size is not RFE.get("schema.task.extra_fields.size")
+        assert size == RFE.get("schema.task.extra_fields.size")
+        alignment = SCHEMAS["initiative-review"]["alignment"]
+        assert alignment is not INITIATIVE.get("schema.review.extra_fields.alignment")
+        assert alignment == INITIATIVE.get("schema.review.extra_fields.alignment")
+
+
+class TestPartialDropInTypes:
+    """A drop-in descriptor (RFE_CREATOR_EXTRA_TYPES) that declares no schema facts must not
+    break the import of artifact_utils (and with it every script): it gets no SCHEMAS entry
+    and no frontmatter.py path-table row, and detection keeps working for it."""
+
+    PARTIAL = (
+        "schema_version: 1\n"
+        "type: docs\n"
+        "identity:\n"
+        "  tracker: jira\n"
+        '  jira: {project: DOCS, issue_type: Task, key_prefixes: ["DOCS-"]}\n'
+        '  local_prefix: "DOC-"\n'
+        "  id_field: doc_id\n"
+        "dirs: {tasks: artifacts/doc-tasks, originals: artifacts/doc-originals, "
+        "reviews: artifacts/doc-reviews}\n"
+    )
+
+    def test_partial_type_is_skipped_not_fatal(self, tmp_path):
+        import subprocess
+
+        root = tmp_path / "types"
+        (root / "docs").mkdir(parents=True)
+        (root / "docs" / "type.yaml").write_text(self.PARTIAL)
+        code = (
+            "import sys, json; sys.path.insert(0, 'scripts'); "
+            "import artifact_utils as a, frontmatter as f; "
+            "print(json.dumps([a._TYPES.names(), list(a.SCHEMAS), f._SCHEMA_BY_DIR, "
+            "a._type_for('DOC-1').name, a._type_for('DOCS-7').name, "
+            "f._detect_schema_type('artifacts/doc-tasks/DOC-1.md')]))"
+        )
+        env = {
+            **os.environ,
+            "RFE_CREATOR_EXTRA_TYPES": str(root),
+            "RFE_CREATOR_EXTRA_TYPES_ALLOWLIST": str(root),
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=os.path.join(os.path.dirname(__file__), ".."),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        import json
+
+        names, schemas, table, owner_local, owner_key, detected = json.loads(result.stdout)
+        assert names == ["rfe", "docs", "initiative"]
+        assert schemas == ["rfe-task", "rfe-review", "initiative-task", "initiative-review"]
+        assert all(not s.startswith("docs-") for _, s in table)
+        assert (owner_local, owner_key, detected) == ("docs", "docs", None)
+
+    def test_shipped_types_declare_every_schema_fact(self):
+        from artifact_utils import _SCHEMA_FACTS, _is_shipped
+
+        for desc in _TYPES:
+            assert _is_shipped(desc), desc
+            for dotted in _SCHEMA_FACTS:
+                assert desc.get(dotted, None) is not None, (desc.name, dotted)
+
+    def test_tolerance_is_for_drop_ins_only(self, tmp_path):
+        """The same partial descriptor is skipped when it comes from a drop-in root and built
+        when it sits under the registry's own root — where a missing fact then raises the
+        loader's KeyError naming the field."""
+        import type_registry
+        import yaml
+        from artifact_utils import _SHIPPED_ROOT, _declares_schemas, _task_schema
+
+        partial = yaml.safe_load(self.PARTIAL)
+        drop_in = type_registry.Descriptor("docs", partial, path=tmp_path / "docs" / "type.yaml")
+        assert _declares_schemas(drop_in) is False
+        shipped = type_registry.Descriptor(
+            "docs", partial, path=_SHIPPED_ROOT / "docs" / "type.yaml"
+        )
+        assert _declares_schemas(shipped) is True
+        with pytest.raises(KeyError) as excinfo:
+            _task_schema(shipped)
+        assert "docs: no such descriptor field 'identity.local_id_pattern'" in str(excinfo.value)
+
+    def test_a_shipped_type_missing_a_fact_fails_the_import(self, tmp_path):
+        """Fail fast, not late: with conventions.parent_key_patterns removed from a copy of
+        types/rfe/type.yaml beside a copy of scripts/, importing artifact_utils raises the
+        loader's KeyError naming the field instead of every later read failing with
+        "Unknown schema type: rfe-task"."""
+        import shutil
+        import subprocess
+
+        import yaml
+
+        repo = os.path.join(os.path.dirname(__file__), "..")
+        shutil.copytree(
+            os.path.join(repo, "scripts"),
+            tmp_path / "scripts",
+            ignore=shutil.ignore_patterns("__pycache__"),
+        )
+        shutil.copytree(os.path.join(repo, "types"), tmp_path / "types")
+        descriptor = tmp_path / "types" / "rfe" / "type.yaml"
+        data = yaml.safe_load(descriptor.read_text())
+        del data["conventions"]["parent_key_patterns"]
+        descriptor.write_text(yaml.safe_dump(data, sort_keys=False))
+        env = {k: v for k, v in os.environ.items() if not k.startswith("RFE_CREATOR_")}
+        env["PYTHONPATH"] = str(tmp_path / "scripts")
+        result = subprocess.run(
+            [sys.executable, "-c", "import artifact_utils"],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        expected = "KeyError: \"rfe: no such descriptor field 'conventions.parent_key_patterns'\""
+        assert expected in result.stderr, result.stderr

--- a/tests/test_artifact_utils.py
+++ b/tests/test_artifact_utils.py
@@ -1361,3 +1361,54 @@ class TestPartialDropInTypes:
         assert result.returncode != 0
         expected = "KeyError: \"rfe: no such descriptor field 'conventions.parent_key_patterns'\""
         assert expected in result.stderr, result.stderr
+
+
+class _FakeDesc:
+    """Minimal Descriptor stand-in: dotted get(), dirs(), and the id properties."""
+
+    def __init__(self, name, data, dirs=None):
+        self.name = name
+        self._data = data
+        self._dirs = dirs or {
+            "tasks": "artifacts/x-tasks",
+            "reviews": "artifacts/x-reviews",
+            "originals": "artifacts/x-originals",
+        }
+
+    def get(self, dotted, default=None):
+        return self._data.get(dotted, default)
+
+    def dirs(self, form="artifacts"):
+        if form == "bare":
+            return {k: v.split("/", 1)[1] for k, v in self._dirs.items()}
+        return dict(self._dirs)
+
+    @property
+    def local_id_pattern(self):
+        return self._data["identity.local_id_pattern"]
+
+    @property
+    def key_prefixes(self):
+        return list(self._data.get("identity.jira.key_prefixes", []))
+
+    @property
+    def id_field(self):
+        return self._data.get("identity.id_field", "x_id")
+
+
+def test_id_pattern_strips_only_the_outer_anchors():
+    """A pattern whose last literal is an escaped dollar must survive anchor removal."""
+    import re
+
+    desc = _FakeDesc(
+        "x", {"identity.local_id_pattern": r"^ABC-\d+\$$", "identity.jira.key_prefixes": ["XYZ-"]}
+    )
+    import artifact_utils
+
+    pattern = artifact_utils._id_pattern(desc)
+    assert pattern == r"^(ABC-\d+\$|XYZ-\d+)$"
+    assert (
+        re.match(pattern, "ABC-12$")
+        and re.match(pattern, "XYZ-3")
+        and not re.match(pattern, "ABC-12")
+    )

--- a/tests/test_check_conflicts.py
+++ b/tests/test_check_conflicts.py
@@ -74,12 +74,9 @@ def _dropin_root(tmp_path):
 
 class TestTypeConfigDerivesFromTheRegistry:
     def test_values_are_the_pre_registry_literals(self):
-        # Behaviour-neutral migration: same keys, same order, same values.
-        plain = {
-            t: {k: v for k, v in c.items() if k != "scan_fn"}
-            for t, c in check_conflicts._TYPE_CONFIG.items()
-        }
-        assert plain == {
+        # Behaviour-neutral migration: same keys, same order, same values. The scanner is no
+        # longer a per-type entry: main() calls artifact_utils.scan_tasks with the descriptor.
+        assert check_conflicts._TYPE_CONFIG == {
             "rfe": {
                 "originals_dir": "rfe-originals",
                 "id_field": "rfe_id",
@@ -93,14 +90,34 @@ class TestTypeConfigDerivesFromTheRegistry:
         }
         assert list(check_conflicts._TYPE_CONFIG) == ["rfe", "initiative"]
         for config in check_conflicts._TYPE_CONFIG.values():
-            assert list(config) == ["originals_dir", "scan_fn", "id_field", "jira_prefix"]
+            assert list(config) == ["originals_dir", "id_field", "jira_prefix"]
+        assert not hasattr(check_conflicts, "_SCAN_FNS")
 
-    def test_scan_fns_are_the_forked_pair(self):
-        assert check_conflicts._TYPE_CONFIG["rfe"]["scan_fn"] is artifact_utils.scan_task_files
-        assert (
-            check_conflicts._TYPE_CONFIG["initiative"]["scan_fn"]
-            is artifact_utils.scan_initiative_task_files
+    @pytest.mark.parametrize("type_name", ["rfe", "initiative"])
+    def test_main_scans_the_selected_type_through_the_generic(
+        self, monkeypatch, tmp_path, type_name
+    ):
+        # The scan is artifact_utils.scan_tasks over the --type descriptor — the same call the
+        # per-type wrappers make, so the rows are what scan_task_files /
+        # scan_initiative_task_files returned before the pair collapsed.
+        for var, value in JIRA_ENV.items():
+            monkeypatch.setenv(var, value)
+        calls = []
+
+        def recording_scan(artifacts_dir, desc):
+            calls.append((artifacts_dir, desc.name))
+            return artifact_utils.scan_tasks(artifacts_dir, desc)
+
+        monkeypatch.setattr(check_conflicts, "scan_tasks", recording_scan)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["check_conflicts.py", "--type", type_name, "--artifacts-dir", str(tmp_path)],
         )
+        with pytest.raises(SystemExit) as excinfo:
+            check_conflicts.main()
+        assert excinfo.value.code == 0
+        assert calls == [(str(tmp_path), type_name)]
 
     @pytest.mark.parametrize("type_name", REG.names())
     def test_projection_from_the_descriptor(self, type_name):
@@ -115,7 +132,9 @@ class TestTypeConfigDerivesFromTheRegistry:
         assert result.returncode == 0
         assert "--type {rfe,initiative}" in result.stdout
 
-    def test_a_drop_in_type_is_offered_but_refused_without_a_scanner(self, tmp_path):
+    def test_a_drop_in_type_is_offered_and_scanned(self, tmp_path):
+        # A third registered type used to be refused (exit 2, "no task scanner is registered")
+        # because the scanners were a forked pair; the generic scans its dirs.tasks like any other.
         root = _dropin_root(tmp_path)
         env = {
             **os.environ,
@@ -133,8 +152,9 @@ class TestTypeConfigDerivesFromTheRegistry:
             text=True,
             env=env,
         )
-        assert result.returncode == 2
-        assert "no task scanner is registered for type 'docs'" in result.stderr
+        assert result.returncode == 0
+        assert result.stdout == "CONFLICT_COUNT=0\nOK: no Jira-sourced items to check\n"
+        assert result.stderr == ""
 
 
 class TestMain:

--- a/tests/test_check_review_progress.py
+++ b/tests/test_check_review_progress.py
@@ -943,3 +943,244 @@ class TestSkillBarrierUsage:
         init = _skill_text("initiative-split")
         assert len(_phases_used(init)) >= len(_phases_used(rfe))
         assert init.count("NEXT_POLL") >= rfe.count("NEXT_POLL")
+
+
+# ── Registry derivation ──
+
+
+# The 14 poll phases in the order the literal table had. argparse renders the --phase /
+# --also-phase choices from this order, so it is CLI surface, not an implementation detail.
+_TODAYS_PHASES = [
+    "fetch",
+    "create",
+    "assess",
+    "feasibility",
+    "review",
+    "revise",
+    "split",
+    "initiative-split",
+    "initiative-fetch",
+    "initiative-assess",
+    "initiative-feasibility",
+    "initiative-review",
+    "initiative-revise",
+    "initiative-alignment",
+]
+
+
+def _hermetic_registry():
+    import type_registry
+
+    return type_registry.load(extra_roots=[], env={})
+
+
+class TestDerivedFromRegistry:
+    """PHASE_CHECKS is a projection of types/<t>/type.yaml (design §10 item 2).
+
+    Nothing in check_review_progress names a directory, an id field or a poll prefix: the
+    rows are dirs x poll_prefix x dimension names, plus the rfe-only create barrier (#148).
+    """
+
+    def test_keys_are_todays_choices_in_todays_order(self):
+        assert list(PHASE_CHECKS) == _TODAYS_PHASES
+
+    def test_rows_are_the_descriptor_projection(self):
+        for desc in _hermetic_registry():
+            pp = desc.get("pipeline.poll_prefix")
+            dirs = desc.dirs()
+            assert PHASE_CHECKS[f"{pp}fetch"]("X-1") == f"{dirs['tasks']}/X-1.md"
+            assert PHASE_CHECKS[f"{pp}assess"]("X-1") == "tmp/rfe-assess/single/X-1.result.md"
+            for base in ("review", "revise"):
+                assert PHASE_CHECKS[f"{pp}{base}"]("X-1") == f"{dirs['reviews']}/X-1-review.md"
+            assert PHASE_CHECKS[f"{pp}split"]("X-1") == f"{dirs['reviews']}/X-1-split-status.yaml"
+            for dim in desc.get("pipeline.dimensions"):
+                name = dim["name"]
+                assert PHASE_CHECKS[f"{pp}{name}"]("X-1") == f"{dirs['reviews']}/X-1-{name}.md"
+
+    def test_create_row_is_rfe_only(self):
+        """#148's Phase-1 barrier is grandfathered to rfe until PR-5's generic body."""
+        for desc in _hermetic_registry():
+            pp = desc.get("pipeline.poll_prefix")
+            assert (f"{pp}create" in PHASE_CHECKS) is (desc.name == "rfe")
+        assert PHASE_CHECKS["create"]("X-1") == PHASE_CHECKS["fetch"]("X-1")
+
+    def test_create_mode_uses_the_owning_types_id_field(self, tmp_path, monkeypatch):
+        """The create check compares identity.id_field, not a literal — rfe_id for rfe."""
+        monkeypatch.chdir(tmp_path)
+        rfe = _hermetic_registry().get("rfe")
+        assert rfe.id_field == "rfe_id"
+        task = tmp_path / PHASE_CHECKS["create"]("RFE-001")
+        task.parent.mkdir(parents=True)
+        task.write_text("---\ninitiative_id: RFE-001\n---\nBody\n")
+        assert check_id("create", "RFE-001") == "pending"
+        task.write_text(f"---\n{rfe.id_field}: RFE-001\n---\nBody\n")
+        assert check_id("create", "RFE-001") == "completed"
+
+    def test_modes_follow_the_phase_base_for_every_type(self, tmp_path, monkeypatch):
+        """review -> score_present and revise -> revised_or_split for each type's poll prefix."""
+        monkeypatch.chdir(tmp_path)
+        for desc in _hermetic_registry():
+            pp = desc.get("pipeline.poll_prefix")
+            review = tmp_path / PHASE_CHECKS[f"{pp}review"]("X-1")
+            review.parent.mkdir(parents=True, exist_ok=True)
+            review.write_text("---\ntitle: t\n---\nBody\n")
+            assert check_id(f"{pp}review", "X-1") == "pending"
+            assert check_id(f"{pp}revise", "X-1") == "pending"
+            review.write_text("---\nscore: 7\nrecommendation: split\n---\nBody\n")
+            assert check_id(f"{pp}review", "X-1") == "completed"
+            assert check_id(f"{pp}revise", "X-1") == "completed"
+            review.write_text("---\nscore: 0\nerror: assess_failed\n---\nBody\n")
+            assert check_id(f"{pp}review", "X-1") == "error"
+
+    def test_other_phases_use_the_exists_mode_for_every_type(self, tmp_path, monkeypatch):
+        """fetch, assess, split and every dimension complete on any file at the path — the
+        content is not inspected (a review-shaped error stub still counts) — and pend on a
+        missing one; for every type's poll prefix. Each file is removed again: the assess
+        staging dir is shared by every type (design §10), so rfe's result file would otherwise
+        complete initiative-assess."""
+        monkeypatch.chdir(tmp_path)
+        for desc in _hermetic_registry():
+            pp = desc.get("pipeline.poll_prefix")
+            dimensions = [dim["name"] for dim in desc.get("pipeline.dimensions")]
+            for base in ["fetch", "assess", "split", *dimensions]:
+                phase = f"{pp}{base}"
+                assert check_id(phase, "X-1") == "pending", phase
+                path = tmp_path / PHASE_CHECKS[phase]("X-1")
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("---\nscore: null\nerror: assess_failed\n---\nBody\n")
+                assert check_id(phase, "X-1") == "completed", phase
+                path.unlink()
+                assert check_id(phase, "X-1") == "pending", phase
+
+    def test_a_partial_drop_in_type_contributes_no_rows(self, tmp_path):
+        """A drop-in descriptor with no pipeline block (identity + dirs only — the shape
+        tests/test_check_conflicts.py registers) is skipped, as artifact_utils skips it for
+        SCHEMAS: the poll script still imports, keeps today's rows and answers the same."""
+        import subprocess
+
+        root = tmp_path / "extra"
+        (root / "docs").mkdir(parents=True)
+        (root / "docs" / "type.yaml").write_text(
+            "schema_version: 1\n"
+            "type: docs\n"
+            "identity:\n"
+            "  tracker: jira\n"
+            '  jira: {project: DOCS, issue_type: Task, key_prefixes: ["DOCS-"]}\n'
+            '  local_prefix: "DOC-"\n'
+            "  id_field: doc_id\n"
+            "dirs: {tasks: artifacts/doc-tasks, originals: artifacts/doc-originals}\n"
+        )
+        scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if not k.startswith("RFE_CREATOR_") and k not in ("CI", "GITHUB_ACTIONS")
+        }
+        env["RFE_CREATOR_EXTRA_TYPES"] = str(root)
+        work = tmp_path / "work"
+        work.mkdir()
+        script = os.path.join(scripts_dir, "check_review_progress.py")
+        result = subprocess.run(
+            [sys.executable, script, "--phase", "review", "RFE-001"],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=work,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout == "COMPLETED=0/1, PENDING=1, NEXT_POLL=60\n"
+        env["PYTHONPATH"] = scripts_dir
+        probe = "import check_review_progress as c; print(list(c.PHASE_CHECKS))"
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=work,
+            check=True,
+        )
+        assert result.stdout.strip() == str(_TODAYS_PHASES)
+
+    def test_a_drop_in_type_gets_rows_and_modes(self, tmp_path):
+        """A type under RFE_CREATOR_EXTRA_TYPES appears after the shipped rows with its own
+        prefix, dirs, dimensions and id field, and its review/revise phases get the real check
+        modes instead of falling through to exists (the literal tuples did that)."""
+        import json
+        import subprocess
+
+        import yaml
+
+        scripts_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "scripts"))
+        with open(os.path.join(scripts_dir, "..", "types", "rfe", "type.yaml")) as f:
+            data = yaml.safe_load(f)
+        data["type"] = "widget"
+        data["identity"]["id_field"] = "widget_id"
+        data["dirs"] = {
+            "tasks": "artifacts/widgets",
+            "originals": "artifacts/widget-originals",
+            "reviews": "artifacts/widget-reviews",
+        }
+        data["pipeline"]["poll_prefix"] = "widget-"
+        data["pipeline"]["state_prefix"] = "widget-"
+        data["pipeline"]["dimensions"] = [
+            {"name": "feasibility", "prompt": "x.md", "blocking": True},
+            {"name": "security", "prompt": "y.md", "blocking": False},
+        ]
+        root = tmp_path / "extra"
+        (root / "widget").mkdir(parents=True)
+        with open(root / "widget" / "type.yaml", "w") as f:
+            yaml.safe_dump(data, f, sort_keys=False)
+
+        work = tmp_path / "work"
+        reviews = work / "artifacts" / "widget-reviews"
+        reviews.mkdir(parents=True)
+        (reviews / "W-1-review.md").write_text("---\ntitle: t\n---\nBody\n")
+        (reviews / "W-2-review.md").write_text("---\nscore: 7\nrecommendation: split\n---\n")
+        probe = (
+            "import json, check_review_progress as c; "
+            "print(json.dumps({'keys': list(c.PHASE_CHECKS), "
+            "'paths': {k: f('W-1') for k, f in c.PHASE_CHECKS.items() if k.startswith('widget-')}, "
+            "'review_1': c.check_id('widget-review', 'W-1'), "
+            "'revise_1': c.check_id('widget-revise', 'W-1'), "
+            "'review_2': c.check_id('widget-review', 'W-2'), "
+            "'revise_2': c.check_id('widget-revise', 'W-2')}))"
+        )
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if not k.startswith("RFE_CREATOR_") and k not in ("CI", "GITHUB_ACTIONS")
+        }
+        env["RFE_CREATOR_EXTRA_TYPES"] = str(root)
+        env["PYTHONPATH"] = scripts_dir
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=work,
+            check=True,
+        )
+        got = json.loads(result.stdout)
+        widget_keys = [
+            "widget-fetch",
+            "widget-assess",
+            "widget-feasibility",
+            "widget-security",
+            "widget-review",
+            "widget-revise",
+            "widget-split",
+        ]
+        assert got["keys"] == _TODAYS_PHASES + widget_keys  # shipped rows first, no widget-create
+        assert got["paths"] == {
+            "widget-fetch": "artifacts/widgets/W-1.md",
+            "widget-assess": "tmp/rfe-assess/single/W-1.result.md",
+            "widget-feasibility": "artifacts/widget-reviews/W-1-feasibility.md",
+            "widget-security": "artifacts/widget-reviews/W-1-security.md",
+            "widget-review": "artifacts/widget-reviews/W-1-review.md",
+            "widget-revise": "artifacts/widget-reviews/W-1-review.md",
+            "widget-split": "artifacts/widget-reviews/W-1-split-status.yaml",
+        }
+        assert got["review_1"] == "pending"  # score_present, not exists
+        assert got["revise_1"] == "pending"  # revised_or_split, not exists
+        assert got["review_2"] == "completed"
+        assert got["revise_2"] == "completed"

--- a/tests/test_check_review_progress.py
+++ b/tests/test_check_review_progress.py
@@ -7,6 +7,8 @@ import re
 import sys
 from unittest.mock import patch
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from check_review_progress import (  # noqa: E402
@@ -1184,3 +1186,64 @@ class TestDerivedFromRegistry:
         assert got["revise_1"] == "pending"  # revised_or_split, not exists
         assert got["review_2"] == "completed"
         assert got["revise_2"] == "completed"
+
+
+class _FakeDesc:
+    """Minimal Descriptor stand-in: dotted get(), dirs(), and the id properties."""
+
+    def __init__(self, name, data, dirs=None):
+        self.name = name
+        self._data = data
+        self._dirs = dirs or {
+            "tasks": "artifacts/x-tasks",
+            "reviews": "artifacts/x-reviews",
+            "originals": "artifacts/x-originals",
+        }
+
+    def get(self, dotted, default=None):
+        return self._data.get(dotted, default)
+
+    def dirs(self, form="artifacts"):
+        if form == "bare":
+            return {k: v.split("/", 1)[1] for k, v in self._dirs.items()}
+        return dict(self._dirs)
+
+    @property
+    def local_id_pattern(self):
+        return self._data["identity.local_id_pattern"]
+
+    @property
+    def key_prefixes(self):
+        return list(self._data.get("identity.jira.key_prefixes", []))
+
+    @property
+    def id_field(self):
+        return self._data.get("identity.id_field", "x_id")
+
+
+@pytest.mark.parametrize("bad", ["review", "assess", "split", "fetch"])
+def test_dimension_named_like_an_engine_phase_is_rejected(bad):
+    desc = _FakeDesc("x", {"pipeline.dimensions": [{"name": bad, "prompt": "p.md"}]})
+    import check_review_progress as crp
+
+    with pytest.raises(ValueError, match="collides with an engine phase"):
+        crp._phase_rows(desc)
+
+
+def test_duplicate_dimension_names_are_rejected():
+    desc = _FakeDesc(
+        "x", {"pipeline.dimensions": [{"name": "feasibility"}, {"name": "feasibility"}]}
+    )
+    import check_review_progress as crp
+
+    with pytest.raises(ValueError, match="collides"):
+        crp._phase_rows(desc)
+
+
+def test_distinct_dimension_names_build_rows():
+    desc = _FakeDesc("x", {"pipeline.dimensions": [{"name": "feasibility"}, {"name": "alignment"}]})
+    import check_review_progress as crp
+
+    rows = crp._phase_rows(desc)
+    assert rows["feasibility"]("ID-1") == "artifacts/x-reviews/ID-1-feasibility.md"
+    assert set(rows) >= {"fetch", "assess", "feasibility", "alignment", "review", "revise", "split"}

--- a/tests/test_collect_children.py
+++ b/tests/test_collect_children.py
@@ -12,14 +12,18 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 from artifact_utils import write_frontmatter  # noqa: E402
 
 SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "collect_children.py")
+# A complete descriptor that ships outside types/ (never enumerated by default): the third
+# type the generic scan must serve without a code change.
+FIXTURE_TYPES = os.path.join(os.path.dirname(__file__), "fixtures", "types")
 
 
-def _run(args, cwd):
+def _run(args, cwd, env=None):
     result = subprocess.run(
         [sys.executable, SCRIPT] + args,
         capture_output=True,
         text=True,
         cwd=cwd,
+        env=env,
     )
     return result.stdout.strip(), result.stderr, result.returncode
 
@@ -198,3 +202,29 @@ class TestIdsFile:
         )
         assert rc == 0
         assert "RHOAIENG-50:RHOAIENG-51" in out
+
+
+class TestThirdType:
+    """The scan is artifact_utils.scan_tasks over the --type descriptor: a registered third
+    type is read from its own dirs.tasks with its own id field, where the forked pair sent
+    every non-initiative type to rfe-tasks/rfe_id."""
+
+    def test_drop_in_type_children_come_from_its_own_tree(self, tmp_path):
+        os.makedirs(tmp_path / "artifacts" / "epic-tasks")
+        os.makedirs(tmp_path / "artifacts" / "rfe-tasks")
+        (tmp_path / "artifacts" / "epic-tasks" / "RHAISTRAT-7-E001.md").write_text(
+            "---\nepic_id: RHAISTRAT-7-E001\ntitle: Child epic\npriority: P1\nstatus: Ready\n"
+            "component: platform\nteam: core\ntype: Implementation\nparent_key: RHAISTRAT-7\n"
+            "---\n\nbody\n"
+        )
+        env = {
+            **os.environ,
+            "RFE_CREATOR_EXTRA_TYPES": FIXTURE_TYPES,
+            "RFE_CREATOR_EXTRA_TYPES_ALLOWLIST": FIXTURE_TYPES,
+        }
+        out, err, rc = _run(
+            ["--type", "epic", "RHAISTRAT-7", "RHAISTRAT-8"], cwd=str(tmp_path), env=env
+        )
+        assert rc == 0, err
+        assert err == ""
+        assert out.splitlines() == ["RHAISTRAT-7:RHAISTRAT-7-E001", "RHAISTRAT-8:"]

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Tests for scripts/frontmatter.py — the registry-derived schema path table and the CLI."""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import frontmatter  # noqa: E402
+from artifact_utils import SCHEMAS, get_schema_yaml  # noqa: E402
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+
+
+class TestDetectSchemaType:
+    def test_table_is_the_hand_written_order(self):
+        """Registry order, reviews before tasks per type — the order the literal `if`
+        chain tested in (rfe-reviews, rfe-tasks, initiative-reviews, initiatives)."""
+        assert frontmatter._SCHEMA_BY_DIR == [
+            ("rfe-reviews/", "rfe-review"),
+            ("rfe-tasks/", "rfe-task"),
+            ("initiative-reviews/", "initiative-review"),
+            ("initiatives/", "initiative-task"),
+        ]
+
+    @pytest.mark.parametrize(
+        "path, expected",
+        [
+            ("artifacts/rfe-tasks/RFE-001.md", "rfe-task"),
+            ("rfe-tasks/RFE-001.md", "rfe-task"),
+            ("/abs/work/artifacts/rfe-tasks/RHAIRFE-1595.md", "rfe-task"),
+            ("artifacts/rfe-reviews/RFE-001-review.md", "rfe-review"),
+            ("rfe-reviews/RHAIRFE-1595-review.md", "rfe-review"),
+            ("artifacts/initiatives/INIT-001.md", "initiative-task"),
+            ("initiatives/RHOAIENG-1.md", "initiative-task"),
+            ("artifacts/initiative-reviews/INIT-001-review.md", "initiative-review"),
+            ("/abs/artifacts/initiative-reviews/RHOAIENG-1-review.md", "initiative-review"),
+            # Not a task/review dir: originals, staging, anything else.
+            ("artifacts/rfe-originals/RHAIRFE-1595.md", None),
+            ("artifacts/initiative-originals/RHOAIENG-1.md", None),
+            ("tmp/rfe-assess/single/RFE-001.md", None),
+            ("RFE-001.md", None),
+        ],
+    )
+    def test_detects_from_dirs(self, path, expected):
+        assert frontmatter._detect_schema_type(path) == expected
+
+    def test_every_schema_is_reachable_from_its_dir(self):
+        detected = {schema for _, schema in frontmatter._SCHEMA_BY_DIR}
+        assert detected == set(SCHEMAS)
+
+
+class TestSchemaCommand:
+    @pytest.mark.parametrize("name", list(SCHEMAS))
+    def test_prints_get_schema_yaml(self, name):
+        result = subprocess.run(
+            [sys.executable, "scripts/frontmatter.py", "schema", name],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout == get_schema_yaml(name) + "\n"
+        assert result.stderr == ""
+
+    def test_choices_are_the_schema_keys_in_order(self):
+        result = subprocess.run(
+            [sys.executable, "scripts/frontmatter.py", "schema", "bogus"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+        positions = [result.stderr.find(f"'{name}'") for name in SCHEMAS]
+        assert all(p >= 0 for p in positions), result.stderr
+        assert positions == sorted(positions), result.stderr

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -77,3 +77,53 @@ class TestSchemaCommand:
         positions = [result.stderr.find(f"'{name}'") for name in SCHEMAS]
         assert all(p >= 0 for p in positions), result.stderr
         assert positions == sorted(positions), result.stderr
+
+
+class _FakeDesc:
+    """Minimal Descriptor stand-in: dotted get(), dirs(), and the id properties."""
+
+    def __init__(self, name, data, dirs=None):
+        self.name = name
+        self._data = data
+        self._dirs = dirs or {
+            "tasks": "artifacts/x-tasks",
+            "reviews": "artifacts/x-reviews",
+            "originals": "artifacts/x-originals",
+        }
+
+    def get(self, dotted, default=None):
+        return self._data.get(dotted, default)
+
+    def dirs(self, form="artifacts"):
+        if form == "bare":
+            return {k: v.split("/", 1)[1] for k, v in self._dirs.items()}
+        return dict(self._dirs)
+
+    @property
+    def local_id_pattern(self):
+        return self._data["identity.local_id_pattern"]
+
+    @property
+    def key_prefixes(self):
+        return list(self._data.get("identity.jira.key_prefixes", []))
+
+    @property
+    def id_field(self):
+        return self._data.get("identity.id_field", "x_id")
+
+
+def test_schema_by_dir_skips_types_without_a_directory():
+    """A drop-in that contributes schemas but declares no reviews dir must not break the table."""
+    partial = _FakeDesc("docs", {"dirs.tasks": "artifacts/docs"}, dirs={"tasks": "artifacts/docs"})
+    full = _FakeDesc(
+        "rfe",
+        {"dirs.tasks": "artifacts/rfe-tasks", "dirs.reviews": "artifacts/rfe-reviews"},
+        dirs={"tasks": "artifacts/rfe-tasks", "reviews": "artifacts/rfe-reviews"},
+    )
+    schemas = {"docs-task": {}, "docs-review": {}, "rfe-task": {}, "rfe-review": {}}
+    table = frontmatter._schema_by_dir([full, partial], schemas)
+    assert table == [
+        ("rfe-reviews/", "rfe-review"),
+        ("rfe-tasks/", "rfe-task"),
+        ("docs/", "docs-task"),
+    ]

--- a/tests/test_generate_run_report.py
+++ b/tests/test_generate_run_report.py
@@ -10,6 +10,7 @@ import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
+import artifact_utils
 import generate_run_report
 import type_registry
 from generate_run_report import TYPE_CONFIG, _parse_run_id, build_report
@@ -948,7 +949,25 @@ class TestTypeConfigIsRegistryDerived:
             assert cfg["child_parent_prefixes"] == (desc.local_prefix, *desc.key_prefixes)
             assert cfg["tracker_prefix"] == desc.write_prefix
             assert cfg["local_prefix"] == desc.local_prefix
-            assert callable(cfg["scan_tasks"])
+            # The generic scan bound to the descriptor, not a per-type function.
+            assert cfg["scan_tasks"].func is artifact_utils.scan_tasks
+            assert cfg["scan_tasks"].keywords["desc"].name == name
+
+    def test_scan_tasks_is_the_generic_over_the_type_tree(self, tmp_path):
+        """config["scan_tasks"](artifacts_dir) returns exactly what the per-type wrappers
+        return — the contract split_children_map, build_report and batch_summary rely on."""
+        art = str(tmp_path / "artifacts")
+        _write(f"{art}/rfe-tasks/RHAIRFE-1.md", TASK_TEMPLATE.format(rfe_id="RHAIRFE-1", extra=""))
+        _write(
+            f"{art}/initiatives/INIT-1.md",
+            "---\ninitiative_id: INIT-1\ntitle: T\npriority: Major\nstatus: Draft\n---\n\nbody\n",
+        )
+        rfe_rows = TYPE_CONFIG["rfe"]["scan_tasks"](art)
+        init_rows = TYPE_CONFIG["initiative"]["scan_tasks"](art)
+        assert rfe_rows == artifact_utils.scan_task_files(art)
+        assert init_rows == artifact_utils.scan_initiative_task_files(art)
+        assert [d["rfe_id"] for _, d in rfe_rows] == ["RHAIRFE-1"]
+        assert [d["initiative_id"] for _, d in init_rows] == ["INIT-1"]
 
     def test_a_drop_in_descriptor_projects_without_a_code_change(self):
         registry = type_registry.load(extra_roots=[FIXTURE_TYPES], env={})
@@ -964,8 +983,10 @@ class TestTypeConfigIsRegistryDerived:
         assert cfg["child_parent_prefixes"] == ("RHAISTRAT-", "RHAI-")
         assert cfg["tracker_prefix"] == "RHAI-"
         assert cfg["local_prefix"] == "RHAISTRAT-"
-        # The forked artifact_utils scanner pair has no third member until it is unified.
-        assert cfg["scan_tasks"] is None
+        # The scan is the generic bound to this descriptor: a third type gets a scanner over
+        # its own dirs.tasks without a code change.
+        assert cfg["scan_tasks"].func is artifact_utils.scan_tasks
+        assert cfg["scan_tasks"].keywords == {"desc": registry.get("epic")}
 
     def test_projection_does_not_alias_descriptor_data(self):
         registry = type_registry.load(extra_roots=[], env={})

--- a/tests/test_schemas_golden.py
+++ b/tests/test_schemas_golden.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""artifact_utils.SCHEMAS is an artifact contract: pin the registry-derived dicts byte for byte.
+
+tests/data/schemas-golden.json was frozen from the hand-written SCHEMAS literal (branch
+feat/registry-adopt-scripts at 2bacd7b, identical to main d0e41d9) with
+``json.dumps(SCHEMAS, sort_keys=False, indent=2, default=str)`` immediately before the schemas
+started deriving from ``types/<name>/type.yaml``. Every frontmatter file in every results repo
+was validated against exactly these specs — field names, ORDER (``frontmatter.py read`` and
+``apply_defaults`` emit fields in schema order), types, enums, patterns, defaults and required
+flags — so unlike the descriptor pins in tests/test_type_registry_pins.py this golden is
+permanent: it must only change together with a deliberate, reviewed change of the artifact
+contract, never as a side effect of a refactor or a descriptor edit.
+
+To regenerate after such a change (and only then):
+    python3 -c "import json, sys; sys.path.insert(0, 'scripts'); from artifact_utils import \\
+        SCHEMAS; print(json.dumps(SCHEMAS, sort_keys=False, indent=2, default=str))" \\
+        > tests/data/schemas-golden.json
+"""
+
+import difflib
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from artifact_utils import SCHEMAS  # noqa: E402
+
+GOLDEN = Path(__file__).resolve().parent / "data" / "schemas-golden.json"
+
+
+def _serialise(schemas):
+    return json.dumps(schemas, sort_keys=False, indent=2, default=str) + "\n"
+
+
+def test_schemas_serialise_to_the_golden_bytes():
+    expected = GOLDEN.read_text(encoding="utf-8")
+    actual = _serialise(SCHEMAS)
+    if actual != expected:
+        diff = "".join(
+            difflib.unified_diff(
+                expected.splitlines(keepends=True),
+                actual.splitlines(keepends=True),
+                fromfile=str(GOLDEN.relative_to(GOLDEN.parents[2])),
+                tofile="artifact_utils.SCHEMAS",
+            )
+        )
+        raise AssertionError("SCHEMAS drifted from tests/data/schemas-golden.json:\n" + diff)
+
+
+def test_golden_holds_no_stringified_values():
+    """``default=str`` never fired: a JSON round-trip of the live dicts is the live dicts.
+
+    Patterns are plain strings (never compiled regexes), enums are lists, defaults are
+    None / False / strings — nothing in the contract needs a repr.
+    """
+    assert json.loads(_serialise(SCHEMAS)) == SCHEMAS
+    assert json.loads(GOLDEN.read_text(encoding="utf-8")) == SCHEMAS
+
+
+def test_schema_key_order_is_types_times_task_review():
+    """The dict order is observable: it is the `frontmatter.py schema` choices order."""
+    assert list(SCHEMAS) == ["rfe-task", "rfe-review", "initiative-task", "initiative-review"]
+    assert list(json.loads(GOLDEN.read_text(encoding="utf-8"))) == list(SCHEMAS)
+
+
+def test_schemas_do_not_alias_each_other():
+    """Per-schema specs are independent objects (mutating one never bleeds into another)."""
+    rfe_status = SCHEMAS["rfe-task"]["status"]["enum"]
+    init_status = SCHEMAS["initiative-task"]["status"]["enum"]
+    assert rfe_status == init_status and rfe_status is not init_status
+    for name in ("rfe-review", "initiative-review"):
+        assert SCHEMAS[name]["scores"]["fields"] is not SCHEMAS[name]["before_scores"]["fields"]

--- a/tests/test_type_registry_pins.py
+++ b/tests/test_type_registry_pins.py
@@ -51,7 +51,6 @@ import check_autofix_complete  # noqa: E402
 import check_conflicts  # noqa: E402
 import check_review_progress  # noqa: E402
 import compare_review_outputs  # noqa: E402
-import frontmatter  # noqa: E402
 import generate_review_pdf  # noqa: E402
 import generate_run_report  # noqa: E402
 import jira_utils  # noqa: E402
@@ -120,12 +119,13 @@ DEFERRED = [
     (
         178,
         "artifact_utils.find_artifact_file (rfe-only, DEAD)",
-        "no callers; deletion candidate — nothing a pin could protect",
+        "DELETED in PR-2b (no callers: grep over scripts/, tests/, .claude/, eval/ hit only the "
+        "definition); nothing a pin could protect",
     ),
     (
         181,
         "artifact_utils.find_removed_context_file (legacy .md, DEAD)",
-        "no callers; deletion candidate",
+        "DELETED in PR-2b (no callers)",
     ),
     (
         188,
@@ -167,8 +167,9 @@ MIGRATED = [
     (
         (66,),
         "check_conflicts._TYPE_CONFIG",
-        "PR-2a: dirs(bare).originals / id_field / key_prefixes[0]; still pinned: the scanner fork "
-        "selected by type name and the startswith(jira_prefix) predicate (prefix-union later)",
+        "PR-2a: dirs(bare).originals / id_field / key_prefixes[0]; PR-2b: the task scan is "
+        "artifact_utils.scan_tasks(desc) (no scan_fn key); still pinned: the "
+        "startswith(jira_prefix) predicate (prefix-union later)",
     ),
     (
         (67,),
@@ -178,8 +179,8 @@ MIGRATED = [
     (
         (69,),
         "validate_batch_input.ALLOWED_PRIORITIES",
-        "PR-2a: rfe schema.task.priority.enum for both types; row 170 (artifact_utils) stays and "
-        "tests/test_validate_batch_input.py holds the two equal until the schemas derive",
+        "PR-2a: rfe schema.task.priority.enum for both types; the task schemas derive the same "
+        "enum per type since PR-2b (row 170)",
     ),
     (
         (70,),
@@ -189,8 +190,9 @@ MIGRATED = [
     (
         tuple(range(71, 82)),
         "generate_run_report.TYPE_CONFIG / SCORE_FIELDS",
-        "PR-2a: descriptor projection per key; still pinned: the scanner fork selected by type "
-        "name",
+        "PR-2a: descriptor projection per key; PR-2b: scan_tasks = "
+        "functools.partial(artifact_utils.scan_tasks, desc=desc); still pinned: the "
+        "child_parent_prefixes derivation guard (RHAISTRAT- excluded)",
     ),
     (
         (87, 102, 106, 147, 148, 153, 154, 155, 156),
@@ -204,6 +206,16 @@ MIGRATED = [
         "PR-2a: descriptor projection per key; PASS_THRESHOLD stays a pinned constant (Q15)",
     ),
     ((105,), "batch_summary._TYPE_CONFIG", "PR-2a: dirs view of generate_run_report.TYPE_CONFIG"),
+    (
+        tuple(range(125, 141)),
+        "check_review_progress.PHASE_CHECKS / check_id modes",
+        "PR-2b: dirs x poll_prefix x {fetch, assess (shared staging), review, revise, split} + "
+        "pipeline.dimensions[].name (+ the rfe-only create row), identity.id_field in the create "
+        "mode, modes by phase base; still literal and pinned: the create grandfather "
+        "_CREATE_BARRIER_TYPES (row 125 residue here), the initiative row order "
+        "(_LEGACY_ROW_ORDER — CLI choices text; tests/test_check_review_progress.py), the "
+        "_detect_fast allowlist (141) and the choices source form (142)",
+    ),
     (
         (143, 144, 145, 146),
         "verify_phase._TYPE_CONFIG / phase tables / error-stub score tail",
@@ -230,13 +242,40 @@ MIGRATED = [
     ),
     (
         (156,),
-        "collect_children id_field",
-        "PR-2a: identity.id_field; still pinned: the scanner fork",
+        "collect_children id_field / scan",
+        "PR-2a: identity.id_field; PR-2b: artifact_utils.scan_tasks(desc) — the type-name "
+        "if/else is gone",
     ),
     (
         (157,),
         "check_right_sized._TYPE_CONFIG / resplit threshold",
         "PR-2a: dirs.reviews + pipeline.resplit; below == 2 stays a descriptor guard (Q3)",
+    ),
+    (
+        (162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 174, 175),
+        "artifact_utils.SCHEMAS",
+        "PR-2b: _task_schema / _review_schema over _TYPES — keys names() x {task, review}; "
+        "identity.id_field (the field's name), local_id_pattern | key_prefixes + digits (its "
+        "grammar), identity.local_id_pattern (the four local_id sites), "
+        "conventions.parent_key_patterns, schema.task.priority.enum, schema.task.extra_fields "
+        "(rfe size), schema.review.score_fields (scores / before_scores), "
+        "schema.review.extra_fields (initiative alignment); byte-pinned by "
+        "tests/test_schemas_golden.py; still pinned: the shared status / recommendation / "
+        "feasibility vocabularies (172, 173), the alignment cross-field residue (175) and the "
+        "frontmatter choices source form (162)",
+    ),
+    (
+        (179, 180, 182, 183, 184, 185, 186, 187),
+        "artifact_utils helpers / frontmatter._detect_schema_type",
+        "PR-2b: find_artifact_file_including_archived reads the rfe descriptor; "
+        "find_removed_context_yaml / find_review_file route via registry.detect(id) or rfe; "
+        "scan_tasks / scan_reviews / rename_to_tracker_key / parse_child take a Descriptor (the "
+        "per-type names are wrappers); rebuild_index reads the rfe id_field; "
+        "frontmatter._SCHEMA_BY_DIR from dirs; still literal and pinned: _is_companion_file "
+        "(177), the rfes.md index contract (186 residue) and — name-keyed until PR-3 — the "
+        "rename ValueError label, rfe's slug-tolerant review lookup and parse_child's rfe "
+        "markdown fallbacks (184, 185 residue; tests/test_artifact_utils.py holds their "
+        "behaviour)",
     ),
 ]
 
@@ -350,8 +389,8 @@ def fm(fields, body="Body\n"):
 
 
 class TestRegistryShape:
-    # rows: 25, 46, 53, 60, 124, 142, 159, 160, 161, 162 (62, 66, 70, 87, 102, 106, 147, 148,
-    # 153-156 MIGRATED)
+    # rows: 25, 46, 53, 60, 124, 142, 159, 160, 161 + the source form of 162 (62, 66, 70, 87,
+    # 102, 106, 147, 148, 153-156, 162 MIGRATED)
 
     def test_shipped_types_in_argparse_order(self):
         assert TYPES == ["rfe", "initiative"]
@@ -373,18 +412,10 @@ class TestRegistryShape:
     def test_every_type_keyed_registry_has_exactly_the_shipped_types(self, name, live):
         pin("registry names()", name, set(TYPES), set(live))
 
-    def test_schemas_keys_are_types_times_task_review(self):
-        # scripts/artifact_utils.py:61,:108,:190,:228 — key order == types x {task, review}
-        expected = [f"{t}-{k}" for t in TYPES for k in ("task", "review")]
-        pin(
-            "names() x {task,review}",
-            "artifact_utils.py:61-228",
-            expected,
-            list(artifact_utils.SCHEMAS),
-        )
-
     def test_frontmatter_schema_choices_are_the_schema_keys(self):
-        # scripts/frontmatter.py:229-231,:237-242,:254-259
+        # scripts/frontmatter.py:229-231,:237-242,:254-259 — row 162's SCHEMAS keys are MIGRATED
+        # (a comprehension over _TYPES; tests/test_schemas_golden.py holds the key order); the
+        # source form of the choices is pinned so a re-introduced literal list is a visible change
         for got in choices("scripts/frontmatter.py", "schema_type") + choices(
             "scripts/frontmatter.py", "--schema-type"
         ):
@@ -1088,8 +1119,8 @@ class TestJqlAndJiraUtils:
 
 
 class TestSmallRegistries:
-    # rows: 65, 66 (residue), 68, 107, 154-161 (residues) — 66, 67, 69, 70, 105, 148-157
-    # MIGRATED as listed above
+    # rows: 65, 66 (residue), 68, 107, 154, 155, 157-161 (residues) — 66, 67, 69, 70, 105,
+    # 148-157, 170 MIGRATED as listed above
 
     def test_fetch_issue_is_rfe_only(self):
         # rows: 65 — fetch_issue.py:59-60,:71,:83,:98,:101,:122,:224 (no --type)
@@ -1101,51 +1132,28 @@ class TestSmallRegistries:
         assert ('f"{issue_key}-comments.md"' in source) is rfe.d["companions"]["comments"]
         assert "--type" not in source
 
-    def test_check_conflicts_scan_fork_and_write_prefix_predicate(self, ctx):
-        # rows: 66 — the dict is MIGRATED; still literal in check_conflicts.py: the forked
-        # scanner pair selected by type name (_SCAN_FNS, collapses with artifact_utils' pair) and
-        # the startswith(jira_prefix) predicate — key_prefixes[0] only, prefix-union in a later
+    def test_check_conflicts_write_prefix_predicate(self, ctx):
+        # rows: 66 — the dict is MIGRATED and the task scan is artifact_utils.scan_tasks(desc)
+        # since PR-2b (no scan_fn entry); still literal in check_conflicts.py: the
+        # startswith(jira_prefix) predicate — key_prefixes[0] only, prefix-union in a later
         # PR-2 step
-        tc = check_conflicts._TYPE_CONFIG[ctx.t]
-        scan = (
-            artifact_utils.scan_initiative_task_files
-            if ctx.id_field == "initiative_id"
-            else artifact_utils.scan_task_files
-        )
-        assert tc["scan_fn"] is scan
+        assert "scan_fn" not in check_conflicts._TYPE_CONFIG[ctx.t]
         assert 'item_id.startswith(tc["jira_prefix"])' in read("scripts/check_conflicts.py")
 
     def test_batch_parent_key_pattern_known_divergence(self):
-        # rows: 68 — Q14: validate_batch_input.py:36 omits INIT- while artifact_utils.py:219 accepts
-        # it; the descriptor carries the wider list; reconciled in PR-3
+        # rows: 68 — Q14: validate_batch_input.py:36 omits INIT- while the initiative task schema
+        # (derived from conventions.parent_key_patterns since PR-2b, row 169 MIGRATED) accepts
+        # it; reconciled in PR-3
         init = _ctx("initiative")
         registry_pattern = "^(" + "|".join(init.conv["parent_key_patterns"]) + ")$"
         assert validate_batch_input.PARENT_KEY_PATTERN.pattern == r"^(RHAISTRAT-\d+|RHOAIENG-\d+)$"
         assert validate_batch_input.PARENT_KEY_PATTERN.pattern != registry_pattern
-        pin(
-            "conventions.parent_key_patterns",
-            "artifact_utils.py:219",
-            registry_pattern,
-            artifact_utils.SCHEMAS["initiative-task"]["parent_key"]["pattern"],
-        )
         local_parent = f"{init.lp}001"
         assert validate_batch_input.PARENT_KEY_PATTERN.match(local_parent) is None
         assert re.match(registry_pattern, local_parent)
-
-    def test_priority_enum_in_the_task_schemas(self, ctx):
-        # rows: 170 — artifact_utils.py:83,:209; descriptor home schema.task.priority (PR1-14,
-        # map_to_tracker == {}). Row 69 (validate_batch_input.ALLOWED_PRIORITIES) is MIGRATED: it
-        # reads the rfe descriptor, and tests/test_validate_batch_input.py holds it equal to both
-        # task schemas until they derive too.
-        prio = ctx.schema["task"]["priority"]
-        pin(
-            "schema.task.priority.enum",
-            f"artifact_utils.SCHEMAS[{ctx.task_schema!r}]",
-            prio["enum"],
-            artifact_utils.SCHEMAS[ctx.task_schema]["priority"]["enum"],
+        assert re.match(
+            artifact_utils.SCHEMAS["initiative-task"]["parent_key"]["pattern"], local_parent
         )
-        assert prio["map_to_tracker"] == {}
-        assert prio["enum"] == ["Blocker", "Critical", "Major", "Normal", "Minor", "Undefined"]
 
     def test_batch_summary_literals(self, ctx):
         # rows: 107 — batch_summary.py:87,:97-111 literals (row 105's dirs dict is MIGRATED)
@@ -1162,6 +1170,7 @@ class TestSmallRegistries:
         # assess staging dir prep_assess writes and verify_phase / PHASE_CHECKS read (design §10)
         assert prep_assess.SINGLE_DIR == ASSESS_STAGING
         assert verify_phase.ASSESS_STAGING == ASSESS_STAGING
+        assert check_review_progress.ASSESS_STAGING == ASSESS_STAGING
 
     def test_error_collect_removed_context_companion(self, ctx):
         # rows: 154 — error_collect.py:216 companion (companions.removed_context); the dirs dict
@@ -1177,15 +1186,6 @@ class TestSmallRegistries:
         assert "status_path = f\"{tc['reviews_dir']}/{pid}-split-status.yaml\"" in read(
             "scripts/split_collect.py"
         )
-
-    def test_collect_children_scan_fork(self):
-        # rows: 156 — collect_children.py:34-39: id_field is MIGRATED; the forked scanner pair is
-        # still selected by type name (collapses with artifact_utils' pair)
-        assert re.search(
-            r'if args\.type == "initiative":\s+tasks = scan_initiative_task_files\(artifacts_dir\)'
-            r"\s+else:\s+tasks = scan_task_files\(artifacts_dir\)",
-            read("scripts/collect_children.py"),
-        ), "collect_children.py:34-39"
 
     def test_resplit_threshold_is_two_for_both_types(self, ctx):
         # rows: 157 — check_right_sized.py reads pipeline.resplit since PR-2a (MIGRATED), which
@@ -1250,18 +1250,12 @@ class TestSmallRegistries:
 class TestRunReportConfig:
     # rows: 82-86 (71-81, 87 MIGRATED)
 
-    def test_scan_tasks_fork_and_child_parent_prefixes_guard(self, ctx):
-        # rows: 71-80 are MIGRATED; still literal: the forked scanner pair selected by type name
-        # (generate_run_report.py _SCAN_TASKS — collapses with artifact_utils' pair), plus the
-        # derivation guard that child_parent_prefixes is (local_prefix, *key_prefixes) and NOT
-        # conventions.parent_key_patterns (RHAISTRAT- must stay excluded, :104)
+    def test_child_parent_prefixes_guard(self, ctx):
+        # rows: 71-81 are MIGRATED (the scanner is artifact_utils.scan_tasks bound to the
+        # descriptor since PR-2b); still pinned: the derivation guard that child_parent_prefixes
+        # is (local_prefix, *key_prefixes) and NOT conventions.parent_key_patterns (RHAISTRAT-
+        # must stay excluded, :104)
         g = generate_run_report.TYPE_CONFIG[ctx.t]
-        scan = (
-            artifact_utils.scan_task_files
-            if ctx.id_field == "rfe_id"
-            else artifact_utils.scan_initiative_task_files
-        )
-        assert g["scan_tasks"] is scan, "generate_run_report.py _SCAN_TASKS forked pair"
         assert "RHAISTRAT-" not in g["child_parent_prefixes"]
 
     def test_predicates_and_rfe_only_keys_in_source(self, ctx):
@@ -1641,77 +1635,20 @@ def _expected_phase_rows(ctx):
 
 
 class TestPhaseChecks:
-    # rows: 125-142
+    # rows: 125 (residue), 141, 142 (125-140 MIGRATED: PHASE_CHECKS and the check_id modes derive
+    # from dirs x poll_prefix x pipeline.dimensions[].name since PR-2b;
+    # tests/test_check_review_progress.py::TestDerivedFromRegistry holds the projection, today's
+    # 14-key order and the four modes)
 
-    def test_whole_table_is_the_union_over_types(self):
-        # rows: 125 — check_review_progress.py:18-36; 14 rows; no initiative-create (#148 rfe-only)
-        expected = {}
-        for t in TYPES:
-            expected.update(_expected_phase_rows(_ctx(t)))
-        live = {k: f("X") for k, f in check_review_progress.PHASE_CHECKS.items()}
-        pin(
-            "dirs x poll_prefix x dimension names (+ rfe create)",
-            "check_review_progress.py:18-36",
-            expected,
-            live,
-        )
-        assert len(check_review_progress.PHASE_CHECKS) == 14
+    def test_create_barrier_is_the_rfe_only_grandfather(self):
+        # rows: 125 (residue) — check_review_progress._CREATE_BARRIER_TYPES: the PR #148 create
+        # barrier is still a name-keyed literal (no descriptor fact says which pipeline polls one),
+        # so PR-5's generic speedrun body inheriting it for every type is a visible pin change
+        # here, not a silent descriptor edit
+        assert check_review_progress._CREATE_BARRIER_TYPES == ("rfe",)
+        assert "create" in check_review_progress.PHASE_CHECKS
         assert "initiative-create" not in check_review_progress.PHASE_CHECKS
-
-    def test_each_row_for_the_type(self, ctx):
-        # rows: 126-139 — one pin per PHASE_CHECKS key derived for this type
-        for key, path in _expected_phase_rows(ctx).items():
-            pin(
-                f"PHASE_CHECKS[{key!r}]",
-                "check_review_progress.py:18-36",
-                path,
-                check_review_progress.PHASE_CHECKS[key]("X"),
-            )
-
-    def test_check_modes(self, ctx, tmp_path, monkeypatch):
-        # rows: 127, 140 — check_review_progress.py:39-84: FOUR modes (exists, frontmatter_valid,
-        # score_present, revised_or_split); literal tuples :61/:72 — a third type falls through to
-        # exists
-        monkeypatch.chdir(tmp_path)
-        rows = _expected_phase_rows(ctx)
-        check = check_review_progress.check_id
-        for key in rows:
-            assert check(key, "X") == "pending", f"{key}: missing output must be pending"
-        review = Path(rows[f"{ctx.pp}review"])
-        write(review, fm({ctx.id_field: "X"}))
-        assert check(f"{ctx.pp}review", "X") == "pending"  # score_present: no score yet
-        write(review, fm({ctx.id_field: "X", "score": 7}))
-        assert check(f"{ctx.pp}review", "X") == "completed"
-        write(review, fm({ctx.id_field: "X", "score": 0, "error": "assess_failed"}))
-        assert check(f"{ctx.pp}review", "X") == "error"
-        assert check(f"{ctx.pp}revise", "X") == "pending"  # revised_or_split
-        write(review, fm({ctx.id_field: "X", "auto_revised": True}))
-        assert check(f"{ctx.pp}revise", "X") == "completed"
-        write(review, fm({ctx.id_field: "X", "recommendation": "split"}))
-        assert check(f"{ctx.pp}revise", "X") == "completed"
-        for key in (
-            f"{ctx.pp}fetch",
-            f"{ctx.pp}assess",
-            f"{ctx.pp}split",
-            *(f"{ctx.pp}{d['name']}" for d in ctx.pipe["dimensions"]),
-        ):
-            write(rows[key], "anything\n")
-            assert check(key, "X") == "completed", f"{key}: exists mode"
-        if ctx.t == "rfe":
-            task = Path(rows["create"])
-            write(task, "# no frontmatter yet\n")
-            assert check("create", "X") == "pending"
-            write(task, fm({ctx.id_field: "Y"}))
-            assert check("create", "X") == "pending"  # frontmatter_valid: id must match (:58)
-            write(task, fm({ctx.id_field: "X"}))
-            assert check("create", "X") == "completed"
-            assert 'data.get("rfe_id") != rfe_id' in read("scripts/check_review_progress.py")
-        assert 'if phase in ("review", "initiative-review"):' in read(
-            "scripts/check_review_progress.py"
-        )
-        assert 'if phase in ("revise", "initiative-revise"):' in read(
-            "scripts/check_review_progress.py"
-        )
+        assert len(check_review_progress.PHASE_CHECKS) == 14
 
     def test_detect_fast_config_allowlist(self):
         # rows: 141 — check_review_progress.py:134-141; each ==
@@ -1742,13 +1679,14 @@ class TestPhaseChecks:
 
 
 class TestVerifyPhase:
-    # rows: 146 (143-145, 147 MIGRATED — tests/test_verify_phase.py::TestAgreesWithProgressChecker
-    # keeps the derived phase table equal to the still-literal check_review_progress.PHASE_CHECKS)
+    # rows: 146 (143-145, 147 MIGRATED — both phase tables derive from the same descriptors since
+    # PR-2b; tests/test_verify_phase.py::TestAgreesWithProgressChecker holds them equal per type)
 
     def test_error_stub_command_and_schema_acceptance(self, ctx, tmp_path, monkeypatch):
         # rows: 146 — verify_phase.py:105-127; the score tail is registry-derived since PR-2a;
-        # pinned here: the fixed stub vocabulary, and that the (still literal) review schema in
-        # artifact_utils accepts the stub shape (validate_types gate 1 restates this; design §3.3)
+        # pinned here: the fixed stub vocabulary, and that the review schema artifact_utils
+        # derives from the same descriptor accepts the stub shape (validate_types gate 1 restates
+        # this; design §3.3)
         monkeypatch.chdir(tmp_path)
         captured = []
         real_run = subprocess.run  # verify_phase shares the subprocess module object
@@ -1789,128 +1727,18 @@ class TestVerifyPhase:
         assert ids.read_text() == ""
 
 
-# ── artifact_utils.SCHEMAS and helpers ────────────────────────────────────────────────────────
-
-# Shared base fields of every task / review schema (artifact_utils.py:61-107 / :108-189, plus the
-# PR-1 additions `type`/`tracker_ref` — Q4, no default). Per-type fields are schema.*.extra_fields.
-BASE_TASK_KEYS = {
-    "local_id",
-    "type",
-    "tracker_ref",
-    "title",
-    "priority",
-    "status",
-    "parent_key",
-    "original_labels",
-}
-BASE_REVIEW_KEYS = {
-    "local_id",
-    "type",
-    "tracker_ref",
-    "score",
-    "pass",
-    "recommendation",
-    "feasibility",
-    "auto_revised",
-    "needs_attention",
-    "scores",
-    "error",
-    "before_score",
-    "needs_attention_reason",
-    "before_scores",
-}
-
-
-def _id_pattern(ctx):
-    # artifact_utils.py:65,:194 — do NOT re.escape the prefix (the live literal has a bare dash)
-    return (
-        "^("
-        + "|".join(
-            [ctx.ident["local_id_pattern"].strip("^$")]
-            + [kp + r"\d+" for kp in ctx.jira["key_prefixes"]]
-        )
-        + ")$"
-    )
+# ── artifact_utils.SCHEMAS and helpers (residues) ─────────────────────────────────────────────
 
 
 class TestArtifactSchemas:
-    # rows: 162-175
-
-    def test_id_patterns(self, ctx):
-        # rows: 163, 164 — artifact_utils.py:65,:112,:194,:232
-        task, review = (
-            artifact_utils.SCHEMAS[ctx.task_schema],
-            artifact_utils.SCHEMAS[ctx.review_schema],
-        )
-        pin(
-            "local_id_pattern | key_prefixes",
-            "artifact_utils.py:65,:194",
-            _id_pattern(ctx),
-            task[ctx.id_field]["pattern"],
-        )
-        pin(
-            "local_id_pattern | key_prefixes",
-            "artifact_utils.py:112,:232",
-            _id_pattern(ctx),
-            review[ctx.id_field]["pattern"],
-        )
-        for ident in ctx.sample_ids:
-            assert re.fullmatch(task[ctx.id_field]["pattern"], ident), ident
-
-    def test_local_id_patterns_four_sites(self, ctx):
-        # rows: 165-168 — artifact_utils.py:73,:120,:199,:237 (design §10 item 1); PR1-16 composite
-        # id
-        pattern = ctx.ident["local_id_pattern"]
-        pin(
-            "identity.local_id_pattern",
-            "artifact_utils.py:73,:199",
-            pattern,
-            artifact_utils.SCHEMAS[ctx.task_schema]["local_id"]["pattern"],
-        )
-        pin(
-            "identity.local_id_pattern",
-            "artifact_utils.py:120,:237",
-            pattern,
-            artifact_utils.SCHEMAS[ctx.review_schema]["local_id"]["pattern"],
-        )
-        assert pattern.count("\\") == 1, "YAML must hold ONE backslash (the design doubled it)"
-        assert re.fullmatch(pattern, "RHAISTRAT-1234-E001") is None, (
-            "PR1-16: composite sibling id must not match"
-        )
-        assert re.fullmatch(pattern, f"{ctx.lp}001")
-
-    def test_parent_key_pattern(self, ctx):
-        # rows: 169 — artifact_utils.py:99,:219 (review schemas have no parent_key)
-        pin(
-            "conventions.parent_key_patterns",
-            "artifact_utils.py:99,:219",
-            "^(" + "|".join(ctx.conv["parent_key_patterns"]) + ")$",
-            artifact_utils.SCHEMAS[ctx.task_schema]["parent_key"]["pattern"],
-        )
-        assert "parent_key" not in artifact_utils.SCHEMAS[ctx.review_schema]
-
-    def test_task_extra_fields(self, ctx):
-        # rows: 171 — artifact_utils.py:85-90 (rfe size); initiative has none
-        task = artifact_utils.SCHEMAS[ctx.task_schema]
-        live_extra = {k: v for k, v in task.items() if k not in BASE_TASK_KEYS | {ctx.id_field}}
-        pin(
-            "schema.task.extra_fields",
-            "artifact_utils.py:61-107,:190-227",
-            ctx.schema["task"]["extra_fields"],
-            live_extra,
-        )
-        if ctx.t == "rfe":
-            assert live_extra["size"] == {
-                "type": "string",
-                "required": False,
-                "enum": ["S", "M", "L", "XL"],
-                "default": None,
-            }
-        assert ("size" in task) is (ctx.t == "rfe")
+    # rows: 172, 173, 175 (residue) (162-171, 174, 175 MIGRATED: SCHEMAS derives from the
+    # descriptors and tests/test_schemas_golden.py pins the derived dicts byte for byte)
 
     def test_shared_enums(self, ctx):
-        # rows: 172, 173 — artifact_utils.py:94,:214 status; :134,:139,:251,:256
-        # recommendation/feasibility
+        # rows: 172, 173 — artifact_utils._STATUS_ENUM / _RECOMMENDATION_ENUM / _FEASIBILITY_ENUM:
+        # the task/review vocabularies shared by every type stay module constants (UNMAPPED);
+        # the feasibility enum is deliberately NOT derived from conventions.labels.feasibility,
+        # so the label map's key order is pinned equal to it
         task, review = (
             artifact_utils.SCHEMAS[ctx.task_schema],
             artifact_utils.SCHEMAS[ctx.review_schema],
@@ -1927,177 +1755,48 @@ class TestArtifactSchemas:
         ]
         pin(
             "list(conventions.labels.feasibility)",
-            "artifact_utils.py:139,:256",
+            "artifact_utils._FEASIBILITY_ENUM",
             list(ctx.labels["feasibility"]),
             review["feasibility"]["enum"],
         )
 
-    def test_scores_and_before_scores_fields(self, ctx):
-        # rows: 174 — artifact_utils.py:154-160,:181-187,:271-277,:298-304 (restated 4x)
+    def test_alignment_vocabulary_agrees_across_descriptor_fields(self, ctx):
+        # rows: 175 (residue) — the review schema's alignment enum (schema.review.extra_fields,
+        # derived) must admit every conventions.labels.alignment key (submit's alignment_labels)
+        # and the dimension's skip_stub.result (what pipeline_state._write_poll_stub writes when
+        # there is no RHAISTRAT parent); validate_types does not cross-check these fields
         review = artifact_utils.SCHEMAS[ctx.review_schema]
-        for key in ("scores", "before_scores"):
-            pin(
-                "schema.review.score_fields",
-                f"artifact_utils {ctx.review_schema}.{key}.fields",
-                ctx.score_fields,
-                list(review[key]["fields"]),
-            )
-            assert all(
-                spec == {"type": "int", "required": True} for spec in review[key]["fields"].values()
-            )
-
-    def test_review_extra_fields(self, ctx):
-        # rows: 175 — artifact_utils.py:306-313 initiative alignment (default is the STRING
-        # not_assessed)
-        review = artifact_utils.SCHEMAS[ctx.review_schema]
-        live_extra = {k: v for k, v in review.items() if k not in BASE_REVIEW_KEYS | {ctx.id_field}}
-        pin(
-            "schema.review.extra_fields",
-            "artifact_utils.py:108-189,:228-315",
-            ctx.schema["review"]["extra_fields"],
-            live_extra,
-        )
-        if "alignment" in ctx.labels:
-            enum = live_extra["alignment"]["enum"]
-            assert live_extra["alignment"] == {
-                "type": "string",
-                "required": False,
-                "enum": ["strong", "partial", "weak", "not_assessed"],
-                "default": "not_assessed",
-            }
-            assert set(ctx.labels["alignment"]) <= set(enum)
-            assert ctx.dims["alignment"]["skip_stub"]["result"] in enum
-            assert ctx.schema["review"]["extra_fields"]["alignment"]["default"] == "not_assessed"
+        if "alignment" not in ctx.labels:
+            assert "alignment" not in review
+            return
+        enum = review["alignment"]["enum"]
+        assert set(ctx.labels["alignment"]) <= set(enum)
+        assert ctx.dims["alignment"]["skip_stub"]["result"] in enum
+        assert review["alignment"]["default"] in enum
 
 
 class TestArtifactHelpers:
-    # rows: 177, 179, 180, 182, 183, 184, 185, 186, 187
+    # rows: 177, 184, 185, 186 (residue) (179, 180, 182-187 MIGRATED: the generics take a
+    # Descriptor and the lookups route via registry.detect(); tests/test_artifact_utils.py and
+    # tests/test_frontmatter.py hold the projections)
 
     def test_companion_suffixes_are_type_agnostic(self, ctx):
-        # rows: 177 — artifact_utils.py:727-731; companions.comments=false (initiative) must NOT
-        # remove
-        # -comments.md from the predicate nor from rename_initiative_to_jira_key (:1079-1080)
+        # rows: 177 — artifact_utils._is_companion_file; companions.comments=false (initiative)
+        # must NOT remove -comments.md from the predicate nor from the rename generic's suffix
+        # map (rename_to_tracker_key renames a -comments.md for every type)
         for suffix in ("-comments.md", "-removed-context.md", "-removed-context.yaml"):
             assert artifact_utils._is_companion_file(f"{ctx.sample_ids[0]}{suffix}")
         assert not artifact_utils._is_companion_file(f"{ctx.sample_ids[0]}.md")
-        rename = (
-            artifact_utils.rename_initiative_to_jira_key
-            if ctx.t == "initiative"
-            else artifact_utils.rename_to_jira_key
+        assert 'filename.endswith("-comments.md")' in inspect.getsource(
+            artifact_utils.rename_to_tracker_key
         )
-        assert 'filename.endswith("-comments.md")' in inspect.getsource(rename)
         assert ctx.d["companions"]["removed_context"] is True
 
-    def test_archived_lookup_wrapper_passes_the_rfe_triple(self, monkeypatch):
-        # rows: 179 — artifact_utils.py:783-812 (:811 wrapper); generate_review_pdf.py:401-406
-        # passes
-        # the same triple from REPORT_CONFIG
-        rfe = _ctx("rfe")
-        seen = []
-        monkeypatch.setattr(
-            artifact_utils, "find_task_file_including_archived", lambda *a: seen.append(a)
-        )
-        artifact_utils.find_artifact_file_including_archived("a", "RFE-1")
-        pin(
-            "(dirs.tasks bare, key_prefixes[0], local_prefix)",
-            "artifact_utils.py:811",
-            ("a", "RFE-1", rfe.bare["tasks"], rfe.wp, rfe.lp),
-            seen[0],
-        )
-        assert re.search(
-            r'config\["tasks_dir"\],\s+config\["jira_prefix"\],\s+config\["local_prefix"\],',
-            read("scripts/generate_review_pdf.py"),
-        )
-
-    def test_removed_context_and_review_lookups(self, ctx, tmp_path):
-        # rows: 180, 182 — artifact_utils.py:815-835 (sniff dispatcher), :881-899 (find_review_file)
-        for ident in ctx.sample_ids:
-            rc = write(
-                tmp_path / ctx.bare["tasks"] / f"{ident}-removed-context.yaml", "blocks: []\n"
-            )
-            pin(
-                "dirs.tasks (bare)",
-                "artifact_utils.py:831-835",
-                str(rc),
-                artifact_utils.find_removed_context_yaml(str(tmp_path), ident),
-            )
-            review = write(
-                tmp_path / ctx.bare["reviews"] / f"{ident}-review.md", fm({ctx.id_field: ident})
-            )
-            pin(
-                "dirs.reviews (bare)",
-                "artifact_utils.py:886",
-                str(review),
-                artifact_utils.find_review_file(str(tmp_path), ident),
-            )
-
-    def test_scan_pairs(self, ctx, tmp_path):
-        # rows: 183 — artifact_utils.py:902-981 (bodies byte-identical apart from three literals)
-        scan = (
-            artifact_utils.scan_task_files
-            if ctx.id_field == "rfe_id"
-            else artifact_utils.scan_initiative_task_files
-        )
-        b, a = ctx.sample_ids[1], ctx.sample_ids[0]
-        for ident in (b, a):
-            write(
-                tmp_path / ctx.bare["tasks"] / f"{ident}.md",
-                fm({ctx.id_field: ident, "title": "T", "priority": "Major", "status": "Ready"}),
-            )
-        write(tmp_path / ctx.bare["tasks"] / f"{a}-comments.md", "No comments found.\n")
-        found = scan(str(tmp_path))
-        pin(
-            "dirs.tasks (bare) sorted by id_field",
-            "artifact_utils.py:909-981",
-            sorted([a, b]),
-            [d[ctx.id_field] for _, d in found],
-        )
-        assert all(os.path.dirname(p) == str(tmp_path / ctx.bare["tasks"]) for p, _ in found)
-        source = inspect.getsource(scan)
-        assert (
-            f'"{ctx.bare["tasks"]}"' in source
-            and f'"{ctx.task_schema}"' in source
-            and f'"{ctx.id_field}"' in source
-        )
-        rfe = _ctx("rfe")
-        review_src = inspect.getsource(artifact_utils.scan_review_files)
-        assert (
-            f'"{rfe.bare["reviews"]}"' in review_src and '"rfe-review"' in review_src
-        )  # rfe-only, unforked
-
-    def test_rename_guards_and_updates(self, ctx):
-        # rows: 184 — artifact_utils.py:987-1049 / :1052-1107 (guards :1001,:1003 / :1058,:1060)
-        rename = (
-            artifact_utils.rename_initiative_to_jira_key
-            if ctx.t == "initiative"
-            else artifact_utils.rename_to_jira_key
-        )
-        source = inspect.getsource(rename)
-        guards = [p for p, _ in re.findall(r're\.fullmatch\(r"([^"]+)", (\w+)\)', source)]
-        pin(
-            "local_id_pattern (unanchored) + key_prefixes[0]\\d+",
-            "artifact_utils.py:1001-1003,:1058-1060",
-            [ctx.ident["local_id_pattern"].strip("^$"), ctx.wp + r"\d+"],
-            guards,
-        )
-        assert f'os.path.join(artifacts_dir, "{ctx.bare["tasks"]}")' in source
-        assert f'os.path.join(artifacts_dir, "{ctx.bare["reviews"]}")' in source
-        assert f'{{"{ctx.id_field}": jira_key, "status": "Submitted", "local_id": ' in source
-        assert f'{{"{ctx.id_field}": jira_key, "local_id": ' in source
-        assert f'"{ctx.task_schema}"' in source and f'"{ctx.review_schema}"' in source
-
-    def test_parse_child_title_fallback_is_rfe_only(self, ctx):
-        # rows: 185 — artifact_utils.py:1176-1225 (:1196 the single non-guard prefix literal)
-        rfe_src = inspect.getsource(artifact_utils.parse_child_artifact)
-        assert 'r"^#\\s+%s\\d+:\\s+(.+)$"' % _ctx("rfe").lp in rfe_src
-        assert "re.match" not in inspect.getsource(artifact_utils.parse_child_initiative)
-        assert "Normal" in ctx.schema["task"]["priority"]["enum"]
-        for fn in (artifact_utils.parse_child_artifact, artifact_utils.parse_child_initiative):
-            assert '"Normal"' in inspect.getsource(fn)
-
     def test_rebuild_index_is_the_rfe_index(self):
-        # rows: 186 — artifact_utils.py:1113-1170; runs iff index.enabled (callers pinned via
-        # submit.has_index / split_submit.do_rebuild_index)
+        # rows: 186 (residue) — rebuild_index runs iff index.enabled (callers pinned via
+        # submit.has_index / split_submit.do_rebuild_index) and reads the rfe id_field from the
+        # registry since PR-2b; the index contract itself (file name, heading, columns) has no
+        # descriptor field and stays literal
         rfe = _ctx("rfe")
         source = inspect.getsource(artifact_utils.rebuild_index)
         assert rfe.d["index"]["enabled"] and not _ctx("initiative").d["index"]["enabled"]
@@ -2105,28 +1804,27 @@ class TestArtifactHelpers:
             '"rfes.md"',
             '"# RFE Summary"',
             '"| ID | Title | Priority | Size | Score | Rec | Status |"',
-            f'"{rfe.id_field}"',
         ):
             assert literal in source, literal
         assert "scan_task_files(" in source and "scan_review_files(" in source
         assert "Size" in source and "size" in rfe.schema["task"]["extra_fields"]
 
-    def test_frontmatter_detects_schema_from_dirs(self, ctx):
-        # rows: 187 — frontmatter.py:76-86 path-substring table (reviews tested before tasks per
-        # type)
-        pin(
-            "dirs.tasks -> f'{type}-task'",
-            "frontmatter.py:76-86",
-            ctx.task_schema,
-            frontmatter._detect_schema_type(f"{ctx.dirs['tasks']}/X.md"),
-        )
-        pin(
-            "dirs.reviews -> f'{type}-review'",
-            "frontmatter.py:76-86",
-            ctx.review_schema,
-            frontmatter._detect_schema_type(f"{ctx.dirs['reviews']}/X-review.md"),
-        )
-        assert frontmatter._detect_schema_type("artifacts/elsewhere/X.md") is None
+    def test_name_keyed_residues_until_pr3(self):
+        # rows: 184, 185 (residue) — three artifact_utils projections are keyed on the type NAME
+        # because no descriptor fact expresses them (the same kind of grandfather as
+        # check_review_progress._CREATE_BARRIER_TYPES): the rename ValueError label, rfe's
+        # slug-tolerant review lookup and parse_child's rfe markdown fallbacks. PR-3's
+        # resolution ladder generalises or retires them, so lifting one is a visible pin change
+        # here, not a silent edit; tests/test_artifact_utils.py holds their behaviour
+        rfe, init = REG.get("rfe"), REG.get("initiative")
+        assert artifact_utils._rename_error_label(rfe) == "rename_to_jira_key"
+        assert artifact_utils._rename_error_label(init) == "rename_initiative_to_jira_key"
+        for fn in (
+            artifact_utils._rename_error_label,
+            artifact_utils._review_to_rename,
+            artifact_utils.parse_child,
+        ):
+            assert 'desc.name == "rfe"' in inspect.getsource(fn), fn.__name__
 
 
 # ── skill layer (grep pins until PR-5 lifts the bodies) ───────────────────────────────────────

--- a/tests/test_validate_types.py
+++ b/tests/test_validate_types.py
@@ -1380,3 +1380,52 @@ class TestStratInputs:
                 if pattern.search(line) and "descriptor" in line.lower():
                     offenders.append(f"{path.name}:{lineno}: {line.strip()}")
         assert offenders == []
+
+
+class _FakeDesc:
+    """Minimal Descriptor stand-in: dotted get(), dirs(), and the id properties."""
+
+    def __init__(self, name, data, dirs=None):
+        self.name = name
+        self._data = data
+        self._dirs = dirs or {
+            "tasks": "artifacts/x-tasks",
+            "reviews": "artifacts/x-reviews",
+            "originals": "artifacts/x-originals",
+        }
+
+    def get(self, dotted, default=None):
+        return self._data.get(dotted, default)
+
+    def dirs(self, form="artifacts"):
+        if form == "bare":
+            return {k: v.split("/", 1)[1] for k, v in self._dirs.items()}
+        return dict(self._dirs)
+
+    @property
+    def local_id_pattern(self):
+        return self._data["identity.local_id_pattern"]
+
+    @property
+    def key_prefixes(self):
+        return list(self._data.get("identity.jira.key_prefixes", []))
+
+    @property
+    def id_field(self):
+        return self._data.get("identity.id_field", "x_id")
+
+
+def test_gate1_rejects_dimension_names_that_collide_with_engine_phases(tmp_path):
+    desc = _FakeDesc(
+        "x",
+        {
+            "pipeline.dimensions": [
+                {"name": "assess"},
+                {"name": "feasibility"},
+                {"name": "feasibility"},
+            ]
+        },
+    )
+    msgs = validate_types.path_messages(desc, tmp_path)
+    assert any("collides with an engine phase" in m for m in msgs)
+    assert any("declared twice" in m for m in msgs)

--- a/tests/test_validate_types.py
+++ b/tests/test_validate_types.py
@@ -1429,3 +1429,21 @@ def test_gate1_rejects_dimension_names_that_collide_with_engine_phases(tmp_path)
     msgs = validate_types.path_messages(desc, tmp_path)
     assert any("collides with an engine phase" in m for m in msgs)
     assert any("declared twice" in m for m in msgs)
+
+
+def test_gate1_ignores_malformed_dimension_names(tmp_path):
+    """An unhashable or non-string name is the schema check's finding, not a TypeError here."""
+    desc = _FakeDesc(
+        "x",
+        {
+            "pipeline.dimensions": [
+                {"name": []},
+                {"name": {"a": 1}},
+                {"name": 3},
+                {"name": "review"},
+            ]
+        },
+    )
+    msgs = validate_types.path_messages(desc, tmp_path)
+    assert any("collides with an engine phase" in m for m in msgs)
+    assert not any("declared twice" in m for m in msgs)

--- a/tests/test_verify_phase.py
+++ b/tests/test_verify_phase.py
@@ -261,6 +261,16 @@ class TestAgreesWithProgressChecker:
     def test_initiative_paths_match(self, phase):
         assert _INITIATIVE_PHASE_OUTPUT[phase]("X-1") == PHASE_CHECKS[f"initiative-{phase}"]("X-1")
 
+    def test_every_registry_type_matches(self):
+        """Both tables derive from the same descriptors; the agreement must hold per type."""
+        import type_registry
+        from verify_phase import _PHASE_OUTPUT
+
+        for desc in type_registry.load(extra_roots=[], env={}):
+            pp = desc.get("pipeline.poll_prefix")
+            for phase, output in _PHASE_OUTPUT[desc.name].items():
+                assert output("X-1") == PHASE_CHECKS[f"{pp}{phase}"]("X-1"), (desc.name, phase)
+
 
 # ── Registry derivation ───────────────────────────────────────────────────────
 

--- a/types/README.md
+++ b/types/README.md
@@ -10,15 +10,26 @@ reference). Design: `design-proposals/work-item-types-unified.md` §3.2 (contrac
 and are invoked by their cwd-relative path (`python3 scripts/type_registry.py …`, design §3.5.1).
 The provider guide is `docs/type-provider-guide.md`.
 
-**Status (PR-2a): 18 scripts read the registry** (table below). An adopted script does
+**Status (PR-2b): 21 scripts read the registry** (table below). An adopted script does
 `import type_registry` and `_TYPES = type_registry.load()` once at import and builds its per-type
-table as a comprehension over `_TYPES.names()`, so a drop-in type appears in it without a code
-change. Adopted scripts use DESCRIPTOR values only (`Descriptor.get`, `dirs()`, `labels`,
-`key_prefixes`, `write_prefix`, `local_prefix`, `id_field`, `score_fields`; the prefix sniffs
-became `TypeRegistry.detect()`); the effective binding (`binding()`) and `resolve` are PR-3.
-Every value a pending script still carries is pinned by `tests/test_type_registry_pins.py` to its
-descriptor projection — source of truth *by test* until it adopts (§10); that file's `MIGRATED`
-list names the matrix rows already covered *by import*, and each adoption deletes its pin.
+table over the registry (`_TYPES.names()` or iteration — both in `names()` order), so a drop-in
+type appears in it without a code change. Adopted scripts use DESCRIPTOR values only (`Descriptor.get`, `dirs()`, `labels`,
+`key_prefixes`, `write_prefix`, `local_prefix`, `local_id_pattern`, `id_field`, `score_fields`;
+the prefix sniffs became `TypeRegistry.detect()`); the effective binding (`binding()`) and
+`resolve` are PR-3. Since PR-2b the artifact schemas and the poll phase table are projections
+too: `artifact_utils.SCHEMAS` builds `<type>-task` / `<type>-review` for every registered type
+that declares `identity.{tracker,id_field,local_id_pattern}`, `conventions.parent_key_patterns`,
+`schema.task.priority.enum` and `schema.review.score_fields` (plus the optional
+`schema.{task,review}.extra_fields`; a partial drop-in gets no schema — and no `frontmatter.py`
+path entry — instead of breaking the import, while a shipped type missing one fails the import),
+the scan / rename / parse helpers are generics over a `Descriptor` (the historical per-type names
+remain as wrappers), and `check_review_progress.PHASE_CHECKS` is `dirs` x `pipeline.poll_prefix`
+x `pipeline.dimensions[].name` (a drop-in without `dirs.{tasks,reviews}` and
+`pipeline.poll_prefix` contributes no rows). `tests/test_schemas_golden.py` pins the derived
+schemas byte for byte. Every value a pending script still carries is pinned by `tests/test_type_registry_pins.py`
+to its descriptor projection — source of truth *by test* until it adopts (§10); that file's
+`MIGRATED` list names the matrix rows already covered *by import*, and each adoption deletes its
+pin.
 
 `type_registry.DEFAULT_ROOT` is `__file__`-relative (`<scripts dir>/../types`): a harness that
 copies `scripts/*.py` elsewhere must copy or symlink `types/` beside it (symlinking `scripts/`
@@ -28,16 +39,19 @@ itself is fine — `resolve()` follows the link).
 
 | Script | Registry it read from the descriptor | Status |
 |---|---|---|
+| `artifact_utils.py` | `SCHEMAS` (`<type>-task` / `<type>-review` per type), `scan_tasks` / `scan_reviews` / `rename_to_tracker_key` / `parse_child` generics over a `Descriptor` (the per-type names are wrappers), `detect()` in `find_review_file` / `find_removed_context_yaml` | PR-2b; name-keyed until PR-3: the rename error label, rfe's slug-tolerant review lookup and `parse_child`'s rfe markdown fallbacks; the `rfes.md` index contract stays literal (`index.enabled`) |
 | `batch_summary.py` | `_TYPE_CONFIG` (dirs view of `generate_run_report.TYPE_CONFIG`), `--type` choices | PR-2a |
-| `check_conflicts.py` | `_TYPE_CONFIG`, `--type` choices | PR-2a; scanner fork by type name and `startswith(jira_prefix)` → prefix-union pending |
+| `check_conflicts.py` | `_TYPE_CONFIG`, `--type` choices; task scan via `artifact_utils.scan_tasks(desc)` | PR-2a, PR-2b; `startswith(jira_prefix)` → prefix-union pending |
 | `check_revised.py` | `_TYPE_CONFIG` | PR-2a |
+| `check_review_progress.py` | `PHASE_CHECKS`, `check_id` id field + modes by phase base, `--phase` / `--also-phase` choices | PR-2b; `_detect_fast` config allowlist literal until the `initiative-speedrun-config` drift is fixed deliberately; the rfe-only `create` row (`_CREATE_BARRIER_TYPES`, lifted in PR-5) and the initiative row order (`_LEGACY_ROW_ORDER`, CLI choices text) are documented legacy literals |
 | `check_right_sized.py` | `_TYPE_CONFIG`, `pipeline.resplit` | PR-2a |
-| `collect_children.py` | `id_field`, `--type` choices | PR-2a; scanner fork by type name pending |
+| `collect_children.py` | `id_field`, `--type` choices; task scan via `artifact_utils.scan_tasks(desc)` | PR-2a, PR-2b |
 | `collect_recommendations.py` | `_review_dir`, `--type` choices | PR-2a |
 | `error_collect.py` | `_TYPE_CONFIG`, `--type` choices | PR-2a |
 | `filter_for_revision.py` | prefix sniff → `detect()` | PR-2a |
+| `frontmatter.py` | `_detect_schema_type` path table (`_SCHEMA_BY_DIR`), `schema` / `--schema-type` choices through `SCHEMAS` | PR-2b |
 | `generate_review_pdf.py` | `REPORT_CONFIG`, `--type` choices | PR-2a |
-| `generate_run_report.py` | `TYPE_CONFIG`, `--type` choices | PR-2a; scanner fork by type name and the `tracker_ref`/role predicates pending |
+| `generate_run_report.py` | `TYPE_CONFIG` (`scan_tasks` bound to `artifact_utils.scan_tasks(desc)`), `--type` choices | PR-2a, PR-2b; the `tracker_ref`/role predicates pending (PR-3) |
 | `jql_query.py` | default exclusion wrapper, `--project` choices | PR-2a |
 | `next_rfe_id.py` | `DEFAULT_PREFIX` / `DEFAULT_DIR` | PR-2a |
 | `prep_assess.py` | prefix sniff → `detect()` | PR-2a |
@@ -46,15 +60,12 @@ itself is fine — `resolve()` follows the link).
 | `split_collect.py` | `_TYPE_CONFIG`, `_set_revise` defaults, `--type` choices | PR-2a |
 | `validate_batch_input.py` | `ALLOWED_PRIORITIES`, known fields, `--type` choices | PR-2a; `PARENT_KEY_PATTERN` literal until PR-3 (Q14) |
 | `verify_phase.py` | phase tables, `_TYPE_CONFIG`, error-stub score tail, `--type` choices | PR-2a |
-| `artifact_utils.py` | `SCHEMAS`, forked scan/rename/parse pairs, sniff dispatchers | pending |
 | `bootstrap_snapshot.py` | `BOOTSTRAP_CONFIG`, `issue-snapshot-` probe | pending |
 | `check_autofix_complete.py` | `_TYPE_CONFIG` | pending |
 | `check_content_preservation.py` | inline dir branch | pending |
-| `check_review_progress.py` | `PHASE_CHECKS` | pending |
 | `cleanup_partial_split.py` | inline dir branch | pending |
 | `compare_review_outputs.py` | `_TYPE_CONFIG` | pending |
 | `fetch_issue.py` | rfe-only paths | pending |
-| `frontmatter.py` | `_detect_schema_type` | pending |
 | `jira_utils.py` | `strip_metadata` prefix regex | pending |
 | `pipeline_state.py` | `PIPELINE_TYPES` (prompt/skill entries move in PR-5) | pending |
 | `snapshot_fetch.py` | `SNAPSHOT_CONFIG` | pending |
@@ -111,10 +122,11 @@ and `produces[]` (§3.7 cross-type chain; rfe-creator ships no gate evaluator),
 `identity.jira.{duplicate_link_type, state_map.close_duplicate, state_map.ready, priority}`, the whole
 `identity.github` branch (§8.6 shape; adapter/emulator are first-requester work), `classification`,
 `dirs.{dupes,merges}`, `companions.extra_suffixes`, `conventions.labels.{processing,human_sign_off,
-templates}`, `conventions.query_default`, `schema.task.priority` (task-side vocabulary +
-`map_to_tracker`; today's enum is pinned equal to `artifact_utils.SCHEMAS`),
-`schema.review.{extra_scores,extra_rules}`, `pipeline.context_sources` (descriptive; SETUP is still
-hardcoded), `pipeline.dimensions[].{blocking, condition.context_exists, setup}`,
+templates}`, `conventions.query_default`, `schema.task.priority.map_to_tracker` (the `enum`
+beside it feeds `artifact_utils.SCHEMAS` and `validate_batch_input.ALLOWED_PRIORITIES` since
+PR-2b / PR-2a; the map has no consumer), `schema.review.{extra_scores,extra_rules}`,
+`pipeline.context_sources` (descriptive; SETUP is still hardcoded),
+`pipeline.dimensions[].{blocking, condition.context_exists, setup}`,
 `snapshot.{mode,processed_gate}`.
 
 The third data point (R1) is the paper descriptor `tests/fixtures/types/epic/type.yaml` for

--- a/types/initiative/type.yaml
+++ b/types/initiative/type.yaml
@@ -1,6 +1,6 @@
 # types/initiative/type.yaml — the initiative work-item type descriptor.
 # Contract: types/_schema/type.schema.json; design-proposals/work-item-types-unified.md §3.2 and the worked
-# example §8.2. Status (PR-2a): 18 scripts read this descriptor at import (types/README.md "Adoption
+# example §8.2. Status (PR-2b): 21 scripts read this descriptor at import (types/README.md "Adoption
 # status"); the values a pending script still carries are pinned equal to it by test, so the descriptor
 # is source of truth BY IMPORT for adopted scripts and BY TEST for the rest (design §10). Every value is
 # the live literal on main (c1df503) with the consuming file:line AT THAT COMMIT in a trailing comment
@@ -64,7 +64,7 @@ conventions:
 schema:
   task:
     extra_fields: {}                                    # initiative-task has no field beyond the shared base — no size (artifact_utils.py:190-227; pinned by test_initiative_task_no_size_field)
-    priority:                                           # validate_batch_input.py ALLOWED_PRIORITIES reads the rfe descriptor's enum for both types (registry-derived since PR-2a); artifact_utils.py:209 (initiative-task) still carries the literal, pinned equal by test
+    priority:                                           # validate_batch_input.py ALLOWED_PRIORITIES reads the rfe descriptor's enum for both types (registry-derived since PR-2a); artifact_utils.py:209 (initiative-task) held the literal until SCHEMAS derived it (PR-2b)
       enum: [Blocker, Critical, Major, Normal, Minor, Undefined]
       map_to_tracker: {}                                # identity map: the task vocabulary IS the Jira vocabulary (sent by name jira_utils.py:178)
   review:

--- a/types/rfe/type.yaml
+++ b/types/rfe/type.yaml
@@ -1,6 +1,6 @@
 # types/rfe/type.yaml — the rfe work-item type descriptor.
 # Contract: types/_schema/type.schema.json; design-proposals/work-item-types-unified.md §3.2 (§8.2 is the
-# initiative twin). Status (PR-2a): 18 scripts read this descriptor at import (types/README.md "Adoption
+# initiative twin). Status (PR-2b): 21 scripts read this descriptor at import (types/README.md "Adoption
 # status"); the values a pending script still carries are pinned equal to it by test, so the descriptor
 # is source of truth BY IMPORT for adopted scripts and BY TEST for the rest (design §10). Every value is
 # the live literal on main (c1df503) with the consuming file:line AT THAT COMMIT in a trailing comment
@@ -62,7 +62,7 @@ schema:
   task:
     extra_fields:                                       # rfe-task fields beyond the shared base (artifact_utils.py:61-107)
       size: { type: string, required: false, enum: [S, M, L, XL], default: null }   # artifact_utils.py:85-90; rebuild_index Size column :1141
-    priority:                                           # validate_batch_input.py ALLOWED_PRIORITIES reads THIS enum for BOTH types (registry-derived since PR-2a); artifact_utils.py:83 (rfe-task) still carries the literal, pinned equal by test
+    priority:                                           # validate_batch_input.py ALLOWED_PRIORITIES reads THIS enum for BOTH types (registry-derived since PR-2a); artifact_utils.py:83 (rfe-task) held the literal until SCHEMAS derived it (PR-2b)
       enum: [Blocker, Critical, Major, Normal, Minor, Undefined]
       map_to_tracker: {}                                # identity map: the task vocabulary IS the Jira vocabulary (sent by name jira_utils.py:178)
   review:


### PR DESCRIPTION
## Summary

PR-2b of the work-item-types design (§10 item 2), **stacked on #176**: the artifact schemas, the phase-check table and the three forked artifact_utils pairs adopt the registry. **Behavior is byte-identical**; the diff to review is this PR's four commits only (base is the PR-2a branch; GitHub retargets to main when #176 merges).

1. **`artifact_utils.SCHEMAS`** is derived per type from the descriptor (id field, local id grammar, priority enum, task extra fields, parent-key patterns, review score fields and extra fields) in today's key order. `tests/data/schemas-golden.json` freezes the pre-change literal and `tests/test_schemas_golden.py` asserts the derived schemas serialise to it byte for byte. That golden is permanent: the frontmatter schemas are an artifact contract, not a pin. The three forked pairs (`scan_task_files`, `rename_to_jira_key`, `parse_child_artifact` and their initiative twins) collapse into `scan_tasks`, `rename_to_tracker_key` and `parse_child` keyed on a descriptor, with the old names kept as wrappers so submit and split_submit are untouched. Each type keeps exactly its previous behavior; the three facts the descriptor cannot express yet (the rfe-only markdown fallbacks in parse_child, the rfe legacy review lookup, the per-type rename error label) are gated explicitly and cite PR-3. `find_review_file` routes through `detect()`. Two functions with no callers anywhere are deleted (`find_artifact_file`, `find_removed_context_file`). `frontmatter.py` derives its schema-by-directory table from the same descriptors.
2. **`check_review_progress.PHASE_CHECKS`** keeps its fourteen keys in today's order, built from each type's dirs, poll prefix and dimensions. The create row stays rfe-only behind an explicit grandfather naming PR-5; the fast-detection config allowlist stays literal, because deriving it would add the initiative speedrun config and change behavior (flagged for a deliberate follow-up).
3. **Residues** from PR-2a: check_conflicts, collect_children and generate_run_report call `scan_tasks(desc)` instead of selecting a scanner by type name. This also closes three of CodeRabbit's four comments on #176 (drop-in types reaching rfe-only paths).
4. **Pins and baseline**: schema, local-id, priority, phase-check and forked-pair pins retired into the MIGRATED list; prefix baseline 50 → 21 occurrences (12 → 11 files, artifact_utils at zero).

## Equivalence evidence

- Golden runs against the pristine PR-2a base on real eval artifact trees: `frontmatter.py schema` for all four names, `read` on every task and review, `set`, `rebuild-index`, `check_review_progress.py` for every phase with existing and missing ids and the create phase with valid and invalid frontmatter, check_conflicts, collect_children, generate_run_report with fixed timestamps, and a harness calling all six wrapped functions plus `find_review_file` with rfe, initiative, foreign and empty ids: identical stdout, exit codes, return values and trees. Independently reproduced by a reviewer and spot-checked by me.
- Suite: 1688 passed. ruff clean. `validate_types` OK. Prefix lint within the tightened baseline.
- The only observable divergence found in about 1400 synthetic and real operations: `find_review_file(dir, None)` now returns None where it used to raise AttributeError. Never a handled input.

## Notes

- Copying `scripts/` without `types/` beside it fails at import for every script now (artifact_utils loads the registry); the harness symlinks `scripts/`, the one test fixture that copied files was fixed in #176.
- Design wording to reconcile: §10 item 2 says the rename guards validate the tracker key against the key-prefix union; the guard checks the write prefix (the key we rename to), which equals today's literal. Recorded in the design branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Artifact schemas, scanning, renaming, parsing, and review-progress checks now derive from registered types.
  - Additional registered types can be supported without type-specific handling.
  - Frontmatter schema detection recognizes registered task and review directories.

- **Bug Fixes**
  - Improved handling for incomplete type definitions and custom directories.
  - Added validation for duplicate or conflicting workflow dimensions.
  - Added checks to keep generated schemas consistent.

- **Documentation**
  - Updated type-registry adoption status and schema requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->