### PR TITLE
Snapshot, bootstrap and fetch adopt the registry (design PR-2c)

### DIFF
--- a/docs/type-provider-guide.md
+++ b/docs/type-provider-guide.md
@@ -5,12 +5,15 @@ authoritative text lives. Design: `design-proposals/work-item-types-unified.md` 
 §3.2.1 (binding override), §3.3 (gates), §3.4 (provider obligations), §3.5 (discovery), §3.7
 (cross-type chain).
 
-**Status (PR-2b): 21 scripts read the registry at import** — the "Adoption status" table in
+**Status (PR-2c): 24 scripts read the registry at import** — the "Adoption status" table in
 [`types/README.md`](../types/README.md) lists them and what is still pending. Since PR-2b the
 artifact schemas (`artifact_utils.SCHEMAS`), the scan / rename / parse helpers and the poll phase
 table (`check_review_progress.PHASE_CHECKS`) are projections too, so a registered type gets its
 `<type>-task` / `<type>-review` schemas, its `<poll_prefix><phase>` rows and the generics without
-a code change. Every per-type value a pending script still carries is pinned by test to its
+a code change; since PR-2c so are the snapshot tables (`snapshot_fetch.SNAPSHOT_CONFIG`,
+`bootstrap_snapshot.BOOTSTRAP_CONFIG`) and the `fetch_issue.py --fetch-all` layout (`--type`,
+default `rfe`), so a registered type gets its hard-filter labels, snapshot / run-report file
+prefixes and fetch layout the same way. Every per-type value a pending script still carries is pinned by test to its
 descriptor projection; each adoption deletes its pin (design §10). Adopted scripts use descriptor
 values only; the effective binding override is not consulted until PR-3.
 
@@ -58,6 +61,20 @@ Rules that are easy to trip:
   `check_review_progress.PHASE_CHECKS` applies the same rule to `dirs.{tasks,reviews}` and
   `pipeline.poll_prefix`: a drop-in without them polls no phase. Copying `types/rfe/` keeps them
   all.
+- **Snapshot facts are read at import, for every type.** `snapshot_fetch.SNAPSHOT_CONFIG` reads
+  `conventions.labels.{ignore,split_quarantine}` and `snapshot.prefix`, and
+  `bootstrap_snapshot.BOOTSTRAP_CONFIG` reads `snapshot.report_prefix` and `reporting.item_key`,
+  over every registered type when the module is imported — and `submit.py` imports
+  `snapshot_fetch`. Gate 1 already requires `snapshot.prefix` and `snapshot.report_prefix`
+  (schema `$defs/snapshot`, the `else` branch of the `mode` conditional; the prefix is also
+  linted non-empty and collision-free) and `reporting.item_key`, but NOT
+  `conventions.labels.ignore` / `.split_quarantine` (`$defs/labels` is an open map with no
+  required keys), so a drop-in that omits either label passes `validate_types.py` and then fails
+  the import of `snapshot_fetch.py`, `bootstrap_snapshot.py` and `submit.py` with a `KeyError`
+  naming the type and the field. Copying `types/rfe/` keeps them; a third type must also pass
+  `prefix=` explicitly to the snapshot helpers (their default is the rfe `snapshot.prefix`).
+  `fetch_issue.py --fetch-all --type <t>` reads `dirs.{tasks,originals}`, `identity.id_field`
+  and `companions.comments` (all schema-required).
 - **Frozen strings (R7).** `conventions.labels.rubric_pass`, `conventions.removed_context_preamble`
   and the `{key}-strategy.md` attachment convention are consumed downstream; change them only with
   a migration note.

--- a/scripts/bootstrap_snapshot.py
+++ b/scripts/bootstrap_snapshot.py
@@ -31,6 +31,7 @@ from datetime import datetime, timezone
 import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import type_registry
 from jira_utils import api_call_with_retry, make_request, require_env
 from snapshot_fetch import (
     SNAPSHOT_CONFIG,
@@ -40,16 +41,27 @@ from snapshot_fetch import (
     fetch_all_issues,
 )
 
+_TYPES = type_registry.load()
+
+# Per-type run-report facts, projected from the type descriptors: the report file prefix
+# is snapshot.report_prefix (rfe's is the grandfathered empty string — its reports are
+# bare <run>.yaml) and the entry-list key is reporting.item_key. Same keys, same order and
+# same values as the literal table this replaces; generate_run_report.py writes from the
+# same two fields and tests/test_report_roundtrip.py round-trips the pair through the CLI.
 BOOTSTRAP_CONFIG = {
-    "rfe": {
-        "report_prefix": "",
-        "item_key": "per_rfe",
-    },
-    "initiative": {
-        "report_prefix": "initiative-run-",
-        "item_key": "per_initiative",
-    },
+    name: {
+        "report_prefix": _TYPES.get(name).get("snapshot.report_prefix"),
+        "item_key": _TYPES.get(name).get("reporting.item_key"),
+    }
+    for name in _TYPES.names()
 }
+
+# Grandfathered probe prefix: _run_dir_has_snapshots looks for the rfe snapshot prefix
+# ("issue-snapshot-") whatever --type is running, exactly as the pre-registry literal did,
+# so an initiative results directory is never recognised as partial. Reading the value
+# from the rfe descriptor changes nothing; making the probe per-type (the selected type's
+# snapshot.prefix) is a deliberate follow-up (design §10 PR-10, latent initiative-CI bugs).
+_RFE_SNAPSHOT_PREFIX = _TYPES.get("rfe").get("snapshot.prefix")
 
 
 def _load_run_report(results_dir, run_name, config=None):
@@ -173,7 +185,7 @@ def _run_dir_has_snapshots(results_dir, run_name):
     if not os.path.isdir(run_dir):
         return False
     return any(
-        name.startswith("issue-snapshot-") and name.endswith(".yaml")
+        name.startswith(_RFE_SNAPSHOT_PREFIX) and name.endswith(".yaml")
         for name in os.listdir(run_dir)
     )
 
@@ -416,7 +428,7 @@ def main():
     )
     parser.add_argument(
         "--type",
-        choices=["rfe", "initiative"],
+        choices=_TYPES.choices(),
         default="rfe",
         help="Issue type (default: rfe)",
     )

--- a/scripts/fetch_issue.py
+++ b/scripts/fetch_issue.py
@@ -31,7 +31,12 @@ import shutil
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import type_registry
 from jira_utils import adf_to_markdown, get_comments, get_issue, require_env
+
+_TYPES = type_registry.load()
 
 
 def _desc_to_markdown(desc_raw):
@@ -51,13 +56,19 @@ def _format_comment_date(iso_date):
     return iso_date[:10]
 
 
-def _fetch_all(issue_key, artifacts_dir, server, user, token):
-    """Fetch issue and write all artifact files.
+def _fetch_all(issue_key, artifacts_dir, server, user, token, type_name="rfe"):
+    """Fetch issue and write all artifact files for one work-item type.
 
-    Returns 0 on success, 1 on error.
+    The artifact layout is the ``type_name`` descriptor's (design
+    work-item-types-unified.md §10 item 2): the task and original directories
+    are ``dirs.tasks`` / ``dirs.originals``, the frontmatter id field is
+    ``identity.id_field`` and the ``<KEY>-comments.md`` companion is written
+    only when ``companions.comments`` is true. Returns 0 on success, 1 on error.
     """
-    tasks_dir = os.path.join(artifacts_dir, "rfe-tasks")
-    originals_dir = os.path.join(artifacts_dir, "rfe-originals")
+    desc = _TYPES.get(type_name)
+    dirs = desc.dirs(form="bare")
+    tasks_dir = os.path.join(artifacts_dir, dirs["tasks"])
+    originals_dir = os.path.join(artifacts_dir, dirs["originals"])
     os.makedirs(tasks_dir, exist_ok=True)
     os.makedirs(originals_dir, exist_ok=True)
 
@@ -79,7 +90,11 @@ def _fetch_all(issue_key, artifacts_dir, server, user, token):
     fields = issue.get("fields", {})
     desc_md = _desc_to_markdown(fields.get("description"))
 
-    # Extract field values
+    # Extract field values. The "Major" fallback below and status=Ready in the
+    # frontmatter are shared pipeline conventions, not type facts: every type's
+    # task schema carries the same priority vocabulary and status enum
+    # (artifact_utils._STATUS_ENUM), so they stay literal here rather than
+    # being read from the descriptor.
     summary = fields.get("summary", "")
     priority_obj = fields.get("priority")
     priority = priority_obj.get("name", "Major") if isinstance(priority_obj, dict) else "Major"
@@ -97,7 +112,7 @@ def _fetch_all(issue_key, artifacts_dir, server, user, token):
         "scripts/frontmatter.py",
         "set",
         task_path,
-        f"rfe_id={issue_key}",
+        f"{desc.id_field}={issue_key}",
         f"title={summary}",
         f"priority={priority}",
         "status=Ready",
@@ -114,32 +129,37 @@ def _fetch_all(issue_key, artifacts_dir, server, user, token):
     with open(orig_path, "w", encoding="utf-8") as f:
         f.write(desc_md + "\n")
 
-    # Fetch and write comments
-    try:
-        comments = get_comments(server, user, token, issue_key)
-    except Exception as e:
-        print(f"Error fetching comments for {issue_key}: {e}", file=sys.stderr)
-        return 1
+    written = [task_path, orig_path]
 
-    comments_path = os.path.join(tasks_dir, f"{issue_key}-comments.md")
-    with open(comments_path, "w", encoding="utf-8") as f:
-        f.write(f"# Comments: {issue_key}\n\n")
-        if not comments:
-            f.write("No comments found.\n")
-        else:
-            for c in comments:
-                author = c.get("author", {}).get("displayName", "Unknown")
-                date = _format_comment_date(c.get("created", ""))
-                body = c.get("body", {})
-                if isinstance(body, dict):
-                    body = adf_to_markdown(body).strip()
-                elif body is not None:
-                    body = str(body).strip()
-                else:
-                    body = ""
-                f.write(f"## {author} — {date}\n\n{body}\n\n")
+    # Fetch and write comments — only for types whose fetch step produces the
+    # companion (companions.comments); no comment request is made otherwise.
+    if desc.get("companions.comments"):
+        try:
+            comments = get_comments(server, user, token, issue_key)
+        except Exception as e:
+            print(f"Error fetching comments for {issue_key}: {e}", file=sys.stderr)
+            return 1
 
-    print(f"OK: wrote {task_path}, {orig_path}, {comments_path}")
+        comments_path = os.path.join(tasks_dir, f"{issue_key}-comments.md")
+        with open(comments_path, "w", encoding="utf-8") as f:
+            f.write(f"# Comments: {issue_key}\n\n")
+            if not comments:
+                f.write("No comments found.\n")
+            else:
+                for c in comments:
+                    author = c.get("author", {}).get("displayName", "Unknown")
+                    date = _format_comment_date(c.get("created", ""))
+                    body = c.get("body", {})
+                    if isinstance(body, dict):
+                        body = adf_to_markdown(body).strip()
+                    elif body is not None:
+                        body = str(body).strip()
+                    else:
+                        body = ""
+                    f.write(f"## {author} — {date}\n\n{body}\n\n")
+        written.append(comments_path)
+
+    print(f"OK: wrote {', '.join(written)}")
     return 0
 
 
@@ -164,6 +184,16 @@ def main():
         help="Fetch issue and write all artifact files "
         "(rfe-tasks, rfe-originals, comments) to "
         "the given directory.",
+    )
+    parser.add_argument(
+        "--type",
+        choices=_TYPES.choices(),
+        default="rfe",
+        help="Work-item type whose artifact layout --fetch-all "
+        "writes: task and original directories, frontmatter "
+        "id field and comments companion come from "
+        "types/<type>/type.yaml (default: rfe). Not used by "
+        "the other modes.",
     )
 
     parser.add_argument(
@@ -194,7 +224,7 @@ def main():
                 file=sys.stderr,
             )
             sys.exit(2)
-        rc = _fetch_all(args.issue_key, args.fetch_all, server, user, token)
+        rc = _fetch_all(args.issue_key, args.fetch_all, server, user, token, args.type)
         sys.exit(rc)
 
     # --write-original-only mode: no --fields means caller just wants

--- a/scripts/snapshot_fetch.py
+++ b/scripts/snapshot_fetch.py
@@ -43,6 +43,7 @@ from datetime import datetime, timezone
 import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import type_registry
 from jira_utils import (
     adf_to_markdown,
     api_call_with_retry,
@@ -53,18 +54,27 @@ from jira_utils import (
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 SNAPSHOT_DIR = os.path.join(SCRIPT_DIR, "..", "artifacts", "auto-fix-runs")
 
+_TYPES = type_registry.load()
+
+# Per-type snapshot facts, projected from the type descriptors (types/<type>/type.yaml,
+# design work-item-types-unified.md §10 item 2): the hard-filter labels are
+# conventions.labels.{ignore,split_quarantine} and the snapshot file prefix is
+# snapshot.prefix. Same keys, same order and same values as the literal table this
+# replaces, so the JQL wrapper and the snapshot file names are unchanged byte for byte.
 SNAPSHOT_CONFIG = {
-    "rfe": {
-        "ignore_label": "rfe-creator-ignore",
-        "quarantine_label": "rfe-creator-split-quarantine",
-        "snapshot_prefix": "issue-snapshot-",
-    },
-    "initiative": {
-        "ignore_label": "initiative-ignore",
-        "quarantine_label": "initiative-split-quarantine",
-        "snapshot_prefix": "initiative-snapshot-",
-    },
+    name: {
+        "ignore_label": _TYPES.get(name).get("conventions.labels.ignore"),
+        "quarantine_label": _TYPES.get(name).get("conventions.labels.split_quarantine"),
+        "snapshot_prefix": _TYPES.get(name).get("snapshot.prefix"),
+    }
+    for name in _TYPES.names()
 }
+
+# The rfe snapshot prefix ("issue-snapshot-") doubles as the default `prefix=` of the
+# reader and writer helpers below: submit.py relies on that default for rfe (its config
+# holds "" as a sentinel for it), and a third type must always pass prefix= explicitly.
+# Bound once at import, so the signatures' defaults keep the value they always had.
+_RFE_SNAPSHOT_PREFIX = _TYPES.get("rfe").get("snapshot.prefix")
 
 
 def normalize_for_hash(text):
@@ -142,7 +152,7 @@ def fetch_all_issues(server, user, token, jql):
     return issues
 
 
-def find_previous_snapshot(snapshot_dir=None, prefix="issue-snapshot-"):
+def find_previous_snapshot(snapshot_dir=None, prefix=_RFE_SNAPSHOT_PREFIX):
     """Find the most recent valid promoted snapshot.
 
     Walks backwards through <prefix>*.yaml files sorted by name
@@ -163,7 +173,7 @@ def find_previous_snapshot(snapshot_dir=None, prefix="issue-snapshot-"):
     return None, None
 
 
-def load_snapshot_from_dir(data_dir, prefix="issue-snapshot-"):
+def load_snapshot_from_dir(data_dir, prefix=_RFE_SNAPSHOT_PREFIX):
     """Find the previous snapshot in a local data directory.
 
     Follows the 'latest' symlink to find the most recent run, then
@@ -281,7 +291,7 @@ def write_id_file(path, ids):
 
 
 def update_snapshot_hashes(
-    hashes, snapshot_dir=None, mark_processed=None, prefix="issue-snapshot-"
+    hashes, snapshot_dir=None, mark_processed=None, prefix=_RFE_SNAPSHOT_PREFIX
 ):
     """Update the latest snapshot with post-submit content hashes.
 
@@ -492,7 +502,7 @@ def main():
     fetch_p.add_argument("jql", nargs="?", default=None, help="JQL query string")
     fetch_p.add_argument(
         "--type",
-        choices=["rfe", "initiative"],
+        choices=_TYPES.choices(),
         default="rfe",
         help="Issue type (default: rfe)",
     )

--- a/tests/data/prefix_predicate_baseline.json
+++ b/tests/data/prefix_predicate_baseline.json
@@ -1,13 +1,11 @@
 {
   "scripts/batch_summary.py": 1,
-  "scripts/bootstrap_snapshot.py": 2,
   "scripts/cleanup_partial_split.py": 1,
   "scripts/clone_results_repo.py": 1,
   "scripts/collect_children.py": 1,
   "scripts/fetch_issue.py": 1,
   "scripts/jira_utils.py": 1,
   "scripts/pipeline_state.py": 1,
-  "scripts/snapshot_fetch.py": 5,
   "scripts/submit.py": 5,
   "scripts/validate_batch_input.py": 2
 }

--- a/tests/test_bootstrap_snapshot.py
+++ b/tests/test_bootstrap_snapshot.py
@@ -6,6 +6,7 @@ import json
 import os
 import subprocess
 import sys
+import textwrap
 import threading
 import urllib.parse
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -17,11 +18,14 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "bootstrap_snapshot.py")
 
+import type_registry  # noqa: E402
 from bootstrap_snapshot import (  # noqa: E402
+    _RFE_SNAPSHOT_PREFIX,
     BOOTSTRAP_CONFIG,
     _description_at_time,
     _load_run_report,
     _parse_adf,
+    _run_dir_has_snapshots,
     find_latest_run_timestamp,
 )
 from snapshot_fetch import normalize_for_hash  # noqa: E402
@@ -1696,3 +1700,120 @@ class TestBootstrapInitiativeType:
         rfe_snaps = [f for f in snap_files if f.startswith("issue-snapshot-")]
         assert len(init_snaps) == 1
         assert len(rfe_snaps) == 0
+
+
+# ── Registry-derived BOOTSTRAP_CONFIG and the grandfathered probe (work-item-types PR-2c) ──
+
+# Hermetic: the developer's RFE_CREATOR_EXTRA_TYPES / RFE_CREATOR_BINDING_* never leak in.
+REG = type_registry.load(extra_roots=[], env={})
+
+
+def _dropin_root(tmp_path):
+    """A minimal third type under a drop-in root (registry env seam, dev/test only)."""
+    root = tmp_path / "types"
+    (root / "docs").mkdir(parents=True)
+    (root / "docs" / "type.yaml").write_text(
+        textwrap.dedent(
+            """\
+            schema_version: 1
+            type: docs
+            identity:
+              tracker: jira
+              jira: {project: DOCS, issue_type: Task, key_prefixes: ["DOCS-"]}
+              local_prefix: "DOC-"
+              id_field: doc_id
+            dirs: {tasks: artifacts/doc-tasks, originals: artifacts/doc-originals}
+            conventions:
+              labels: {ignore: docs-ignore, split_quarantine: docs-split-quarantine}
+            snapshot: {prefix: docs-snapshot-, report_prefix: docs-run-}
+            reporting: {item_key: per_doc}
+            """
+        )
+    )
+    return str(root)
+
+
+def _clean_env(**extra):
+    env = {k: v for k, v in os.environ.items() if not k.startswith("RFE_CREATOR_")}
+    env.update(extra)
+    return env
+
+
+class TestBootstrapConfigDerivesFromTheRegistry:
+    def test_values_are_the_pre_registry_literals(self):
+        # Behaviour-neutral migration: same keys, same order, same values as the literal table
+        # this replaced (rfe's empty report prefix is grandfathered: its reports are <run>.yaml).
+        assert BOOTSTRAP_CONFIG == {
+            "rfe": {"report_prefix": "", "item_key": "per_rfe"},
+            "initiative": {"report_prefix": "initiative-run-", "item_key": "per_initiative"},
+        }
+        assert list(BOOTSTRAP_CONFIG) == ["rfe", "initiative"]
+        for config in BOOTSTRAP_CONFIG.values():
+            assert list(config) == ["report_prefix", "item_key"]
+
+    @pytest.mark.parametrize("type_name", REG.names())
+    def test_projection_from_the_descriptor(self, type_name):
+        desc = REG.get(type_name)
+        bc = BOOTSTRAP_CONFIG[type_name]
+        assert bc["report_prefix"] == desc.get("snapshot.report_prefix")
+        assert bc["item_key"] == desc.get("reporting.item_key")
+
+    def test_type_choices_are_the_registry_choices(self):
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--help"], capture_output=True, text=True, env=_clean_env()
+        )
+        assert result.returncode == 0
+        assert "--type {rfe,initiative}" in result.stdout
+
+    def test_a_drop_in_type_is_offered_and_configured(self, tmp_path):
+        root = _dropin_root(tmp_path)
+        env = _clean_env(
+            RFE_CREATOR_EXTRA_TYPES=root,
+            RFE_CREATOR_EXTRA_TYPES_ALLOWLIST=root,
+            JIRA_SERVER="http://127.0.0.1:9",
+            JIRA_USER="u",
+            JIRA_TOKEN="t",
+        )
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--help"], capture_output=True, text=True, env=env
+        )
+        assert "--type {rfe,docs,initiative}" in result.stdout
+        # Both per-type tables are indexed before the first Jira call; an empty results dir
+        # stops the run at the offline gate right after, so this proves the drop-in type is
+        # configured end to end without a server.
+        results = tmp_path / "results"
+        results.mkdir()
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--type", "docs", "--results-dir", str(results), "x"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 1
+        assert result.stderr == "Error: no valid run directories found\n"
+
+
+class TestRunDirSnapshotProbeIsGrandfatheredToTheRfePrefix:
+    """_run_dir_has_snapshots probes for the rfe snapshot prefix whatever --type is running —
+    the pre-registry literal 'issue-snapshot-', now read from the rfe descriptor. Making the
+    probe per-type is a deliberate follow-up; this pins today's behaviour so that change is a
+    visible test change and not a silent one."""
+
+    def _plant(self, tmp_path, run, filename):
+        path = tmp_path / run / "auto-fix-runs" / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("issues: {}\n")
+
+    def test_probe_prefix_is_the_rfe_descriptor_snapshot_prefix(self):
+        assert _RFE_SNAPSHOT_PREFIX == REG.get("rfe").get("snapshot.prefix") == "issue-snapshot-"
+
+    @pytest.mark.parametrize("type_name", REG.names())
+    def test_only_rfe_prefixed_snapshots_are_seen(self, tmp_path, type_name):
+        prefix = REG.get(type_name).get("snapshot.prefix")
+        self._plant(tmp_path, "run", f"{prefix}20260401-120000.yaml")
+        assert _run_dir_has_snapshots(str(tmp_path), "run") is (type_name == "rfe")
+
+    def test_non_yaml_and_missing_dir_are_not_snapshots(self, tmp_path):
+        self._plant(tmp_path, "run", "issue-snapshot-20260401-120000.yaml.bak")
+        assert _run_dir_has_snapshots(str(tmp_path), "run") is False
+        assert _run_dir_has_snapshots(str(tmp_path), "missing") is False

--- a/tests/test_fetch_issue.py
+++ b/tests/test_fetch_issue.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""Tests for scripts/fetch_issue.py — the type-aware ``--fetch-all`` artifact writer.
+
+design-proposals/work-item-types-unified.md §10 item 2 ("fetch_issue.py --fetch-all made
+type-aware"): the task and original directories (``dirs.tasks`` / ``dirs.originals``), the
+frontmatter id field (``identity.id_field``) and whether a ``<KEY>-comments.md`` companion is
+produced (``companions.comments``) are read from the selected type's descriptor. ``--type`` is
+additive: the rfe invocation every skill issues today (no ``--type``) is byte-identical to the
+pre-registry script — the golden bytes below were captured on main c1df503 and are literals on
+purpose. The priority fallback ``Major`` and ``status=Ready`` are shared pipeline conventions,
+not type facts, and stay literal in the script.
+
+Unit tests monkeypatch the two Jira reads; the last class drives the script as a subprocess
+against the jira-emulator (``jira`` fixture, tests/conftest.py).
+"""
+
+import io
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from contextlib import redirect_stdout
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import fetch_issue  # noqa: E402
+import type_registry  # noqa: E402
+from artifact_utils import read_frontmatter, read_frontmatter_validated  # noqa: E402
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SCRIPT = os.path.join(REPO_ROOT, "scripts", "fetch_issue.py")
+REG = type_registry.load(extra_roots=[], env={})
+
+JIRA_ENV = {"JIRA_SERVER": "http://x", "JIRA_USER": "u", "JIRA_TOKEN": "t"}
+DEFAULT_FIELDS = ["summary", "description", "priority", "labels", "status", "issuetype"]
+
+
+def _clean_env(**extra):
+    # Subprocess env without the registry's RFE_CREATOR_* seam: a developer's
+    # RFE_CREATOR_EXTRA_TYPES would otherwise widen --type's choices in the child.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("RFE_CREATOR_")}
+    env.update(extra)
+    return env
+
+
+# ── fixtures: one issue, two comments, the c1df503 golden artifacts ───────────────────────────
+
+DESC_MD = (
+    "## Problem\n\n"
+    "Data scientists cannot export registered models to S3-compatible storage.\n\n"
+    "- Manual copies drift from the registry\n- No audit trail\n"
+)
+
+
+def _paragraph(text):
+    return {"type": "paragraph", "content": [{"type": "text", "text": text}]}
+
+
+ADF = {
+    "type": "doc",
+    "version": 1,
+    "content": [
+        {
+            "type": "heading",
+            "attrs": {"level": 2},
+            "content": [{"type": "text", "text": "Problem"}],
+        },
+        _paragraph("Data scientists cannot export registered models to S3-compatible storage."),
+        {
+            "type": "bulletList",
+            "content": [
+                {
+                    "type": "listItem",
+                    "content": [_paragraph("Manual copies drift from the registry")],
+                },
+                {"type": "listItem", "content": [_paragraph("No audit trail")]},
+            ],
+        },
+    ],
+}
+
+ISSUE = {
+    "key": "RHAIRFE-1595",
+    "fields": {
+        "summary": "Add model registry export to S3-compatible storage",
+        "description": ADF,
+        "priority": {"name": "Major"},
+        "labels": ["rfe-creator-autofix-rubric-pass", "customer-request"],
+        "status": {"name": "New"},
+        "issuetype": {"name": "Feature Request", "id": "10700"},
+    },
+}
+
+COMMENTS = [
+    {
+        "author": {"displayName": "Jane Doe"},
+        "created": "2025-01-15T10:30:00.000+0000",
+        "body": {
+            "type": "doc",
+            "version": 1,
+            "content": [_paragraph("Acme Corp asked for this twice.")],
+        },
+    },
+    {
+        "author": {"displayName": "John Roe"},
+        "created": "2025-02-01T08:00:00.000+0000",
+        "body": "Plain string body.",
+    },
+]
+
+# Captured on main c1df503 by running _fetch_all over ISSUE/COMMENTS (no --type existed).
+GOLDEN_TASK = (
+    b"---\nrfe_id: RHAIRFE-1595\ntitle: Add model registry export to S3-compatible storage\n"
+    b"priority: Major\nstatus: Ready\noriginal_labels:\n- rfe-creator-autofix-rubric-pass\n"
+    b"- customer-request\nlocal_id: null\nsize: null\nparent_key: null\n---\n" + DESC_MD.encode()
+)
+GOLDEN_ORIGINAL = DESC_MD.encode()
+GOLDEN_COMMENTS = (
+    "# Comments: RHAIRFE-1595\n\n"
+    "## Jane Doe — 2025-01-15\n\nAcme Corp asked for this twice.\n\n"
+    "## John Roe — 2025-02-01\n\nPlain string body.\n\n"
+).encode("utf-8")
+
+
+def _issue_for(key):
+    """ISSUE re-keyed; an initiative key carries no priority (exercises the Major fallback)."""
+    fields = dict(ISSUE["fields"])
+    if key.startswith(REG.get("initiative").write_prefix):
+        fields["priority"] = None
+        fields["labels"] = []
+        fields["issuetype"] = {"name": "Initiative", "id": "10103"}
+    return {"key": key, "fields": fields}
+
+
+@pytest.fixture
+def fake_jira(monkeypatch):
+    """Monkeypatch the two Jira reads and record every call; cwd is the repo root because
+    _fetch_all shells out to scripts/frontmatter.py by relative path."""
+    calls = {"issue": [], "comments": []}
+
+    def fake_get_issue(server, user, token, key, fields=None):
+        calls["issue"].append((key, list(fields) if fields else fields))
+        return _issue_for(key)
+
+    def fake_get_comments(server, user, token, key):
+        calls["comments"].append(key)
+        return COMMENTS
+
+    monkeypatch.setattr(fetch_issue, "get_issue", fake_get_issue)
+    monkeypatch.setattr(fetch_issue, "get_comments", fake_get_comments)
+    for var, value in JIRA_ENV.items():
+        monkeypatch.setenv(var, value)
+    monkeypatch.chdir(REPO_ROOT)
+    return calls
+
+
+def _fetch_all(key, artifacts, **kwargs):
+    """Run _fetch_all in-process; returns (rc, stdout)."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = fetch_issue._fetch_all(key, str(artifacts), "http://x", "u", "t", **kwargs)
+    return rc, buf.getvalue()
+
+
+def _main(monkeypatch, *argv):
+    """Run main() in-process; returns (exit code, stdout). --fetch-all always sys.exit()s;
+    the JSON modes return normally, which is exit 0."""
+    monkeypatch.setattr(sys, "argv", ["fetch_issue.py", *argv])
+    buf = io.StringIO()
+    code = 0
+    with redirect_stdout(buf):
+        try:
+            fetch_issue.main()
+        except SystemExit as exc:
+            code = exc.code
+    return code, buf.getvalue()
+
+
+def _tree(root):
+    """{relative path: bytes} for every file under root."""
+    out = {}
+    for dirpath, _, files in os.walk(root):
+        for name in files:
+            path = os.path.join(dirpath, name)
+            with open(path, "rb") as f:
+                out[os.path.relpath(path, root)] = f.read()
+    return out
+
+
+# ── the rfe invocation is unchanged ──────────────────────────────────────────────────────────
+
+
+class TestRfeInvocationIsByteIdentical:
+    def test_default_type_writes_the_c1df503_golden_bytes(self, tmp_path, fake_jira):
+        artifacts = tmp_path / "artifacts"
+        rc, out = _fetch_all("RHAIRFE-1595", artifacts)
+        assert rc == 0
+        task = artifacts / "rfe-tasks" / "RHAIRFE-1595.md"
+        original = artifacts / "rfe-originals" / "RHAIRFE-1595.md"
+        comments = artifacts / "rfe-tasks" / "RHAIRFE-1595-comments.md"
+        assert task.read_bytes() == GOLDEN_TASK
+        assert original.read_bytes() == GOLDEN_ORIGINAL
+        assert comments.read_bytes() == GOLDEN_COMMENTS
+        assert _tree(artifacts).keys() == {
+            "rfe-tasks/RHAIRFE-1595.md",
+            "rfe-originals/RHAIRFE-1595.md",
+            "rfe-tasks/RHAIRFE-1595-comments.md",
+        }
+        assert out == f"OK: wrote {task}, {original}, {comments}\n"
+        # The request lists are PR-1's (issuetype requested, nothing written reads it) and the
+        # comments are fetched exactly once, after the issue.
+        assert fake_jira["issue"] == [("RHAIRFE-1595", DEFAULT_FIELDS)]
+        assert fake_jira["comments"] == ["RHAIRFE-1595"]
+
+    def test_explicit_type_rfe_equals_no_type(self, tmp_path, monkeypatch, fake_jira):
+        implicit = tmp_path / "implicit"
+        explicit = tmp_path / "explicit"
+        code_a, out_a = _main(monkeypatch, "RHAIRFE-1595", "--fetch-all", str(implicit))
+        code_b, out_b = _main(
+            monkeypatch, "RHAIRFE-1595", "--fetch-all", str(explicit), "--type", "rfe"
+        )
+        assert code_a == code_b == 0
+        assert _tree(implicit) == _tree(explicit)
+        assert out_a.replace(str(implicit), "<dir>") == out_b.replace(str(explicit), "<dir>")
+        assert _tree(implicit)["rfe-tasks/RHAIRFE-1595.md"] == GOLDEN_TASK
+
+    def test_fetch_all_signature_is_backward_compatible(self, tmp_path, fake_jira):
+        # Positional five-argument callers (tests/test_pr1_transparent_edits.py) still work and
+        # still mean rfe.
+        rc = fetch_issue._fetch_all("RHAIRFE-1595", str(tmp_path), "http://x", "u", "t")
+        assert rc == 0
+        assert (tmp_path / "rfe-tasks" / "RHAIRFE-1595.md").read_bytes() == GOLDEN_TASK
+
+
+# ── the initiative layout ────────────────────────────────────────────────────────────────────
+
+
+class TestInitiativeLayout:
+    def test_writes_initiative_dirs_id_field_and_no_comments(self, tmp_path, fake_jira):
+        artifacts = tmp_path / "artifacts"
+        rc, out = _fetch_all("RHOAIENG-12345", artifacts, type_name="initiative")
+        assert rc == 0
+        task = artifacts / "initiatives" / "RHOAIENG-12345.md"
+        original = artifacts / "initiative-originals" / "RHOAIENG-12345.md"
+        assert _tree(artifacts).keys() == {
+            "initiatives/RHOAIENG-12345.md",
+            "initiative-originals/RHOAIENG-12345.md",
+        }
+        assert out == f"OK: wrote {task}, {original}\n"
+        # companions.comments is false for initiative: no companion AND no comment request.
+        assert fake_jira["comments"] == []
+        assert fake_jira["issue"] == [("RHOAIENG-12345", DEFAULT_FIELDS)]
+
+        data, body = read_frontmatter_validated(str(task), "initiative-task")
+        assert data["initiative_id"] == "RHOAIENG-12345"
+        assert "rfe_id" not in data
+        assert data["title"] == ISSUE["fields"]["summary"]
+        assert data["priority"] == "Major"  # fallback: the issue carries no priority
+        assert data["status"] == "Ready"
+        assert data["original_labels"] is None  # no labels -> null, as for rfe
+        assert body == DESC_MD
+        assert original.read_bytes() == GOLDEN_ORIGINAL
+
+    def test_frontmatter_bytes(self, tmp_path, fake_jira):
+        # The initiative-task schema's field order and defaults (no `size`, parent_key null),
+        # written by scripts/frontmatter.py exactly as the initiative fetch agent hand-built it.
+        rc, _ = _fetch_all("RHOAIENG-12345", tmp_path, type_name="initiative")
+        assert rc == 0
+        assert (tmp_path / "initiatives" / "RHOAIENG-12345.md").read_bytes() == (
+            b"---\ninitiative_id: RHOAIENG-12345\n"
+            b"title: Add model registry export to S3-compatible storage\n"
+            b"priority: Major\nstatus: Ready\noriginal_labels: null\nlocal_id: null\n"
+            b"parent_key: null\n---\n" + DESC_MD.encode()
+        )
+
+    def test_cli_type_initiative(self, tmp_path, monkeypatch, fake_jira):
+        code, out = _main(
+            monkeypatch, "RHOAIENG-12345", "--fetch-all", str(tmp_path), "--type", "initiative"
+        )
+        assert code == 0
+        assert _tree(tmp_path).keys() == {
+            "initiatives/RHOAIENG-12345.md",
+            "initiative-originals/RHOAIENG-12345.md",
+        }
+        assert out.startswith("OK: wrote ")
+        assert "comments" not in out
+
+
+# ── every registered type: the layout is the descriptor projection ───────────────────────────
+
+
+class TestLayoutIsTheDescriptorProjection:
+    @pytest.mark.parametrize("type_name", REG.names())
+    def test_dirs_id_field_and_companion_follow_the_descriptor(
+        self, tmp_path, fake_jira, type_name
+    ):
+        desc = REG.get(type_name)
+        key = f"{desc.write_prefix}42"
+        bare = desc.dirs(form="bare")
+        rc, out = _fetch_all(key, tmp_path, type_name=type_name)
+        assert rc == 0
+
+        task = tmp_path / bare["tasks"] / f"{key}.md"
+        original = tmp_path / bare["originals"] / f"{key}.md"
+        comments = tmp_path / bare["tasks"] / f"{key}-comments.md"
+        expected = {task, original}
+        if desc.get("companions.comments"):
+            expected.add(comments)
+        assert {tmp_path / rel for rel in _tree(tmp_path)} == expected
+        assert (
+            out
+            == "OK: wrote "
+            + ", ".join(str(p) for p in (task, original, comments)[: len(expected)])
+            + "\n"
+        )
+
+        data, _ = read_frontmatter(str(task))
+        assert list(data)[0] == desc.id_field
+        assert data[desc.id_field] == key
+        assert (fake_jira["comments"] == [key]) is bool(desc.get("companions.comments"))
+
+
+def _dropin_root(tmp_path):
+    """A third type under a drop-in root (registry env seam, dev/test only) that declares the
+    facts artifact_utils needs to build its task schema, its own dirs and a comments companion.
+    """
+    root = tmp_path / "types"
+    (root / "docs").mkdir(parents=True)
+    (root / "docs" / "type.yaml").write_text(
+        textwrap.dedent(
+            """\
+            schema_version: 1
+            type: docs
+            identity:
+              tracker: jira
+              jira: {project: DOCS, issue_type: Task, key_prefixes: ["DOCS-"]}
+              local_prefix: "DOC-"
+              local_id_pattern: "DOC-\\\\d+"
+              id_field: doc_id
+            dirs:
+              tasks: artifacts/doc-tasks
+              originals: artifacts/doc-originals
+              reviews: artifacts/doc-reviews
+            companions: {comments: true, removed_context: false}
+            conventions:
+              parent_key_patterns: ["DOCS-\\\\d+"]
+            schema:
+              task: {priority: {enum: [Blocker, Critical, Major, Normal, Minor, Undefined]}}
+              review: {score_fields: [what, why]}
+            """
+        )
+    )
+    return str(root)
+
+
+class TestDropInType:
+    def test_a_third_type_writes_its_own_layout(self, tmp_path, monkeypatch, fake_jira):
+        # Type-aware means every registered type, not an rfe/initiative fork: a drop-in with
+        # companions.comments true gets its dirs, its id field AND the comments companion.
+        root = _dropin_root(tmp_path)
+        # The frontmatter.py subprocess must see the same registry (allowlisted for CI runs).
+        monkeypatch.setenv("RFE_CREATOR_EXTRA_TYPES", root)
+        monkeypatch.setenv("RFE_CREATOR_EXTRA_TYPES_ALLOWLIST", root)
+        monkeypatch.setattr(fetch_issue, "_TYPES", type_registry.load(extra_roots=[root]))
+
+        artifacts = tmp_path / "artifacts"
+        rc, out = _fetch_all("DOCS-7", artifacts, type_name="docs")
+        assert rc == 0
+        assert _tree(artifacts).keys() == {
+            "doc-tasks/DOCS-7.md",
+            "doc-originals/DOCS-7.md",
+            "doc-tasks/DOCS-7-comments.md",
+        }
+        data, _ = read_frontmatter(str(artifacts / "doc-tasks" / "DOCS-7.md"))
+        assert data["doc_id"] == "DOCS-7"
+        assert (artifacts / "doc-tasks" / "DOCS-7-comments.md").read_bytes() == (
+            GOLDEN_COMMENTS.replace(b"RHAIRFE-1595", b"DOCS-7")
+        )
+        assert fake_jira["comments"] == ["DOCS-7"]
+
+    def test_help_offers_the_drop_in(self, tmp_path):
+        root = _dropin_root(tmp_path)
+        env = _clean_env(RFE_CREATOR_EXTRA_TYPES=root, RFE_CREATOR_EXTRA_TYPES_ALLOWLIST=root)
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--help"], capture_output=True, text=True, env=env
+        )
+        assert result.returncode == 0
+        assert "--type {rfe,docs,initiative}" in result.stdout
+
+
+# ── CLI surface ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestCli:
+    def test_help_offers_the_registry_choices_and_keeps_the_fetch_all_text(self):
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--help"], capture_output=True, text=True, env=_clean_env()
+        )
+        assert result.returncode == 0
+        assert "--type {" + ",".join(REG.choices()) + "}" in result.stdout
+        assert "--type {rfe,initiative}" in result.stdout
+        # The pre-registry --fetch-all sentence is byte-identical (argparse re-wraps it). Its
+        # "(rfe-tasks, rfe-originals, comments)" wording is deliberately stale for
+        # --type initiative: PR-2c keeps --help byte-identical apart from the new --type block.
+        # The follow-up that makes the help type-neutral may reword it and update this pin;
+        # the pin is not a requirement to keep the sentence.
+        assert (
+            "Fetch issue and write all artifact files (rfe-tasks,\n"
+            "                        rfe-originals, comments) to the given directory."
+        ) in result.stdout
+        assert "(default: rfe)" in result.stdout
+
+    def test_source_keeps_the_pre_registry_help_and_the_shared_conventions(self):
+        with open(SCRIPT, encoding="utf-8") as f:
+            source = f.read()
+        # The "(rfe-tasks, rfe-originals, comments)" sentence is deliberately stale for
+        # --type initiative (kept so --help changes only by the --type block in PR-2c); the
+        # follow-up that makes the help type-neutral may reword it and update this pin.
+        assert (
+            'help="Fetch issue and write all artifact files "\n'
+            '        "(rfe-tasks, rfe-originals, comments) to "\n'
+            '        "the given directory.",'
+        ) in source
+        # Shared pipeline conventions, deliberately literal (not descriptor facts).
+        assert '"status=Ready",' in source
+        assert 'else "Major"' in source
+        assert "choices=_TYPES.choices()" in source
+
+    def test_unknown_type_is_a_usage_error(self, tmp_path):
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "RHAIRFE-1", "--fetch-all", str(tmp_path), "--type", "epic"],
+            capture_output=True,
+            text=True,
+            env=_clean_env(**JIRA_ENV),
+        )
+        assert result.returncode == 2
+        assert "invalid choice: 'epic'" in result.stderr
+        assert _tree(tmp_path) == {}
+
+    def test_missing_credentials_exit_2_for_every_type(self, tmp_path, monkeypatch):
+        for var in JIRA_ENV:
+            monkeypatch.delenv(var, raising=False)
+        for type_name in REG.names():
+            code, out = _main(monkeypatch, "X-1", "--fetch-all", str(tmp_path), "--type", type_name)
+            assert code == 2
+            assert out == ""
+        assert _tree(tmp_path) == {}
+
+    def test_type_is_ignored_by_the_fields_mode(self, monkeypatch, fake_jira):
+        # Only --fetch-all reads --type; the JSON modes are type-neutral and unchanged.
+        code, out = _main(
+            monkeypatch, "RHAIRFE-1595", "--fields", "summary,status", "--type", "initiative"
+        )
+        assert code == 0
+        assert json.loads(out) == {
+            "key": "RHAIRFE-1595",
+            "fields": {"summary": ISSUE["fields"]["summary"], "status": {"name": "New"}},
+        }
+        assert fake_jira["issue"] == [("RHAIRFE-1595", ["summary", "status"])]
+
+
+# ── end to end against the jira-emulator ─────────────────────────────────────────────────────
+
+
+class TestFetchAllAgainstTheEmulator:
+    @pytest.fixture
+    def env(self, jira):
+        return _clean_env(JIRA_SERVER=jira.url, JIRA_USER="admin", JIRA_TOKEN="admin")
+
+    def _run(self, env, *args):
+        return subprocess.run(
+            [sys.executable, SCRIPT, *args],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=REPO_ROOT,
+        )
+
+    def test_rfe_writes_task_original_and_comments(self, tmp_path, jira, env):
+        jira.request(
+            "POST",
+            "/api/admin/import",
+            {
+                "issues": [
+                    {
+                        "key": "RHAIRFE-1",
+                        "summary": "Export models",
+                        "project": "RHAIRFE",
+                        "issue_type": "Feature Request",
+                        "description": "Body text.",
+                        "labels": ["customer-request"],
+                        "priority": "Critical",
+                    }
+                ]
+            },
+        )
+        jira.request(
+            "POST",
+            "/rest/api/3/issue/RHAIRFE-1/comment",
+            {"body": {"type": "doc", "version": 1, "content": [_paragraph("Acme asked twice.")]}},
+        )
+        artifacts = tmp_path / "artifacts"
+        result = self._run(env, "RHAIRFE-1", "--fetch-all", str(artifacts))
+        assert result.returncode == 0, result.stderr
+        task = artifacts / "rfe-tasks" / "RHAIRFE-1.md"
+        original = artifacts / "rfe-originals" / "RHAIRFE-1.md"
+        comments = artifacts / "rfe-tasks" / "RHAIRFE-1-comments.md"
+        assert result.stdout == f"OK: wrote {task}, {original}, {comments}\n"
+
+        data, body = read_frontmatter_validated(str(task), "rfe-task")
+        assert data["rfe_id"] == "RHAIRFE-1"
+        assert data["title"] == "Export models"
+        assert data["priority"] == "Critical"
+        assert data["status"] == "Ready"
+        assert data["original_labels"] == ["customer-request"]
+        assert body == "Body text.\n"
+        assert original.read_text(encoding="utf-8") == "Body text.\n"
+        text = comments.read_text(encoding="utf-8")
+        assert text.startswith("# Comments: RHAIRFE-1\n\n## Admin User — ")
+        assert text.endswith("\n\nAcme asked twice.\n\n")
+
+    def test_initiative_writes_only_task_and_original(self, tmp_path, jira, env):
+        jira.create("RHOAIENG-1", "Serve models at the edge", "Init body.", issue_type="Initiative")
+        artifacts = tmp_path / "artifacts"
+        result = self._run(env, "RHOAIENG-1", "--fetch-all", str(artifacts), "--type", "initiative")
+        assert result.returncode == 0, result.stderr
+        task = artifacts / "initiatives" / "RHOAIENG-1.md"
+        original = artifacts / "initiative-originals" / "RHOAIENG-1.md"
+        assert result.stdout == f"OK: wrote {task}, {original}\n"
+        assert _tree(artifacts).keys() == {
+            "initiatives/RHOAIENG-1.md",
+            "initiative-originals/RHOAIENG-1.md",
+        }
+
+        data, body = read_frontmatter_validated(str(task), "initiative-task")
+        assert data["initiative_id"] == "RHOAIENG-1"
+        assert data["title"] == "Serve models at the edge"
+        assert data["priority"] == "Major"  # the emulator leaves priority unset
+        assert data["status"] == "Ready"
+        assert data["original_labels"] is None
+        assert body == "Init body.\n"
+        assert original.read_text(encoding="utf-8") == "Init body.\n"

--- a/tests/test_snapshot_fetch.py
+++ b/tests/test_snapshot_fetch.py
@@ -3,14 +3,18 @@
 ID file writing, and snapshot loading from results directories."""
 
 import hashlib
+import inspect
 import os
+import subprocess
 import sys
+import textwrap
 
 import pytest
 import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
+import type_registry
 from snapshot_fetch import (
     SNAPSHOT_CONFIG,
     cmd_fetch,
@@ -926,3 +930,168 @@ class TestCmdFetchInitiativeType:
         initiative_snaps = [f for f in snap_files if f.startswith("initiative-snapshot-")]
         assert len(rfe_snaps) == 1
         assert len(initiative_snaps) == 0
+
+
+# ── Registry-derived SNAPSHOT_CONFIG (work-item-types PR-2c) ─────────────────
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "snapshot_fetch.py")
+# Hermetic: the developer's RFE_CREATOR_EXTRA_TYPES / RFE_CREATOR_BINDING_* never leak in.
+REG = type_registry.load(extra_roots=[], env={})
+
+
+def _dropin_root(tmp_path):
+    """A minimal third type under a drop-in root (registry env seam, dev/test only)."""
+    root = tmp_path / "types"
+    (root / "docs").mkdir(parents=True)
+    (root / "docs" / "type.yaml").write_text(
+        textwrap.dedent(
+            """\
+            schema_version: 1
+            type: docs
+            identity:
+              tracker: jira
+              jira: {project: DOCS, issue_type: Task, key_prefixes: ["DOCS-"]}
+              local_prefix: "DOC-"
+              id_field: doc_id
+            dirs: {tasks: artifacts/doc-tasks, originals: artifacts/doc-originals}
+            conventions:
+              labels: {ignore: docs-ignore, split_quarantine: docs-split-quarantine}
+            snapshot: {prefix: docs-snapshot-, report_prefix: docs-run-}
+            reporting: {item_key: per_doc}
+            """
+        )
+    )
+    return str(root)
+
+
+def _clean_env(**extra):
+    env = {k: v for k, v in os.environ.items() if not k.startswith("RFE_CREATOR_")}
+    env.update(extra)
+    return env
+
+
+class TestSnapshotConfigDerivesFromTheRegistry:
+    def test_values_are_the_pre_registry_literals(self):
+        # Behaviour-neutral migration: same keys, same order, same values as the literal table
+        # this replaced — the hard-filter JQL wrapper and the snapshot file names are built
+        # from these, and both are production contracts (results-repo file names).
+        assert SNAPSHOT_CONFIG == {
+            "rfe": {
+                "ignore_label": "rfe-creator-ignore",
+                "quarantine_label": "rfe-creator-split-quarantine",
+                "snapshot_prefix": "issue-snapshot-",
+            },
+            "initiative": {
+                "ignore_label": "initiative-ignore",
+                "quarantine_label": "initiative-split-quarantine",
+                "snapshot_prefix": "initiative-snapshot-",
+            },
+        }
+        assert list(SNAPSHOT_CONFIG) == ["rfe", "initiative"]
+        for config in SNAPSHOT_CONFIG.values():
+            assert list(config) == ["ignore_label", "quarantine_label", "snapshot_prefix"]
+
+    @pytest.mark.parametrize("type_name", REG.names())
+    def test_projection_from_the_descriptor(self, type_name):
+        desc = REG.get(type_name)
+        sc = SNAPSHOT_CONFIG[type_name]
+        assert sc["ignore_label"] == desc.labels["ignore"]
+        assert sc["quarantine_label"] == desc.labels["split_quarantine"]
+        assert sc["snapshot_prefix"] == desc.get("snapshot.prefix")
+
+    def test_default_prefix_kwargs_are_the_rfe_prefix_bound_at_import(self):
+        # submit.py relies on these defaults for rfe (its own snapshot_prefix is "" as a
+        # sentinel for them); a third type must always pass prefix=. The default is the rfe
+        # descriptor's snapshot.prefix, bound once when the module is imported.
+        rfe_prefix = REG.get("rfe").get("snapshot.prefix")
+        assert rfe_prefix == "issue-snapshot-"
+        for fn in (find_previous_snapshot, load_snapshot_from_dir, update_snapshot_hashes):
+            assert inspect.signature(fn).parameters["prefix"].default == rfe_prefix, fn.__name__
+
+    def test_type_choices_are_the_registry_choices(self):
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "fetch", "--help"],
+            capture_output=True,
+            text=True,
+            env=_clean_env(),
+        )
+        assert result.returncode == 0
+        assert "--type {rfe,initiative}" in result.stdout
+
+    def test_a_drop_in_type_is_offered_and_configured(self, tmp_path):
+        root = _dropin_root(tmp_path)
+        env = _clean_env(RFE_CREATOR_EXTRA_TYPES=root, RFE_CREATOR_EXTRA_TYPES_ALLOWLIST=root)
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "fetch", "--help"], capture_output=True, text=True, env=env
+        )
+        assert "--type {rfe,docs,initiative}" in result.stdout
+        # The one fetch path that needs no Jira — --reprocess without a JQL reuses the prior
+        # IDs — still indexes SNAPSHOT_CONFIG by type, so it proves the drop-in is configured.
+        ids_file = tmp_path / "ids.txt"
+        ids_file.write_text("DOCS-1\nDOCS-2\n")
+        changed_file = tmp_path / "changed.txt"
+        result = subprocess.run(
+            [
+                sys.executable,
+                SCRIPT,
+                "fetch",
+                "--type",
+                "docs",
+                "--reprocess",
+                "--ids-file",
+                str(ids_file),
+                "--changed-file",
+                str(changed_file),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout == "TOTAL=2\nCHANGED=2\nNEW=0\nUNCHANGED=0\n"
+        assert changed_file.read_text() == "DOCS-1\nDOCS-2\n"
+
+
+class TestHardFilterJqlWrapperIsByteStable:
+    """The wrapper sent to Jira, per type, exactly as before the registry derivation."""
+
+    def _captured_jql(self, tmp_path, monkeypatch, type_name, jql):
+        import argparse
+
+        captured = {}
+
+        def mock_fetch_all(server, user, token, wrapped):
+            captured["jql"] = wrapped
+            return {}
+
+        monkeypatch.setattr("snapshot_fetch.require_env", lambda: ("http://x", "u", "t"))
+        monkeypatch.setattr("snapshot_fetch.fetch_all_issues", mock_fetch_all)
+        monkeypatch.setattr("snapshot_fetch.find_previous_snapshot", lambda **kw: (None, None))
+        monkeypatch.setattr("snapshot_fetch.SNAPSHOT_DIR", str(tmp_path / "auto-fix-runs"))
+        cmd_fetch(
+            argparse.Namespace(
+                reprocess=False,
+                jql=jql,
+                random=None,
+                limit=None,
+                data_dir=None,
+                type=type_name,
+                ids_file=str(tmp_path / "ids.txt"),
+                changed_file=str(tmp_path / "changed.txt"),
+            )
+        )
+        return captured["jql"]
+
+    def test_rfe(self, tmp_path, monkeypatch):
+        assert self._captured_jql(tmp_path, monkeypatch, "rfe", "project = RHAIRFE") == (
+            "(project = RHAIRFE) AND statusCategory != Done "
+            "AND (labels not in (rfe-creator-ignore, rfe-creator-split-quarantine) "
+            "OR labels is EMPTY)"
+        )
+
+    def test_initiative(self, tmp_path, monkeypatch):
+        assert self._captured_jql(tmp_path, monkeypatch, "initiative", "project = RHOAIENG") == (
+            "(project = RHOAIENG) AND statusCategory != Done "
+            "AND (labels not in (initiative-ignore, initiative-split-quarantine) "
+            "OR labels is EMPTY)"
+        )

--- a/tests/test_type_registry_pins.py
+++ b/tests/test_type_registry_pins.py
@@ -22,7 +22,10 @@ Grandfathered projections (explicit — never "compare literally"):
     'issue-snapshot-' (Q16); snapshot.prefix itself is the non-empty string;
   * validate_batch_input.PARENT_KEY_PATTERN omits INIT- (Q14: known divergence until PR-3);
   * the four rfe rubric-path sites in skill bodies are STALE (design §10 PR-5) and are pinned as
-    such so the PR-5 fix is a visible pin change.
+    such so the PR-5 fix is a visible pin change;
+  * bootstrap_snapshot._run_dir_has_snapshots probes the rfe snapshot.prefix for every --type
+    (PR-2c reads it from the rfe descriptor instead of the literal; the per-type probe is a
+    deliberate follow-up, design §10 PR-10) — pinned as a residue so that change is visible.
 
 Rows of the PR-1 pin matrix that carry no descriptor projection are listed in DEFERRED with a
 reason, and rows whose registry now derives from the descriptor at import are listed in MIGRATED
@@ -160,9 +163,35 @@ DEFERRED = [
 # (rows, registry, "<PR>: <projection>; <what, if anything, is still literal and pinned>")
 MIGRATED = [
     (
+        (47, 48, 49, 50, 53),
+        "snapshot_fetch.SNAPSHOT_CONFIG / default prefix= kwargs / --type choices",
+        "PR-2c: conventions.labels.{ignore,split_quarantine} + snapshot.prefix over names(); the "
+        "rfe snapshot.prefix is bound once at import as the default prefix= of "
+        "find_previous_snapshot / load_snapshot_from_dir / update_snapshot_hashes (same value, "
+        "same signatures); still pinned: the hard-filter wrapper source form (51) and the "
+        "output filename form (59)",
+    ),
+    (
+        (54, 55, 56, 60),
+        "bootstrap_snapshot.BOOTSTRAP_CONFIG / _run_dir_has_snapshots probe / --type choices",
+        "PR-2c: snapshot.report_prefix + reporting.item_key over names(); the probe reads the rfe "
+        "descriptor's snapshot.prefix and stays rfe-only for every type (grandfathered — the "
+        "per-type probe is a deliberate follow-up; tests/test_bootstrap_snapshot.py pins the "
+        "behaviour); still pinned: the wrapper duplicate (57) and the run-report path (58)",
+    ),
+    (
         (62,),
         "jql_query default exclusion wrapper",
         "PR-2a: conventions.labels.{ignore,rubric_pass}",
+    ),
+    (
+        (65,),
+        "fetch_issue._fetch_all rfe-only layout / --type",
+        "PR-2c: dirs(bare).tasks / dirs(bare).originals, identity.id_field, the comments "
+        "companion (and its request) gated on companions.comments, registry.choices() for the "
+        "new --type (default rfe; the no---type invocation is byte-identical); still literal and "
+        "pinned: status=Ready and the priority fallback Major (shared pipeline vocabulary that "
+        "every type's task schema carries, not type facts)",
     ),
     (
         (66,),
@@ -389,8 +418,8 @@ def fm(fields, body="Body\n"):
 
 
 class TestRegistryShape:
-    # rows: 25, 46, 53, 60, 124, 142, 159, 160, 161 + the source form of 162 (62, 66, 70, 87,
-    # 102, 106, 147, 148, 153-156, 162 MIGRATED)
+    # rows: 25, 46, 124, 142, 159, 160, 161 + the source form of 162 (47-50, 53-56, 60, 62, 65,
+    # 66, 70, 87, 102, 106, 147, 148, 153-156, 162 MIGRATED)
 
     def test_shipped_types_in_argparse_order(self):
         assert TYPES == ["rfe", "initiative"]
@@ -402,8 +431,6 @@ class TestRegistryShape:
             # (comprehension over names()) has this property by construction and is not listed.
             ("submit.TYPE_CONFIGS", submit.TYPE_CONFIGS),
             ("split_submit.SPLIT_CONFIG", split_submit.SPLIT_CONFIG),
-            ("snapshot_fetch.SNAPSHOT_CONFIG", snapshot_fetch.SNAPSHOT_CONFIG),
-            ("bootstrap_snapshot.BOOTSTRAP_CONFIG", bootstrap_snapshot.BOOTSTRAP_CONFIG),
             ("pipeline_state.PIPELINE_TYPES", pipeline_state.PIPELINE_TYPES),
             ("compare_review_outputs._TYPE_CONFIG", compare_review_outputs._TYPE_CONFIG),
             ("check_autofix_complete._TYPE_CONFIG", check_autofix_complete._TYPE_CONFIG),
@@ -426,8 +453,6 @@ class TestRegistryShape:
         [
             ("scripts/submit.py", "--type"),  # :365-370
             ("scripts/split_submit.py", "--type"),  # :853-858
-            ("scripts/snapshot_fetch.py", "--type"),  # :490-495
-            ("scripts/bootstrap_snapshot.py", "--type"),  # :417-422
             ("scripts/pipeline_state.py", "--type"),  # :848 cmd_init
             ("scripts/compare_review_outputs.py", "--type"),  # :145
             ("scripts/cleanup_partial_split.py", "--type"),  # :27
@@ -435,7 +460,7 @@ class TestRegistryShape:
         ],
     )
     def test_argparse_type_choices_are_registry_choices(self, rel, flag):
-        # rows: 25, 46, 53, 60, 124, 159, 160, 161 — the literal lists still carried
+        # rows: 25, 46, 124, 159, 160, 161 — the literal lists still carried (53, 60 MIGRATED)
         # (check_revised.py / check_right_sized.py hand-parse --type without choices)
         got = choices(rel, flag)
         assert got, f"{rel}: no add_argument({flag!r}, choices=...) found"
@@ -457,12 +482,16 @@ class TestRegistryShape:
             ("scripts/error_collect.py", "--type"),
             ("scripts/split_collect.py", "--type"),
             ("scripts/collect_children.py", "--type"),
+            ("scripts/snapshot_fetch.py", "--type"),
+            ("scripts/bootstrap_snapshot.py", "--type"),
+            ("scripts/fetch_issue.py", "--type"),  # new in PR-2c (row 65): no literal list ever
         ],
     )
     def test_migrated_argparse_choices_read_the_registry(self, rel, flag):
-        # MIGRATED rows 62, 66, 70, 87, 102, 106, 147, 148, 153-156 — the literal list is gone;
-        # the source form is pinned (as test_frontmatter_schema_choices_are_the_schema_keys pins
-        # "list(SCHEMAS.keys())") so a re-introduced literal list is a visible change.
+        # MIGRATED rows 53, 60, 62, 65, 66, 70, 87, 102, 106, 147, 148, 153-156 — the literal
+        # list is gone; the source form is pinned (as
+        # test_frontmatter_schema_choices_are_the_schema_keys pins "list(SCHEMAS.keys())") so a
+        # re-introduced literal list is a visible change.
         assert choices(rel, flag) == ["_TYPES.choices()"], rel
 
     def test_pipeline_types_and_state_validation_share_the_choices(self):
@@ -924,40 +953,9 @@ class TestSplitSubmitConfig:
 
 
 class TestSnapshotAndBootstrap:
-    # rows: 47-51, 53-61
-
-    def test_snapshot_config(self, ctx):
-        sc = snapshot_fetch.SNAPSHOT_CONFIG[ctx.t]
-        pin(
-            "conventions.labels.ignore",
-            "snapshot_fetch.py:58,:63",
-            ctx.labels["ignore"],
-            sc["ignore_label"],
-        )
-        pin(
-            "conventions.labels.split_quarantine",
-            "snapshot_fetch.py:59,:64",
-            ctx.labels["split_quarantine"],
-            sc["quarantine_label"],
-        )
-        pin(
-            "snapshot.prefix", "snapshot_fetch.py:60,:65", ctx.snap["prefix"], sc["snapshot_prefix"]
-        )
-
-    def test_default_prefix_kwargs_are_the_rfe_prefix(self):
-        # rows: 50 — snapshot_fetch.py:142,:163,:280-282; a third type must always pass prefix
-        rfe = _ctx("rfe")
-        for fn in (
-            snapshot_fetch.find_previous_snapshot,
-            snapshot_fetch.load_snapshot_from_dir,
-            snapshot_fetch.update_snapshot_hashes,
-        ):
-            pin(
-                "snapshot.prefix (rfe default)",
-                f"snapshot_fetch.{fn.__name__}",
-                rfe.snap["prefix"],
-                inspect.signature(fn).parameters["prefix"].default,
-            )
+    # rows: 51, 57, 58, 59, 61 (47-50, 53-56, 60 MIGRATED — SNAPSHOT_CONFIG / BOOTSTRAP_CONFIG
+    # derive from the descriptors since PR-2c; what stays literal is the wrapper and path
+    # composition below, and the grandfathered rfe-only shape of the snapshot probe)
 
     def test_hard_filter_jql_wrapper_in_both_scripts(self, ctx):
         # rows: 51, 57 — snapshot_fetch.py:368-379 and its verbatim duplicate
@@ -984,25 +982,6 @@ class TestSnapshotAndBootstrap:
             assert 'f"AND (labels not in ({excluded}) OR labels is EMPTY)"' in source
         assert "updated_jql = f'{jql} AND updated >= \"{run_jql_ts}\"'" in boot_src
 
-    def test_bootstrap_config_matches_run_report_writer(self, ctx):
-        # rows: 54, 55 — bootstrap_snapshot.py:45-50 reads what generate_run_report.py writes;
-        # the writer's TYPE_CONFIG is registry-derived since PR-2a (MIGRATED rows 71-81), so the
-        # reader is pinned to the descriptor directly (tests/test_report_roundtrip.py keeps the
-        # real-CLI round trip; PR1-10)
-        bc = bootstrap_snapshot.BOOTSTRAP_CONFIG[ctx.t]
-        pin(
-            "snapshot.report_prefix",
-            "bootstrap_snapshot.py:45,:49",
-            ctx.snap["report_prefix"],
-            bc["report_prefix"],
-        )
-        pin(
-            "reporting.item_key",
-            "bootstrap_snapshot.py:46,:50",
-            ctx.rep["item_key"],
-            bc["item_key"],
-        )
-
     def test_run_report_reader_path_is_report_prefix_plus_run(self, ctx, tmp_path):
         # rows: 58 — bootstrap_snapshot.py:76-79 path derivation
         run = "20260818-120000"
@@ -1026,15 +1005,17 @@ class TestSnapshotAndBootstrap:
         )
         assert report is not None
 
-    def test_run_dir_snapshot_probe_is_hardcoded_to_the_rfe_prefix(self, tmp_path):
-        # rows: 56 — bootstrap_snapshot.py:175-178 literal 'issue-snapshot-' (rfe-only; latent
-        # initiative bug — PR-2 reads snapshot.prefix, which makes this pin change visibly)
-        assert 'name.startswith("issue-snapshot-")' in read("scripts/bootstrap_snapshot.py")
+    def test_run_dir_snapshot_probe_is_grandfathered_to_the_rfe_prefix(self, tmp_path):
+        # rows: 56 (MIGRATED value, grandfathered shape) — bootstrap_snapshot.py:176 read the
+        # literal 'issue-snapshot-' for every --type; since PR-2c it reads the rfe descriptor's
+        # snapshot.prefix and is still rfe-only for every type. The per-type probe is a
+        # deliberate follow-up, so the behaviour is pinned here to make that change visible.
+        assert "name.startswith(_RFE_SNAPSHOT_PREFIX)" in read("scripts/bootstrap_snapshot.py")
         pin(
             "snapshot.prefix (rfe)",
             "bootstrap_snapshot.py:176",
             _ctx("rfe").snap["prefix"],
-            "issue-snapshot-",
+            bootstrap_snapshot._RFE_SNAPSHOT_PREFIX,
         )
         for t in TYPES:
             run = f"run-{t}"
@@ -1119,18 +1100,35 @@ class TestJqlAndJiraUtils:
 
 
 class TestSmallRegistries:
-    # rows: 65, 66 (residue), 68, 107, 154, 155, 157-161 (residues) — 66, 67, 69, 70, 105,
+    # rows: 66 (residue), 68, 107, 154, 155, 157-161 (residues) — 65, 66, 67, 69, 70, 105,
     # 148-157, 170 MIGRATED as listed above
 
-    def test_fetch_issue_is_rfe_only(self):
-        # rows: 65 — fetch_issue.py:59-60,:71,:83,:98,:101,:122,:224 (no --type)
+    def test_fetch_issue_fetch_all_is_type_aware(self):
+        # rows: 65 (MIGRATED) — fetch_issue.py:59-60,:98,:122 carried the rfe literals and :224
+        # had no --type; since PR-2c _fetch_all reads the selected type's descriptor (design §10
+        # item 2) and --type offers registry.choices(). The source form is pinned, as for the
+        # other migrated sites, so a re-introduced rfe literal is a visible change; what stays
+        # literal is shared pipeline vocabulary — status=Ready and the Major priority fallback,
+        # which every type's task schema accepts — not a type fact. tests/test_fetch_issue.py
+        # holds the rfe artifacts byte-golden (c1df503) and the per-type layout.
         rfe = _ctx("rfe")
         source = read("scripts/fetch_issue.py")
-        assert f'os.path.join(artifacts_dir, "{rfe.bare["tasks"]}")' in source
-        assert f'os.path.join(artifacts_dir, "{rfe.bare["originals"]}")' in source
-        assert f'f"{rfe.id_field}={{issue_key}}"' in source
-        assert ('f"{issue_key}-comments.md"' in source) is rfe.d["companions"]["comments"]
-        assert "--type" not in source
+        assert "_TYPES = type_registry.load()" in source
+        assert 'dirs = desc.dirs(form="bare")' in source
+        assert 'os.path.join(artifacts_dir, dirs["tasks"])' in source
+        assert 'os.path.join(artifacts_dir, dirs["originals"])' in source
+        assert 'f"{desc.id_field}={issue_key}"' in source
+        assert 'if desc.get("companions.comments"):' in source
+        assert 'f"{issue_key}-comments.md"' in source
+        assert f'os.path.join(artifacts_dir, "{rfe.bare["tasks"]}")' not in source
+        assert f'os.path.join(artifacts_dir, "{rfe.bare["originals"]}")' not in source
+        assert f'f"{rfe.id_field}={{issue_key}}"' not in source
+        assert '"status=Ready",' in source
+        assert 'else "Major"' in source
+        for t in TYPES:
+            task = artifact_utils.SCHEMAS[f"{t}-task"]
+            assert "Ready" in task["status"]["enum"], t
+            assert "Major" in task["priority"]["enum"], t
 
     def test_check_conflicts_write_prefix_predicate(self, ctx):
         # rows: 66 — the dict is MIGRATED and the task scan is artifact_utils.scan_tasks(desc)

--- a/types/README.md
+++ b/types/README.md
@@ -10,7 +10,7 @@ reference). Design: `design-proposals/work-item-types-unified.md` §3.2 (contrac
 and are invoked by their cwd-relative path (`python3 scripts/type_registry.py …`, design §3.5.1).
 The provider guide is `docs/type-provider-guide.md`.
 
-**Status (PR-2b): 21 scripts read the registry** (table below). An adopted script does
+**Status (PR-2c): 24 scripts read the registry** (table below). An adopted script does
 `import type_registry` and `_TYPES = type_registry.load()` once at import and builds its per-type
 table over the registry (`_TYPES.names()` or iteration — both in `names()` order), so a drop-in
 type appears in it without a code change. Adopted scripts use DESCRIPTOR values only (`Descriptor.get`, `dirs()`, `labels`,
@@ -26,7 +26,17 @@ the scan / rename / parse helpers are generics over a `Descriptor` (the historic
 remain as wrappers), and `check_review_progress.PHASE_CHECKS` is `dirs` x `pipeline.poll_prefix`
 x `pipeline.dimensions[].name` (a drop-in without `dirs.{tasks,reviews}` and
 `pipeline.poll_prefix` contributes no rows). `tests/test_schemas_golden.py` pins the derived
-schemas byte for byte. Every value a pending script still carries is pinned by `tests/test_type_registry_pins.py`
+schemas byte for byte. Since PR-2c the snapshot side is a projection too: `snapshot_fetch.SNAPSHOT_CONFIG`
+(`conventions.labels.{ignore,split_quarantine}`, `snapshot.prefix`) and
+`bootstrap_snapshot.BOOTSTRAP_CONFIG` (`snapshot.report_prefix`, `reporting.item_key`) build over
+`names()`, the snapshot reader / writer helpers' default `prefix=` is the rfe `snapshot.prefix`
+bound once at import (submit's `''` sentinel keeps relying on it), and `fetch_issue.py --fetch-all`
+writes the selected `--type`'s layout (`dirs.{tasks,originals}`, `identity.id_field`, the comments
+companion gated on `companions.comments`). Those two tables are built at import for **every**
+registered type — and `submit.py` imports `snapshot_fetch` — so a drop-in must carry
+`conventions.labels.{ignore,split_quarantine}` and `snapshot.{prefix,report_prefix}` (gate 1
+already requires the two `snapshot` keys but not the two labels; copying `types/rfe/` keeps them
+all) or the import fails with a `KeyError` naming the type and the field. Every value a pending script still carries is pinned by `tests/test_type_registry_pins.py`
 to its descriptor projection — source of truth *by test* until it adopts (§10); that file's
 `MIGRATED` list names the matrix rows already covered *by import*, and each adoption deletes its
 pin.
@@ -41,6 +51,7 @@ itself is fine — `resolve()` follows the link).
 |---|---|---|
 | `artifact_utils.py` | `SCHEMAS` (`<type>-task` / `<type>-review` per type), `scan_tasks` / `scan_reviews` / `rename_to_tracker_key` / `parse_child` generics over a `Descriptor` (the per-type names are wrappers), `detect()` in `find_review_file` / `find_removed_context_yaml` | PR-2b; name-keyed until PR-3: the rename error label, rfe's slug-tolerant review lookup and `parse_child`'s rfe markdown fallbacks; the `rfes.md` index contract stays literal (`index.enabled`) |
 | `batch_summary.py` | `_TYPE_CONFIG` (dirs view of `generate_run_report.TYPE_CONFIG`), `--type` choices | PR-2a |
+| `bootstrap_snapshot.py` | `BOOTSTRAP_CONFIG` (`snapshot.report_prefix`, `reporting.item_key`), `--type` choices | PR-2c; the `issue-snapshot-` run-dir probe (`_run_dir_has_snapshots`) reads the rfe descriptor's `snapshot.prefix` and stays rfe-only for every `--type` (grandfathered; the per-type probe is a deliberate follow-up, design §10 PR-10) |
 | `check_conflicts.py` | `_TYPE_CONFIG`, `--type` choices; task scan via `artifact_utils.scan_tasks(desc)` | PR-2a, PR-2b; `startswith(jira_prefix)` → prefix-union pending |
 | `check_revised.py` | `_TYPE_CONFIG` | PR-2a |
 | `check_review_progress.py` | `PHASE_CHECKS`, `check_id` id field + modes by phase base, `--phase` / `--also-phase` choices | PR-2b; `_detect_fast` config allowlist literal until the `initiative-speedrun-config` drift is fixed deliberately; the rfe-only `create` row (`_CREATE_BARRIER_TYPES`, lifted in PR-5) and the initiative row order (`_LEGACY_ROW_ORDER`, CLI choices text) are documented legacy literals |
@@ -48,6 +59,7 @@ itself is fine — `resolve()` follows the link).
 | `collect_children.py` | `id_field`, `--type` choices; task scan via `artifact_utils.scan_tasks(desc)` | PR-2a, PR-2b |
 | `collect_recommendations.py` | `_review_dir`, `--type` choices | PR-2a |
 | `error_collect.py` | `_TYPE_CONFIG`, `--type` choices | PR-2a |
+| `fetch_issue.py` | `--fetch-all` layout (`dirs.{tasks,originals}`, `identity.id_field`, the comments companion and its request gated on `companions.comments`), new `--type` (registry choices, default `rfe`; the no-`--type` invocation is byte-identical) | PR-2c; `status=Ready` and the `Major` priority fallback stay literal (shared pipeline vocabulary, not type facts) |
 | `filter_for_revision.py` | prefix sniff → `detect()` | PR-2a |
 | `frontmatter.py` | `_detect_schema_type` path table (`_SCHEMA_BY_DIR`), `schema` / `--schema-type` choices through `SCHEMAS` | PR-2b |
 | `generate_review_pdf.py` | `REPORT_CONFIG`, `--type` choices | PR-2a |
@@ -57,18 +69,16 @@ itself is fine — `resolve()` follows the link).
 | `prep_assess.py` | prefix sniff → `detect()` | PR-2a |
 | `preserve_review_state.py` | prefix sniff → `detect()` | PR-2a |
 | `reassess_save.py` | `_TYPE_CONFIG`, `--type` choices | PR-2a |
+| `snapshot_fetch.py` | `SNAPSHOT_CONFIG` (`conventions.labels.{ignore,split_quarantine}`, `snapshot.prefix`), default `prefix=` of `find_previous_snapshot` / `load_snapshot_from_dir` / `update_snapshot_hashes` (rfe `snapshot.prefix`, bound at import), `--type` choices | PR-2c; the hard-filter JQL wrapper and the `f"{prefix}{ts}.yaml"` file name are composition, still pinned by source form |
 | `split_collect.py` | `_TYPE_CONFIG`, `_set_revise` defaults, `--type` choices | PR-2a |
 | `validate_batch_input.py` | `ALLOWED_PRIORITIES`, known fields, `--type` choices | PR-2a; `PARENT_KEY_PATTERN` literal until PR-3 (Q14) |
 | `verify_phase.py` | phase tables, `_TYPE_CONFIG`, error-stub score tail, `--type` choices | PR-2a |
-| `bootstrap_snapshot.py` | `BOOTSTRAP_CONFIG`, `issue-snapshot-` probe | pending |
 | `check_autofix_complete.py` | `_TYPE_CONFIG` | pending |
 | `check_content_preservation.py` | inline dir branch | pending |
 | `cleanup_partial_split.py` | inline dir branch | pending |
 | `compare_review_outputs.py` | `_TYPE_CONFIG` | pending |
-| `fetch_issue.py` | rfe-only paths | pending |
 | `jira_utils.py` | `strip_metadata` prefix regex | pending |
 | `pipeline_state.py` | `PIPELINE_TYPES` (prompt/skill entries move in PR-5) | pending |
-| `snapshot_fetch.py` | `SNAPSHOT_CONFIG` | pending |
 | `split_submit.py` | `SPLIT_CONFIG` | pending (last, with `submit.py`) |
 | `submit.py` | `TYPE_CONFIGS` | pending (last; emulator suites in CI) |
 

--- a/types/initiative/type.yaml
+++ b/types/initiative/type.yaml
@@ -1,6 +1,6 @@
 # types/initiative/type.yaml — the initiative work-item type descriptor.
 # Contract: types/_schema/type.schema.json; design-proposals/work-item-types-unified.md §3.2 and the worked
-# example §8.2. Status (PR-2b): 21 scripts read this descriptor at import (types/README.md "Adoption
+# example §8.2. Status (PR-2c): 24 scripts read this descriptor at import (types/README.md "Adoption
 # status"); the values a pending script still carries are pinned equal to it by test, so the descriptor
 # is source of truth BY IMPORT for adopted scripts and BY TEST for the rest (design §10). Every value is
 # the live literal on main (c1df503) with the consuming file:line AT THAT COMMIT in a trailing comment
@@ -32,7 +32,7 @@ dirs:                                                   # artifacts/ form (Q13);
   reviews: artifacts/initiative-reviews                 # pipeline_state.py:117; verify_phase.py:56; submit.py:101 (bare); reassess_save.py:21
 index: { enabled: false }                               # submit.py:126 has_index; split_submit.py:145 do_rebuild_index; no initiative index file exists
 companions:
-  comments: false                                       # initiative-review/prompts/fetch-agent.md:10 fetches without comments and writes only task + original (:35-37); fetch_issue.py --fetch-all is rfe-only. Means "the fetch step produces one" — rename_initiative_to_jira_key (artifact_utils.py:1079-1080) still maps -comments.md and a test pins it
+  comments: false                                       # initiative-review/prompts/fetch-agent.md:10 fetches without comments and writes only task + original (:35-37); fetch_issue.py --fetch-all gates the comments companion (and the comment request) on this flag (PR-2c). Means "the fetch step produces one" — rename_initiative_to_jira_key (artifact_utils.py:1079-1080) still maps -comments.md and a test pins it
   removed_context: true                                 # artifact_utils.py:727-731 (type-agnostic); :831-833 find_removed_context_yaml initiative branch; error_collect.py:216
 
 conventions:

--- a/types/rfe/type.yaml
+++ b/types/rfe/type.yaml
@@ -1,6 +1,6 @@
 # types/rfe/type.yaml — the rfe work-item type descriptor.
 # Contract: types/_schema/type.schema.json; design-proposals/work-item-types-unified.md §3.2 (§8.2 is the
-# initiative twin). Status (PR-2b): 21 scripts read this descriptor at import (types/README.md "Adoption
+# initiative twin). Status (PR-2c): 24 scripts read this descriptor at import (types/README.md "Adoption
 # status"); the values a pending script still carries are pinned equal to it by test, so the descriptor
 # is source of truth BY IMPORT for adopted scripts and BY TEST for the rest (design §10). Every value is
 # the live literal on main (c1df503) with the consuming file:line AT THAT COMMIT in a trailing comment
@@ -32,7 +32,7 @@ dirs:                                                   # artifacts/ form (Q13);
   reviews: artifacts/rfe-reviews                        # pipeline_state.py:105; verify_phase.py:43; submit.py:70 (bare); reassess_save.py:20
 index: { enabled: true }                                # submit.py:91 has_index; split_submit.py:125 do_rebuild_index; artifact_utils.py:1113-1170 rebuild_index -> artifacts/rfes.md
 companions:
-  comments: true                                        # fetch_issue.py:122 writes {KEY}-comments.md under --fetch-all; rfe.review/prompts/fetch-agent.md:16,:26
+  comments: true                                        # fetch_issue.py --fetch-all gates the comments companion (and the comment request) on this flag (PR-2c; fetch_issue.py:122 at c1df503); rfe.review/prompts/fetch-agent.md:16,:26
   removed_context: true                                 # artifact_utils.py:727-731 companion suffixes; submit.py:1115; error_collect.py:216; check_content_preservation.py:246
 
 conventions:


### PR DESCRIPTION
## Summary

PR-2c of the work-item-types design (§10 item 2), **stacked on #177** (which sits on #176): the snapshot and bootstrap configs read the registry, and `fetch_issue --fetch-all` becomes type-aware. **Behavior is byte-identical for every existing invocation.** Three commits.

1. **`snapshot_fetch.SNAPSHOT_CONFIG`** and **`bootstrap_snapshot.BOOTSTRAP_CONFIG`** derive per type from the descriptors (ignore and quarantine labels, snapshot prefix, report prefix, item key), same keys and order; the rfe snapshot prefix that serves as the default keyword argument of the snapshot readers and writer is bound once at import, so signatures are unchanged. The design invariants in `docs/snapshot-incremental-fetch.md` are untouched: nothing changes in what is hashed, persisted, selected or merged, nor in file naming. The bootstrap run-directory probe still reads the **rfe** prefix for every type, as today; making it per-type would change which run directories an initiative bootstrap considers, so it stays a documented, pinned residue for a deliberate follow-up.
2. **`fetch_issue --fetch-all`** gains `--type` (default rfe, additive): directories, id field and the comments companion (written only when `companions.comments` is true) come from the descriptor. `--help` changes only by the new option block. New tests cover both layouts against stubbed Jira responses.
3. **Pins and baseline**: retired pins move to the MIGRATED list, the rfe-only probe keeps an explicit residue pin, prefix baseline 21 → 14 occurrences (11 → 9 files).

## Equivalence evidence

- Golden runs against the pristine PR-2b base: bootstrap_snapshot offline modes on three real results-repo run directories with a deterministic mock Jira; a frozen-time harness over the snapshot load, diff, update and fetch paths on real snapshots; fetch_issue `--fetch-all` with identical stubbed responses; `--help` for all three scripts. Identical stdout, exit codes, produced files and JQL strings (fetch_issue differs only by the documented `--type` block). Reproduced independently by a reviewer and spot-checked by me (config dicts, signatures and help output compared against the base).
- Unit suite 1717 passed; **emulator integration suite 140 passed**; ruff clean; `validate_types` OK; prefix lint within the tightened baseline.

## Deferred on purpose (behavior-changing, need the eval bar rather than golden runs)

Per-type bootstrap probe; `jira_utils.strip_metadata` heading regex rendered from the prefix union; the fast-detection config allowlist; the descriptor-driven bootstrap with `rubric.ref` pinning (§7.3). Each is recorded in the design document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Extended “fetch all” workflows to support selecting different work-item types.
  - Generated files, directories, identifiers, snapshot names, and optional comment files now follow each type’s configured format.
  - Command-line type choices and snapshot handling automatically reflect available registered types.

- **Documentation**
  - Updated provider guidance and type documentation with configuration requirements, snapshot settings, and multi-type fetching details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->