### PR TITLE
submit and split_submit adopt the registry (design PR-2d)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,3 +52,10 @@ jobs:
 
     - name: Run tests
       run: python3 -m pytest tests/ -v -k "not integration"
+
+    # The Jira write path (submit.py, split_submit.py) reads the type registry; the
+    # jira-emulator suites are its equivalence proof and gate that adoption
+    # (design work-item-types-unified.md section 10 item 2). jira-emulator comes from
+    # requirements-dev.txt; the server runs in-process on a free local port.
+    - name: Run emulator integration tests
+      run: python3 -m pytest tests/ -v -k integration

--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,9 @@ test: ## Run pytest (excludes integration tests)
 	@echo "Running tests..."
 	@python3 -m pytest tests/ -v -k "not integration"
 
+.PHONY: test-integration
+test-integration: ## Run the jira-emulator integration tests (pip install -r requirements-dev.txt)
+	@echo "Running integration tests..."
+	@python3 -m pytest tests/ -v -k integration
+
 .DEFAULT_GOAL := help

--- a/docs/type-provider-guide.md
+++ b/docs/type-provider-guide.md
@@ -5,7 +5,7 @@ authoritative text lives. Design: `design-proposals/work-item-types-unified.md` 
 §3.2.1 (binding override), §3.3 (gates), §3.4 (provider obligations), §3.5 (discovery), §3.7
 (cross-type chain).
 
-**Status (PR-2c): 24 scripts read the registry at import** — the "Adoption status" table in
+**Status (PR-2d): 26 scripts read the registry at import** — the "Adoption status" table in
 [`types/README.md`](../types/README.md) lists them and what is still pending. Since PR-2b the
 artifact schemas (`artifact_utils.SCHEMAS`), the scan / rename / parse helpers and the poll phase
 table (`check_review_progress.PHASE_CHECKS`) are projections too, so a registered type gets its
@@ -13,7 +13,9 @@ table (`check_review_progress.PHASE_CHECKS`) are projections too, so a registere
 a code change; since PR-2c so are the snapshot tables (`snapshot_fetch.SNAPSHOT_CONFIG`,
 `bootstrap_snapshot.BOOTSTRAP_CONFIG`) and the `fetch_issue.py --fetch-all` layout (`--type`,
 default `rfe`), so a registered type gets its hard-filter labels, snapshot / run-report file
-prefixes and fetch layout the same way. Every per-type value a pending script still carries is pinned by test to its
+prefixes and fetch layout the same way; since PR-2d the Jira write path (`submit.TYPE_CONFIGS`,
+`split_submit.SPLIT_CONFIG`) is a projection too, so a registered type submits, approves, splits
+and closes with its own binding and conventions. Every per-type value a pending script still carries is pinned by test to its
 descriptor projection; each adoption deletes its pin (design §10). Adopted scripts use descriptor
 values only; the effective binding override is not consulted until PR-3.
 
@@ -65,7 +67,8 @@ Rules that are easy to trip:
   `conventions.labels.{ignore,split_quarantine}` and `snapshot.prefix`, and
   `bootstrap_snapshot.BOOTSTRAP_CONFIG` reads `snapshot.report_prefix` and `reporting.item_key`,
   over every registered type when the module is imported — and `submit.py` imports
-  `snapshot_fetch`. Gate 1 already requires `snapshot.prefix` and `snapshot.report_prefix`
+  `snapshot_fetch` (since PR-2d it loads the registry directly as well). Gate 1 already requires
+  `snapshot.prefix` and `snapshot.report_prefix`
   (schema `$defs/snapshot`, the `else` branch of the `mode` conditional; the prefix is also
   linted non-empty and collision-free) and `reporting.item_key`, but NOT
   `conventions.labels.ignore` / `.split_quarantine` (`$defs/labels` is an open map with no
@@ -75,6 +78,26 @@ Rules that are easy to trip:
   `prefix=` explicitly to the snapshot helpers (their default is the rfe `snapshot.prefix`).
   `fetch_issue.py --fetch-all --type <t>` reads `dirs.{tasks,originals}`, `identity.id_field`
   and `companions.comments` (all schema-required).
+- **Submit facts are read at import, for every type.** `submit.TYPE_CONFIGS` and
+  `split_submit.SPLIT_CONFIG` read `identity.jira.{project,issue_type,key_prefixes}`,
+  `identity.{id_field,local_prefix}`, `dirs.{tasks,reviews,originals}`,
+  `display.{entity,entity_plural}`,
+  `conventions.{type_label,label_prefix,comment_prefix,removed_context_preamble}`,
+  `conventions.labels.{rubric_pass,feasibility}` (`alignment` optional), `index.enabled` and
+  `snapshot.prefix` over every registered type when either module is imported. Everything but
+  the two label keys is schema-required, so a drop-in that omits `labels.rubric_pass` or
+  `labels.feasibility` passes gate 1 and fails the import of `submit.py` with a `KeyError`
+  naming the type and the field. `identity.jira.split_link_type` and
+  `identity.jira.state_map.{approved,close_superseded}` are optional in the schema, so their
+  absence is refused when it matters rather than at import: `split_submit.py` reads the link
+  type and the close-superseded transition / resolution with a `None` default at import and
+  refuses to split a parent of a type missing any of them before any scan or Jira call (exit 5,
+  the systemic code, so `submit.py`'s split loop aborts instead of flagging every parent);
+  because it recovers those two facts by the `(project, issue_type)` pair, two registered types
+  sharing a pair fail its import with a `RegistryError` naming both. `submit.py` reads
+  `state_map.approved` with a `None` default at startup and only `--auto-approve` requires it
+  (a usage error naming the type and the field, before any scan or Jira call). Copying
+  `types/rfe/` keeps them all.
 - **Frozen strings (R7).** `conventions.labels.rubric_pass`, `conventions.removed_context_preamble`
   and the `{key}-strategy.md` attachment convention are consumed downstream; change them only with
   a migration note.

--- a/scripts/split_submit.py
+++ b/scripts/split_submit.py
@@ -24,22 +24,22 @@ import os
 import re
 import sys
 import urllib.error
+from functools import partial
 
 # Ensure progress output is visible immediately when stdout is redirected
 # to a file or pipe (Python defaults to full buffering in that case).
 sys.stdout.reconfigure(line_buffering=True)
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import type_registry  # noqa: E402
 from artifact_utils import (  # noqa: E402
     ValidationError,
     find_review_file,
-    parse_child_artifact,
-    parse_child_initiative,
+    parse_child,
     read_frontmatter_validated,
     rebuild_index,
-    rename_initiative_to_jira_key,
-    rename_to_jira_key,
-    scan_initiative_task_files,
-    scan_task_files,
+    rename_to_tracker_key,
+    scan_tasks,
 )
 from jira_utils import (  # noqa: E402
     add_comment,
@@ -106,56 +106,98 @@ def _classify_exit(exc):
     return EXIT_PER_PARENT
 
 
-SPLIT_CONFIG = {
-    "rfe": {
-        "project": "RHAIRFE",
-        "issue_type": "Feature Request",
-        "comment_marker": "[RFE Creator]",
-        "label_prefix": "rfe-creator",
-        "entity_name": "RFE",
-        "entity_name_plural": "RFEs",
-        "id_field": "rfe_id",
-        "reviews_dir": "rfe-reviews",
-        "review_schema": "rfe-review",
-        "originals_dir": "rfe-originals",
-        "scan_fn": scan_task_files,
-        "rename_fn": rename_to_jira_key,
-        "parse_child_fn": parse_child_artifact,
-        "find_review_fn": lambda artifacts_dir, child_id: find_review_file(artifacts_dir, child_id),
-        "do_rebuild_index": True,
-        "alignment_labels": None,
-    },
-    "initiative": {
-        "project": "RHOAIENG",
-        "issue_type": "Initiative",
-        "comment_marker": "[Initiative Creator]",
-        "label_prefix": "initiative",
-        "entity_name": "Initiative",
-        "entity_name_plural": "Initiatives",
-        "id_field": "initiative_id",
-        "reviews_dir": "initiative-reviews",
-        "review_schema": "initiative-review",
-        "originals_dir": "initiative-originals",
-        "scan_fn": scan_initiative_task_files,
-        "rename_fn": rename_initiative_to_jira_key,
-        "parse_child_fn": parse_child_initiative,
-        "find_review_fn": lambda artifacts_dir, child_id: _direct_review_path(
-            artifacts_dir, "initiative-reviews", child_id
-        ),
-        "do_rebuild_index": False,
-        "alignment_labels": {
-            "strong": "initiative-alignment-strong",
-            "partial": "initiative-alignment-partial",
-            "weak": "initiative-alignment-weak",
-        },
-    },
-}
+# The work-item type registry (types/<name>/type.yaml), read once at import; every
+# per-type value below is a projection of a descriptor (design work-item-types-unified.md
+# §10 item 2). Deliberately the DESCRIPTOR values, not the effective binding: deployment
+# overrides land with resolve() in a later PR.
+_TYPES = type_registry.load()
 
 
-def _direct_review_path(artifacts_dir, reviews_dir, child_id):
-    """Return review path if it exists, else None."""
-    path = os.path.join(artifacts_dir, reviews_dir, f"{child_id}-review.md")
-    return path if os.path.isfile(path) else None
+def _split_config(desc):
+    """Project one descriptor onto the SPLIT_CONFIG entry the phases read.
+
+    The four callables keep the ``(artifacts_dir, ...)`` signatures the per-type wrappers
+    had: scan_tasks / rename_to_tracker_key / parse_child are bound to ``desc``, and
+    find_review_file routes by the child id, which the task schema constrains to this
+    type's ``local_id_pattern`` or ``key_prefixes`` — so it lands on ``dirs.reviews`` too.
+    """
+    dirs = desc.dirs("bare")
+    alignment = desc.get("conventions.labels.alignment", None)
+    return {
+        "project": desc.get("identity.jira.project"),
+        "issue_type": desc.get("identity.jira.issue_type"),
+        "comment_marker": desc.get("conventions.comment_prefix"),
+        "label_prefix": desc.get("conventions.label_prefix"),
+        "entity_name": desc.get("display.entity"),
+        "entity_name_plural": desc.get("display.entity_plural"),
+        "id_field": desc.id_field,
+        "reviews_dir": dirs["reviews"],
+        "review_schema": f"{desc.name}-review",
+        "originals_dir": dirs["originals"],
+        "scan_fn": partial(scan_tasks, desc=desc),
+        "rename_fn": partial(rename_to_tracker_key, desc=desc),
+        "parse_child_fn": partial(parse_child, desc=desc),
+        "find_review_fn": find_review_file,
+        "do_rebuild_index": desc.get("index.enabled"),
+        "alignment_labels": dict(alignment) if alignment is not None else None,
+    }
+
+
+SPLIT_CONFIG = {name: _split_config(_TYPES.get(name)) for name in _TYPES.names()}
+
+
+# The Jira-side facts of the split transaction that SPLIT_CONFIG never carried (its key
+# set is a contract shared with the tests): the link type between a parent and its
+# children, and how the parent is closed once they exist. Keyed by the (project,
+# issue_type) binding pair every SPLIT_CONFIG entry carries, so a phase recovers them from
+# its ``config`` alone. validate_types.py keeps the pair unique per registered type, but
+# the registry does not run that gate at load, so the invariant is enforced here where it
+# is relied on: a second type with the same pair would otherwise silently replace the
+# first's facts. Read with a None default: both are optional in the schema and a
+# registered type that never splits must not break the import (main() refuses to split a
+# parent of such a type before any scan or Jira call).
+def _tracker_facts(types):
+    facts, owner = {}, {}
+    for desc in types:
+        pair = (desc.get("identity.jira.project"), desc.get("identity.jira.issue_type"))
+        if pair in owner:
+            raise type_registry.RegistryError(
+                f"split_submit: types {owner[pair]!r} and {desc.name!r} share the "
+                f"(project, issue_type) binding {pair}; the split link type and the "
+                "close-superseded state are recovered by that pair, so it must be unique"
+            )
+        owner[pair] = desc.name
+        facts[pair] = {
+            "split_link_type": desc.get("identity.jira.split_link_type", None),
+            "close_superseded": desc.get("identity.jira.state_map.close_superseded", None),
+        }
+    return facts
+
+
+_TRACKER = _tracker_facts(_TYPES)
+
+
+def _tracker(config):
+    """The ``_TRACKER`` entry of the type ``config`` projects."""
+    return _TRACKER[(config["project"], config["issue_type"])]
+
+
+def _missing_split_facts(config):
+    """Names of the binding facts a split of this type needs but its descriptor omits.
+
+    Empty for both shipped types. A type may legitimately omit them (it never splits);
+    the refusal belongs to the moment a parent of that type is submitted for a split.
+    """
+    facts = _tracker(config)
+    close = facts["close_superseded"] or {}
+    missing = []
+    if not facts["split_link_type"]:
+        missing.append("identity.jira.split_link_type")
+    # phase3_close matches the target status and sets the resolution on the transition.
+    for key in ("transition", "resolution"):
+        if not close.get(key):
+            missing.append(f"identity.jira.state_map.close_superseded.{key}")
+    return missing
 
 
 def _feasibility_labels(label_prefix):
@@ -197,6 +239,7 @@ def _inspect_child(server, user, token, child_key, artifact_path, parent_key, co
     from jira_utils import adf_to_markdown, normalize_for_compare
 
     _, _, _, cleaned = config["parse_child_fn"](artifact_path)
+    split_link_type = _tracker(config)["split_link_type"]
     issue = get_issue(server, user, token, child_key, ["description", "summary", "issuelinks"])
     fields = issue.get("fields", {})
     desc_raw = fields.get("description")
@@ -207,7 +250,7 @@ def _inspect_child(server, user, token, child_key, artifact_path, parent_key, co
     else:
         live = normalize_for_compare(str(desc_raw))
     linked = any(
-        link.get("type", {}).get("name") == "Work item split"
+        link.get("type", {}).get("name") == split_link_type
         and parent_key
         in (
             (link.get("inwardIssue") or {}).get("key"),
@@ -290,6 +333,7 @@ def discover_state(server, user, token, parent_key, expected_children, config):
     state = SubmissionState()
     state.total_children = len(expected_children)
     marker = re.escape(config["comment_marker"])
+    split_link_type = _tracker(config)["split_link_type"]
     ids_in_order = [child_id for (child_id, _, _, _) in expected_children]
     id_by_title = {title: child_id for (child_id, title, _, _) in expected_children}
     title_by_id = {child_id: title for (child_id, title, _, _) in expected_children}
@@ -407,7 +451,7 @@ def discover_state(server, user, token, parent_key, expected_children, config):
         ["issuelinks", "status", "components", "labels", "parent", "reporter"],
     )
     for link in issue.get("fields", {}).get("issuelinks", []):
-        if link.get("type", {}).get("name") != "Work item split":
+        if link.get("type", {}).get("name") != split_link_type:
             continue
         # Real Jira renders the child as outwardIssue on the parent; the
         # jira-emulator renders it as inwardIssue. Check both ends — the
@@ -494,7 +538,7 @@ def discover_state(server, user, token, parent_key, expected_children, config):
                 )
                 continue
             linked = any(
-                link.get("type", {}).get("name") == "Work item split"
+                link.get("type", {}).get("name") == split_link_type
                 and parent_key
                 in (
                     (link.get("inwardIssue") or {}).get("key"),
@@ -577,6 +621,7 @@ def phase2_create_link(
     find_review = config["find_review_fn"]
     feas_labels = _feasibility_labels(label_prefix)
     alignment_labels = config["alignment_labels"]
+    split_link_type = _tracker(config)["split_link_type"]
 
     for idx, (child_id, title, priority, artifact_path) in enumerate(children, 1):
         done = state.phase2_done.get(child_id)
@@ -607,7 +652,7 @@ def phase2_create_link(
                 done["commented"] = True
                 continue
             if not done["linked"]:
-                create_issue_link(server, user, token, "Work item split", parent_key, child_key)
+                create_issue_link(server, user, token, split_link_type, parent_key, child_key)
                 print(f"           Linked {child_key} to {parent_key}")
                 done["linked"] = True
             if not done["commented"]:
@@ -682,7 +727,7 @@ def phase2_create_link(
                 print(f"           Parent: {state.parent_parent_key}")
             if state.parent_reporter_id:
                 print(f"           Reporter: {state.parent_reporter_id}")
-            print(f"           Would link to {parent_key} via 'Work item split'")
+            print(f"           Would link to {parent_key} via '{split_link_type}'")
             if attn_reason:
                 print("           Would post needs-attention comment")
             state.phase2_done[child_id] = {
@@ -713,7 +758,7 @@ def phase2_create_link(
             print(f"           Parent: {state.parent_parent_key}")
 
         # 2. Link to parent
-        create_issue_link(server, user, token, "Work item split", parent_key, child_key)
+        create_issue_link(server, user, token, split_link_type, parent_key, child_key)
         print(f"           Linked {child_key} to {parent_key}")
 
         # 3. Post confirmation comment (carries the child's local id so
@@ -788,13 +833,17 @@ def build_split_summary_adf(server, children, state, total, config):
 
 
 def phase3_close(server, user, token, parent_key, children, state, config, dry_run):
-    """Close the parent ticket with resolution Obsolete."""
+    """Close the parent ticket with the type's close-superseded transition and resolution
+    (``identity.jira.state_map.close_superseded``: Closed / Obsolete for both shipped types)."""
     if state.parent_closed:
         print("  Phase 3: Parent already closed, skipping")
         return
 
     total = len(children)
     label_prefix = config["label_prefix"]
+    close = _tracker(config)["close_superseded"]
+    # The TARGET STATUS name (matched case-insensitively below) and the resolution set on it.
+    target_status, resolution = close["transition"], close["resolution"]
 
     if len(state.phase2_done) < total:
         missing = [cid for (cid, _, _, _) in children if cid not in state.phase2_done]
@@ -805,7 +854,10 @@ def phase3_close(server, user, token, parent_key, children, state, config, dry_r
 
     if dry_run:
         print(f"  Phase 3: Would label {parent_key} with {label_prefix}-split-original")
-        print(f"  Phase 3: Would transition {parent_key} to Closed (resolution: Obsolete)")
+        print(
+            f"  Phase 3: Would transition {parent_key} to {target_status} "
+            f"(resolution: {resolution})"
+        )
         print("           Would post summary comment")
         return
 
@@ -813,17 +865,20 @@ def phase3_close(server, user, token, parent_key, children, state, config, dry_r
     add_labels(server, user, token, parent_key, [f"{label_prefix}-split-original"])
     print(f"  Phase 3: Labeled {parent_key} with {label_prefix}-split-original")
 
-    # Find the "Closed" transition
+    # Find the transition whose target is the close-superseded status
     transitions = get_transitions(server, user, token, parent_key)
     closed_transition = None
     for t in transitions:
-        if t["to"].get("name", "").lower() == "closed":
+        if t["to"].get("name", "").lower() == target_status.lower():
             closed_transition = t
             break
 
     if not closed_transition:
         available = [t["name"] for t in transitions]
-        print(f"  WARNING: No 'Closed' transition found. Available: {available}", file=sys.stderr)
+        print(
+            f"  WARNING: No '{target_status}' transition found. Available: {available}",
+            file=sys.stderr,
+        )
         print("  Skipping parent closure.", file=sys.stderr)
         return
 
@@ -834,9 +889,9 @@ def phase3_close(server, user, token, parent_key, children, state, config, dry_r
         token,
         parent_key,
         closed_transition["id"],
-        fields={"resolution": {"name": "Obsolete"}},
+        fields={"resolution": {"name": resolution}},
     )
-    print(f"  Phase 3: Transitioned {parent_key} to Closed (Obsolete)")
+    print(f"  Phase 3: Transitioned {parent_key} to {target_status} ({resolution})")
 
     # Post summary comment with smart-linked child keys
     summary_adf = build_split_summary_adf(server, children, state, total, config)
@@ -852,7 +907,7 @@ def main():
     parser.add_argument("parent_key", help="Parent Jira issue key to split")
     parser.add_argument(
         "--type",
-        choices=["rfe", "initiative"],
+        choices=_TYPES.choices(),
         default="rfe",
         help="Entry type (default: rfe)",
     )
@@ -864,6 +919,17 @@ def main():
     )
     args = parser.parse_args()
     config = SPLIT_CONFIG[args.type]
+
+    # A type without the split facts cannot be split: refuse before any scan or Jira call
+    # rather than create children and then fail to link or close. Run-wide (every parent
+    # of the type fails the same way), so the exit code aborts submit.py's split loop.
+    missing = _missing_split_facts(config)
+    if missing:
+        print(
+            f"Error: type '{args.type}' declares no {' / '.join(missing)}; it cannot be split.",
+            file=sys.stderr,
+        )
+        sys.exit(EXIT_SYSTEMIC)
 
     server, user, token = require_env()
 

--- a/scripts/submit.py
+++ b/scripts/submit.py
@@ -26,16 +26,16 @@ import sys
 # to a file or pipe (Python defaults to full buffering in that case).
 sys.stdout.reconfigure(line_buffering=True)
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import type_registry  # noqa: E402
 from artifact_utils import (  # noqa: E402
     ValidationError,
     find_removed_context_yaml,
     read_frontmatter_validated,
     rebuild_index,
-    rename_initiative_to_jira_key,
-    rename_to_jira_key,
+    rename_to_tracker_key,
     render_removed_context_comment,
-    scan_initiative_task_files,
-    scan_task_files,
+    scan_tasks,
     update_frontmatter,
 )
 from generate_run_report import TYPE_CONFIG as REPORT_TYPE_CONFIG  # noqa: E402
@@ -58,74 +58,54 @@ from snapshot_fetch import compute_content_hash, update_snapshot_hashes  # noqa:
 
 # ─── Type Configurations ─────────────────────────────────────────────────────
 
-TYPE_CONFIGS = {
-    "rfe": {
-        "project": "RHAIRFE",
-        "issue_type": "Feature Request",
-        "type_label": "RFE",
-        "id_field": "rfe_id",
-        "local_prefix": "RFE-",
-        "jira_prefix": "RHAIRFE-",
-        "tasks_dir": "rfe-tasks",
-        "reviews_dir": "rfe-reviews",
-        "originals_dir": "rfe-originals",
-        "task_schema": "rfe-task",
-        "review_schema": "rfe-review",
-        "snapshot_prefix": "",
-        "split_type_arg": None,
-        "label_prefix": "rfe-creator",
-        "rubric_pass_label": "rfe-creator-autofix-rubric-pass",
-        "feasibility_labels": {
-            "feasible": "rfe-creator-feasibility-pass",
-            "infeasible": "rfe-creator-feasibility-fail",
-            "indeterminate": "rfe-creator-feasibility-unknown",
-        },
-        "alignment_labels": None,
-        "removed_context_preamble": (
-            "*[RFE Creator]* The following technical implementation "
-            "details were removed from the RFE description during review. "
-            "This content is better suited for a RHAISTRAT and is "
-            "preserved here for reference:"
-        ),
-        "comment_prefix": "[RFE Creator]",
-        "has_index": True,
-    },
-    "initiative": {
-        "project": "RHOAIENG",
-        "issue_type": "Initiative",
-        "type_label": "Initiative",
-        "id_field": "initiative_id",
-        "local_prefix": "INIT-",
-        "jira_prefix": "RHOAIENG-",
-        "tasks_dir": "initiatives",
-        "reviews_dir": "initiative-reviews",
-        "originals_dir": "initiative-originals",
-        "task_schema": "initiative-task",
-        "review_schema": "initiative-review",
-        "snapshot_prefix": "initiative-snapshot-",
-        "split_type_arg": "initiative",
-        "label_prefix": "initiative",
-        "rubric_pass_label": "initiative-autofix-rubric-pass",
-        "feasibility_labels": {
-            "feasible": "initiative-feasibility-pass",
-            "infeasible": "initiative-feasibility-fail",
-            "indeterminate": "initiative-feasibility-unknown",
-        },
-        "alignment_labels": {
-            "strong": "initiative-alignment-strong",
-            "partial": "initiative-alignment-partial",
-            "weak": "initiative-alignment-weak",
-        },
-        "removed_context_preamble": (
-            "*[Initiative Creator]* The following technical implementation "
-            "details were removed from the Initiative description during review. "
-            "This content may be useful as strategy context and is "
-            "preserved here for reference:"
-        ),
-        "comment_prefix": "[Initiative Creator]",
-        "has_index": False,
-    },
-}
+# The work-item type registry (types/<name>/type.yaml), read once at import. Every
+# per-type value below is a projection of a descriptor (design
+# work-item-types-unified.md §10 item 2) — DESCRIPTOR values only, never the effective
+# binding: an environment override must not reach the Jira write path before resolve()
+# (a later PR) prints and checks it.
+_TYPES = type_registry.load()
+
+
+def _type_config(desc):
+    """Project one descriptor onto the per-type table main() reads.
+
+    Same keys, same key order and same values as the literal table this replaces, so
+    every label, comment, plan line and Jira payload composed from it is unchanged byte
+    for byte. Two entries are conventions rather than descriptor fields, both
+    grandfathered for rfe: ``snapshot_prefix`` is "" for rfe — a sentinel for
+    snapshot_fetch's default prefix (only a truthy value is forwarded as ``prefix=``) —
+    and ``split_type_arg`` is the argv convention for spawning split_submit.py (no
+    ``--type`` for rfe, the type name otherwise). The labels composed elsewhere in this
+    file (auto-created, auto-revised, needs-attention, split-quarantine) keep composing
+    from ``label_prefix`` exactly as before.
+    """
+    dirs = desc.dirs("bare")
+    alignment = desc.get("conventions.labels.alignment", None)
+    return {
+        "project": desc.get("identity.jira.project"),
+        "issue_type": desc.get("identity.jira.issue_type"),
+        "type_label": desc.get("conventions.type_label"),
+        "id_field": desc.id_field,
+        "local_prefix": desc.local_prefix,
+        "jira_prefix": desc.write_prefix,
+        "tasks_dir": dirs["tasks"],
+        "reviews_dir": dirs["reviews"],
+        "originals_dir": dirs["originals"],
+        "task_schema": f"{desc.name}-task",
+        "review_schema": f"{desc.name}-review",
+        "snapshot_prefix": "" if desc.name == "rfe" else desc.get("snapshot.prefix"),
+        "split_type_arg": None if desc.name == "rfe" else desc.name,
+        "label_prefix": desc.get("conventions.label_prefix"),
+        "rubric_pass_label": desc.get("conventions.labels.rubric_pass"),
+        "feasibility_labels": dict(desc.get("conventions.labels.feasibility")),
+        "alignment_labels": None if alignment is None else dict(alignment),
+        "removed_context_preamble": desc.get("conventions.removed_context_preamble"),
+        "comment_prefix": desc.get("conventions.comment_prefix"),
+        "has_index": desc.get("index.enabled"),
+    }
+
+
+TYPE_CONFIGS = {name: _type_config(_TYPES.get(name)) for name in _TYPES.names()}
 
 # Module-level alias for backward compat (used by test_submit.py direct imports)
 FEASIBILITY_LABELS = TYPE_CONFIGS["rfe"]["feasibility_labels"]
@@ -149,19 +129,6 @@ def feasibility_label_changes(verdict, *, is_reject, original_labels, feasibilit
     new_label = feasibility_labels[verdict]
     stale = [lbl for lbl in feasibility_labels.values() if lbl != new_label and lbl in original]
     return new_label, stale
-
-
-def _scan_tasks(artifacts_dir, cfg):
-    if cfg["id_field"] == "initiative_id":
-        return scan_initiative_task_files(artifacts_dir)
-    return scan_task_files(artifacts_dir)
-
-
-def _rename_to_jira(artifacts_dir, item_id, jira_key, cfg):
-    if cfg["id_field"] == "initiative_id":
-        rename_initiative_to_jira_key(artifacts_dir, item_id, jira_key)
-    else:
-        rename_to_jira_key(artifacts_dir, item_id, jira_key)
 
 
 def _find_review(artifacts_dir, item_id, cfg):
@@ -189,8 +156,10 @@ def _generate_reports(args):
         "--report-stage",
         "final",
     ]
-    if args.type == "initiative":
-        yaml_cmd.extend(["--type", "initiative"])
+    # Both report scripts default to rfe; the rfe invocation carries no --type (grandfathered
+    # argv, kept byte-identical) and every other type is named explicitly.
+    if args.type != "rfe":
+        yaml_cmd.extend(["--type", args.type])
     result = subprocess.run(yaml_cmd, capture_output=True, text=True)
     if result.returncode == 0:
         print(f"  YAML report: {result.stdout.strip()}")
@@ -207,8 +176,8 @@ def _generate_reports(args):
         "--output",
         html_output,
     ]
-    if args.type == "initiative":
-        html_cmd.extend(["--type", "initiative"])
+    if args.type != "rfe":
+        html_cmd.extend(["--type", args.type])
     result = subprocess.run(html_cmd, capture_output=True, text=True)
     if result.returncode != 0:
         print(f"Warning: HTML report generation failed: {result.stderr}", file=sys.stderr)
@@ -364,7 +333,7 @@ def main():
     )
     parser.add_argument(
         "--type",
-        choices=["rfe", "initiative"],
+        choices=_TYPES.choices(),
         default="rfe",
         help="Item type to submit (default: rfe)",
     )
@@ -391,12 +360,21 @@ def main():
     args = parser.parse_args()
 
     cfg = TYPE_CONFIGS[args.type]
+    desc = _TYPES.get(args.type)
     id_field = cfg["id_field"]
     jira_prefix = cfg["jira_prefix"]
     type_label = cfg["type_label"]
+    # The one transition this script performs, declared per tracker binding (design §3.4):
+    # the target status of --auto-approve and the already-there short-circuit. Optional in
+    # the schema (a type that never approves omits it), so it is only required by the flag.
+    approved_status = desc.get("identity.jira.state_map.approved", None)
 
     if args.generate_report and not args.report_timestamp:
         parser.error("--report-timestamp is required when --generate-report is set")
+    if args.auto_approve and not approved_status:
+        parser.error(
+            f"--auto-approve: type '{args.type}' declares no identity.jira.state_map.approved"
+        )
 
     server, user, token = require_env()
 
@@ -406,7 +384,7 @@ def main():
         sys.exit(1)
 
     # Scan task files
-    tasks = _scan_tasks(args.artifacts_dir, cfg)
+    tasks = scan_tasks(args.artifacts_dir, desc)
     if not tasks:
         print(f"Error: No {type_label} task files found.", file=sys.stderr)
         sys.exit(1)
@@ -656,7 +634,7 @@ def main():
     if split_parents and not args.dry_run:
         try:
             split_child_hashes = {}
-            post_split_tasks = _scan_tasks(args.artifacts_dir, cfg)
+            post_split_tasks = scan_tasks(args.artifacts_dir, desc)
             for path, data in post_split_tasks:
                 if data.get("parent_key") and data.get("status") == "Submitted":
                     item_id = data.get(id_field, "")
@@ -687,7 +665,7 @@ def main():
             )
 
     # --- Phase 2: Submit regular items ---
-    tasks = _scan_tasks(args.artifacts_dir, cfg)
+    tasks = scan_tasks(args.artifacts_dir, desc)
 
     submittable = [
         (path, data)
@@ -969,7 +947,7 @@ def main():
 
     approve_comment = (
         f"*{cfg['comment_prefix']}* This {type_label} has been automatically "
-        "transitioned to Approved status based on passing rubric scoring and "
+        f"transitioned to {approved_status} status based on passing rubric scoring and "
         "technical feasibility checks. Approval does not constitute a commitment "
         "to customers until this item is prioritized into a product release "
         "by product management."
@@ -978,14 +956,14 @@ def main():
     def _maybe_approve(item_id, jira_key, entry):
         if not args.auto_approve or not entry.get("auto_approve"):
             return
-        if entry.get("jira_status") == "Approved":
-            print(f"  {item_id}: Already Approved, skipping transition")
+        if entry.get("jira_status") == approved_status:
+            print(f"  {item_id}: Already {approved_status}, skipping transition")
             return
         if args.dry_run:
-            print(f"  {item_id}: Would transition to Approved")
+            print(f"  {item_id}: Would transition to {approved_status}")
             return
-        if transition_issue(server, user, token, jira_key, "Approved"):
-            print(f"  {item_id}: Transitioned to Approved")
+        if transition_issue(server, user, token, jira_key, approved_status):
+            print(f"  {item_id}: Transitioned to {approved_status}")
             comment_adf = markdown_to_adf(approve_comment)
             add_comment(server, user, token, jira_key, comment_adf)
             print(f"  {item_id}: Posted auto-approve comment")
@@ -1139,7 +1117,7 @@ def main():
             if not entry["is_existing"] and not args.dry_run:
                 new_key = results.get(item_id)
                 if new_key and not new_key.endswith("DRY"):
-                    _rename_to_jira(args.artifacts_dir, item_id, new_key, cfg)
+                    rename_to_tracker_key(args.artifacts_dir, item_id, new_key, desc)
                     print(f"  {item_id}: Renamed to {new_key}")
 
             mark_processed_ids.append(item_id)

--- a/scripts/type_registry.py
+++ b/scripts/type_registry.py
@@ -21,7 +21,7 @@ be lifted verbatim into the ``creator-core`` follow-up (design §10 item 10), so
 them free of repo-specific helpers: JSON-Schema validation lives in
 ``scripts/validate_types.py`` (the only place ``jsonschema`` is imported), not here.
 
-Adoption status (PR-2a): 18 scripts load the registry at import (module-level
+Adoption status (PR-2d): 26 scripts load the registry at import (module-level
 ``_TYPES = type_registry.load()``; the table in ``types/README.md`` lists them) and use
 DESCRIPTOR values only; ``detect()``/``owns()`` are the design §5 rung-3 seed. The values a
 pending script still carries are pinned equal to the descriptors by test, and the remaining

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,89 @@ import time
 import urllib.request
 
 import pytest
+import yaml
+
+TYPES_DIR = os.path.join(os.path.dirname(__file__), "..", "types")
+
+
+# ─── Drop-in type descriptors ─────────────────────────────────────────────────
+
+
+def _set_dotted(data, dotted, value):
+    node = data
+    keys = dotted.split(".")
+    for key in keys[:-1]:
+        node = node.setdefault(key, {})
+    node[keys[-1]] = value
+
+
+def _del_dotted(data, dotted):
+    node = data
+    keys = dotted.split(".")
+    for key in keys[:-1]:
+        node = node[key]
+    del node[keys[-1]]
+
+
+# A drop-in derived from types/rfe with its own binding, id grammar and layout, so it registers
+# next to the shipped types (split_submit refuses two types on one (project, issue_type) pair)
+# and scans its own directories. Everything else (labels, schema facts, snapshot, reporting)
+# stays the rfe value, so every adopted table builds for it at import.
+MEMO_OVERRIDES = {
+    "display": {"entity": "Memo", "entity_plural": "Memos"},
+    "identity.jira.project": "MEMO",
+    "identity.jira.issue_type": "Memo",
+    "identity.jira.key_prefixes": ["MEMO-"],
+    "identity.local_prefix": "MEMO-",
+    "identity.local_id_pattern": r"^MEMO-\d+$",
+    "identity.id_field": "memo_id",
+    "dirs.tasks": "artifacts/memo-tasks",
+    "dirs.originals": "artifacts/memo-originals",
+    "dirs.reviews": "artifacts/memo-reviews",
+    "conventions.type_label": "Memo",
+    "conventions.parent_key_patterns": [r"MEMO-\d+"],
+    "snapshot.prefix": "memo-snapshot-",
+}
+
+
+def write_drop_in(root, name, base="rfe", overrides=None, drop=()):
+    """Write ``<root>/<name>/type.yaml``: the shipped ``base`` descriptor renamed to ``name``,
+    with the dotted ``drop`` paths removed and the dotted ``overrides`` applied. Returns the
+    descriptor path. ``root`` is what RFE_CREATOR_EXTRA_TYPES takes."""
+    with open(os.path.join(TYPES_DIR, base, "type.yaml"), encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    data["type"] = name
+    for dotted in drop:
+        _del_dotted(data, dotted)
+    for dotted, value in (overrides or {}).items():
+        _set_dotted(data, dotted, value)
+    path = os.path.join(root, name, "type.yaml")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(data, fh, sort_keys=False)
+    return path
+
+
+class DropInRoot:
+    """One extra registry root under tmp_path; ``path`` is the RFE_CREATOR_EXTRA_TYPES value."""
+
+    def __init__(self, path):
+        self.path = path
+
+    def add(self, name, base="rfe", overrides=None, drop=()):
+        write_drop_in(self.path, name, base=base, overrides=overrides, drop=drop)
+        return self.path
+
+    def memo(self, name="memo", drop=()):
+        """An rfe copy on its own (MEMO, Memo) binding, minus the ``drop`` paths."""
+        return self.add(name, overrides=MEMO_OVERRIDES, drop=drop)
+
+
+@pytest.fixture
+def drop_in_root(tmp_path):
+    root = tmp_path / "extra-types"
+    root.mkdir()
+    return DropInRoot(str(root))
 
 
 def _find_free_port():

--- a/tests/data/prefix_predicate_baseline.json
+++ b/tests/data/prefix_predicate_baseline.json
@@ -6,6 +6,5 @@
   "scripts/fetch_issue.py": 1,
   "scripts/jira_utils.py": 1,
   "scripts/pipeline_state.py": 1,
-  "scripts/submit.py": 5,
   "scripts/validate_batch_input.py": 2
 }

--- a/tests/test_initiative_submit.py
+++ b/tests/test_initiative_submit.py
@@ -8,6 +8,7 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import type_registry  # noqa: E402
 
 SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "submit.py")
 
@@ -18,14 +19,30 @@ def _write(path, content):
         f.write(content)
 
 
+def _clean_env(**extra):
+    """The developer's registry seams and the headless/CI markers stay out of subprocess runs
+    (an RFE_CREATOR_EXTRA_TYPES root would change the --type choices; a runner's ``CI`` would
+    gate it)."""
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith("RFE_CREATOR_") and k not in type_registry.HEADLESS_MARKER_VARS
+    }
+    env.update(extra)
+    return env
+
+
+FAKE_CREDS = {
+    "JIRA_SERVER": "https://fake.atlassian.net",
+    "JIRA_USER": "fake@example.com",
+    "JIRA_TOKEN": "fake-token",
+}
+NO_CREDS = {"JIRA_SERVER": "", "JIRA_USER": "", "JIRA_TOKEN": ""}
+
+
 def _run_submit(artifacts_dir, extra_flags=None):
     """Run submit.py --type initiative --dry-run and return stdout."""
-    env = {
-        **os.environ,
-        "JIRA_SERVER": "https://fake.atlassian.net",
-        "JIRA_USER": "fake@example.com",
-        "JIRA_TOKEN": "fake-token",
-    }
+    env = _clean_env(**FAKE_CREDS)
     cmd = [
         "python3",
         SCRIPT,
@@ -370,12 +387,7 @@ class TestAutoApprove:
 class TestGenerateReportFlag:
     def test_generate_report_without_timestamp_fails(self):
         """--generate-report without --report-timestamp → error exit."""
-        env = {
-            **os.environ,
-            "JIRA_SERVER": "",
-            "JIRA_USER": "",
-            "JIRA_TOKEN": "",
-        }
+        env = _clean_env(**NO_CREDS)
         result = subprocess.run(
             [sys.executable, SCRIPT, "--type", "initiative", "--dry-run", "--generate-report"],
             capture_output=True,
@@ -393,12 +405,7 @@ class TestGenerateReportFlag:
             _default_review("INIT-001"),
         )
 
-        env = {
-            **os.environ,
-            "JIRA_SERVER": "https://fake.atlassian.net",
-            "JIRA_USER": "fake@example.com",
-            "JIRA_TOKEN": "fake-token",
-        }
+        env = _clean_env(**FAKE_CREDS)
         result = subprocess.run(
             [
                 sys.executable,
@@ -491,3 +498,66 @@ class TestNeedsAttention:
         stdout, _, rc = _run_submit(art_dir)
         assert rc == 0
         assert "Would post needs-attention comment" in stdout
+
+
+class TestTypeConfigProjection:
+    """The initiative entry of submit.TYPE_CONFIGS, projected from types/initiative/type.yaml,
+    must equal the literal table submit.py carried before it read the registry — key for key,
+    in key order (the rfe twin and the shared invariants live in tests/test_submit.py)."""
+
+    INITIATIVE = {
+        "project": "RHOAIENG",
+        "issue_type": "Initiative",
+        "type_label": "Initiative",
+        "id_field": "initiative_id",
+        "local_prefix": "INIT-",
+        "jira_prefix": "RHOAIENG-",
+        "tasks_dir": "initiatives",
+        "reviews_dir": "initiative-reviews",
+        "originals_dir": "initiative-originals",
+        "task_schema": "initiative-task",
+        "review_schema": "initiative-review",
+        "snapshot_prefix": "initiative-snapshot-",
+        "split_type_arg": "initiative",
+        "label_prefix": "initiative",
+        "rubric_pass_label": "initiative-autofix-rubric-pass",
+        "feasibility_labels": {
+            "feasible": "initiative-feasibility-pass",
+            "infeasible": "initiative-feasibility-fail",
+            "indeterminate": "initiative-feasibility-unknown",
+        },
+        "alignment_labels": {
+            "strong": "initiative-alignment-strong",
+            "partial": "initiative-alignment-partial",
+            "weak": "initiative-alignment-weak",
+        },
+        "removed_context_preamble": (
+            "*[Initiative Creator]* The following technical implementation "
+            "details were removed from the Initiative description during review. "
+            "This content may be useful as strategy context and is "
+            "preserved here for reference:"
+        ),
+        "comment_prefix": "[Initiative Creator]",
+        "has_index": False,
+    }
+
+    def test_initiative_projection_is_the_literal_table(self):
+        import submit as submit_mod
+
+        cfg = submit_mod.TYPE_CONFIGS["initiative"]
+        assert cfg == self.INITIATIVE
+        assert list(cfg) == list(self.INITIATIVE)
+        assert list(cfg["feasibility_labels"]) == list(self.INITIATIVE["feasibility_labels"])
+        assert list(cfg["alignment_labels"]) == list(self.INITIATIVE["alignment_labels"])
+        assert {k: type(v) for k, v in cfg.items()} == {
+            k: type(v) for k, v in self.INITIATIVE.items()
+        }
+
+    def test_projected_maps_do_not_alias_descriptor_data(self):
+        import submit as submit_mod
+
+        desc = submit_mod._TYPES.get("initiative")
+        cfg = submit_mod.TYPE_CONFIGS["initiative"]
+        assert cfg["alignment_labels"] == desc.get("conventions.labels.alignment")
+        assert cfg["alignment_labels"] is not desc.get("conventions.labels.alignment")
+        assert cfg["feasibility_labels"] is not desc.get("conventions.labels.feasibility")

--- a/tests/test_split_submit.py
+++ b/tests/test_split_submit.py
@@ -8,17 +8,25 @@ import sys
 import urllib.error
 
 import pytest
+import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import split_submit
+import type_registry
+from artifact_utils import read_frontmatter_validated
 from split_submit import (
     EXIT_PER_PARENT,
     EXIT_SYSTEMIC,
+    SPLIT_CONFIG,
     SubmissionState,
     _classify_exit,
     build_split_summary_adf,
+    phase3_close,
 )
 
 SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "split_submit.py")
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+EXTRA_TYPES = os.path.join(os.path.dirname(__file__), "fixtures", "types")
 
 
 def _write(path, content):
@@ -207,3 +215,449 @@ class TestUsageExitCode:
             text=True,
         )
         assert r.returncode == 64
+
+
+# ─── Registry projection (design work-item-types-unified.md §10 item 2) ──────
+
+
+# The SPLIT_CONFIG entry shape the phases and the integration tests read — frozen.
+SPLIT_CONFIG_KEYS = [
+    "project",
+    "issue_type",
+    "comment_marker",
+    "label_prefix",
+    "entity_name",
+    "entity_name_plural",
+    "id_field",
+    "reviews_dir",
+    "review_schema",
+    "originals_dir",
+    "scan_fn",
+    "rename_fn",
+    "parse_child_fn",
+    "find_review_fn",
+    "do_rebuild_index",
+    "alignment_labels",
+]
+TYPES = split_submit._TYPES.names()
+
+
+def _clean_env(**extra):
+    """The developer's registry seams and the headless/CI markers stay out of subprocess
+    runs (a CI runner's ``CI`` would otherwise gate RFE_CREATOR_EXTRA_TYPES)."""
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith("RFE_CREATOR_") and k not in type_registry.HEADLESS_MARKER_VARS
+    }
+    env.update({"JIRA_SERVER": "", "JIRA_USER": "", "JIRA_TOKEN": ""})
+    env.update(extra)
+    return env
+
+
+def _fm(fields, body="Body.\n"):
+    return "---\n" + yaml.safe_dump(fields, sort_keys=False) + "---\n\n" + body
+
+
+def _task_fields(desc, item_id, **extra):
+    fields = {desc.id_field: item_id, "title": "Child", "priority": "Major", "status": "Ready"}
+    fields.update(extra)
+    return fields
+
+
+def _review_fields(desc, item_id, **extra):
+    fields = {
+        desc.id_field: item_id,
+        "score": 9,
+        "pass": True,
+        "recommendation": "submit",
+        "feasibility": "feasible",
+        "auto_revised": False,
+        "needs_attention": False,
+        "scores": {name: 2 for name in desc.score_fields},
+    }
+    fields.update(extra)
+    return fields
+
+
+@pytest.fixture(params=TYPES, ids=TYPES)
+def desc(request):
+    return split_submit._TYPES.get(request.param)
+
+
+class TestSplitConfigProjection:
+    """SPLIT_CONFIG is a projection of the type registry: one entry per registered type in
+    ``choices()`` order, the frozen key shape, and callables bound to the type's descriptor
+    that keep the ``(artifacts_dir, ...)`` signatures of the per-type wrappers they replace."""
+
+    def test_one_entry_per_registered_type_with_the_frozen_key_order(self):
+        assert list(SPLIT_CONFIG) == split_submit._TYPES.choices()
+        for config in SPLIT_CONFIG.values():
+            assert list(config) == SPLIT_CONFIG_KEYS
+
+    def test_scalar_values_project_the_descriptor(self, desc):
+        config = SPLIT_CONFIG[desc.name]
+        jira = desc.get("identity.jira")
+        bare = desc.dirs("bare")
+        assert (config["project"], config["issue_type"]) == (jira["project"], jira["issue_type"])
+        assert config["comment_marker"] == desc.get("conventions.comment_prefix")
+        assert config["label_prefix"] == desc.get("conventions.label_prefix")
+        assert config["entity_name"] == desc.get("display.entity")
+        assert config["entity_name_plural"] == desc.get("display.entity_plural")
+        assert config["id_field"] == desc.id_field
+        assert (config["reviews_dir"], config["originals_dir"]) == (
+            bare["reviews"],
+            bare["originals"],
+        )
+        assert config["review_schema"] == f"{desc.name}-review"
+        assert config["do_rebuild_index"] is desc.get("index.enabled")
+        assert config["alignment_labels"] == desc.get("conventions.labels.alignment", None)
+
+    def test_callables_are_bound_to_the_type(self, desc, tmp_path):
+        config = SPLIT_CONFIG[desc.name]
+        bare = desc.dirs("bare")
+        local, key = f"{desc.local_prefix}001", f"{desc.write_prefix}4321"
+        task = tmp_path / bare["tasks"] / f"{local}.md"
+        _write(str(task), _fm(_task_fields(desc, local), "## Problem\n\nChild body.\n"))
+        _write(str(tmp_path / bare["tasks"] / f"{local}-comments.md"), "# Comments\n")
+        review = tmp_path / bare["reviews"] / f"{local}-review.md"
+        _write(str(review), _fm(_review_fields(desc, local)))
+
+        # scan_fn: this type's dirs.tasks, validated as <type>-task, companions skipped
+        tasks = config["scan_fn"](str(tmp_path))
+        assert [(os.path.basename(p), d[desc.id_field]) for p, d in tasks] == [
+            (f"{local}.md", local)
+        ]
+
+        # parse_child_fn: (title, priority, full_markdown, cleaned_markdown)
+        title, priority, full, cleaned = config["parse_child_fn"](str(task))
+        assert (title, priority) == ("Child", "Major")
+        assert "Child body." in full and "Child body." in cleaned
+
+        # find_review_fn: this type's dirs.reviews, by local id and by tracker key
+        assert config["find_review_fn"](str(tmp_path), local) == str(review)
+        assert config["find_review_fn"](str(tmp_path), f"{desc.local_prefix}999") is None
+
+        # rename_fn: task + companions + review move to the tracker key
+        config["rename_fn"](str(tmp_path), local, key)
+        renamed_task = tmp_path / bare["tasks"] / f"{key}.md"
+        renamed_review = tmp_path / bare["reviews"] / f"{key}-review.md"
+        assert renamed_task.is_file() and renamed_review.is_file() and not task.exists()
+        assert (tmp_path / bare["tasks"] / f"{key}-comments.md").is_file()
+        data, _ = read_frontmatter_validated(str(renamed_task), f"{desc.name}-task")
+        assert (data[desc.id_field], data["status"], data["local_id"]) == (key, "Submitted", local)
+        assert config["find_review_fn"](str(tmp_path), key) == str(renamed_review)
+
+    def test_a_third_type_projects_without_code_changes(self):
+        reg = type_registry.load(
+            root=os.path.join(REPO_ROOT, "types"), extra_roots=[EXTRA_TYPES], env={}
+        )
+        config = split_submit._split_config(reg.get("epic"))
+        assert list(config) == SPLIT_CONFIG_KEYS
+        assert (config["project"], config["issue_type"]) == ("RHAI", "Epic")
+        assert (config["entity_name"], config["entity_name_plural"]) == ("Epic", "Epics")
+        assert (config["id_field"], config["reviews_dir"], config["review_schema"]) == (
+            "epic_id",
+            "epic-reviews",
+            "epic-review",
+        )
+        assert config["do_rebuild_index"] is False and config["alignment_labels"] is None
+        callables = ("scan_fn", "rename_fn", "parse_child_fn", "find_review_fn")
+        assert all(callable(config[k]) for k in callables)
+
+    def test_drop_in_type_appears_in_the_config_and_the_type_choices(self, tmp_path):
+        env = _clean_env(RFE_CREATOR_EXTRA_TYPES=EXTRA_TYPES)
+        r = subprocess.run(
+            [sys.executable, SCRIPT, "--help"], capture_output=True, text=True, env=env
+        )
+        assert r.returncode == 0, r.stderr
+        assert "{rfe,epic,initiative}" in r.stdout
+        # The epic fixture never splits (no split_link_type, state_map {}), so a split of one
+        # is refused up front — before the scan that would otherwise report no epic files.
+        r = subprocess.run(
+            [sys.executable, SCRIPT, "RHAI-1", "--dry-run", "--type", "epic"]
+            + ["--artifacts-dir", str(tmp_path)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert r.returncode == split_submit.EXIT_SYSTEMIC
+        assert "type 'epic' declares no identity.jira.split_link_type" in r.stderr
+        assert "it cannot be split." in r.stderr
+        assert "No epic files found" not in r.stderr
+
+
+class TestTrackerFactsFromTheBinding:
+    """The split link type and the close-superseded transition/resolution come from the
+    type's Jira binding (identity.jira.split_link_type / state_map.close_superseded),
+    recovered from a SPLIT_CONFIG entry through its (project, issue_type) pair."""
+
+    def test_tracker_projects_the_binding(self, desc):
+        facts = split_submit._tracker(SPLIT_CONFIG[desc.name])
+        assert facts["split_link_type"] == desc.get("identity.jira.split_link_type")
+        assert facts["close_superseded"] == desc.get("identity.jira.state_map.close_superseded")
+        assert facts["split_link_type"]
+        assert facts["close_superseded"]["transition"] and facts["close_superseded"]["resolution"]
+
+    def test_inspect_child_derives_linked_from_the_binding_link_type(
+        self, desc, tmp_path, monkeypatch
+    ):
+        config = SPLIT_CONFIG[desc.name]
+        parent, key = f"{desc.write_prefix}1000", f"{desc.write_prefix}1001"
+        child = tmp_path / f"{desc.local_prefix}001.md"
+        _write(str(child), _fm(_task_fields(desc, f"{desc.local_prefix}001")))
+        live = {}
+
+        def fake_get_issue(server, user, token, issue_key, fields=None):
+            assert issue_key == key
+            link = {"type": {"name": live["link"]}, "inwardIssue": {"key": parent}}
+            return {"fields": {"summary": "Child", "description": None, "issuelinks": [link]}}
+
+        monkeypatch.setattr(split_submit, "get_issue", fake_get_issue)
+        live["link"] = desc.get("identity.jira.split_link_type")
+        seen = split_submit._inspect_child("s", "u", "t", key, str(child), parent, config)
+        assert seen["linked"] is True and seen["title"] == "Child"
+        live["link"] = "Relates"
+        seen = split_submit._inspect_child("s", "u", "t", key, str(child), parent, config)
+        assert seen["linked"] is False
+
+    def _closable(self, desc):
+        parent = f"{desc.write_prefix}1000"
+        child_id = f"{desc.local_prefix}001"
+        children = [(child_id, "Child", "Major", "/fake/path")]
+        state = SubmissionState()
+        state.phase2_done = {
+            child_id: {"key": f"{desc.write_prefix}1001", "linked": True, "commented": True}
+        }
+        return parent, children, state
+
+    def test_phase3_dry_run_plans_the_binding_transition(self, desc, capsys):
+        config = SPLIT_CONFIG[desc.name]
+        close = desc.get("identity.jira.state_map.close_superseded")
+        parent, children, state = self._closable(desc)
+        phase3_close("s", "u", "t", parent, children, state, config, dry_run=True)
+        out = capsys.readouterr().out
+        assert f"Would label {parent} with {config['label_prefix']}-split-original" in out
+        assert (
+            f"Would transition {parent} to {close['transition']} "
+            f"(resolution: {close['resolution']})"
+        ) in out
+
+    def test_phase3_matches_the_target_status_case_insensitively(self, desc, monkeypatch, capsys):
+        config = SPLIT_CONFIG[desc.name]
+        close = desc.get("identity.jira.state_map.close_superseded")
+        parent, children, state = self._closable(desc)
+        calls = {}
+        transitions = [
+            {"id": "1", "name": "Start", "to": {"name": "In Progress"}},
+            {"id": "9", "name": "Retire", "to": {"name": close["transition"].upper()}},
+        ]
+        monkeypatch.setattr(
+            split_submit, "add_labels", lambda s, u, t, k, labels: calls.update(labels=labels)
+        )
+        monkeypatch.setattr(split_submit, "get_transitions", lambda s, u, t, k: transitions)
+        monkeypatch.setattr(
+            split_submit,
+            "do_transition",
+            lambda s, u, t, k, tid, fields=None: calls.update(tid=tid, fields=fields),
+        )
+        monkeypatch.setattr(
+            split_submit, "add_comment", lambda s, u, t, k, adf: calls.update(adf=adf)
+        )
+        phase3_close("https://j", "u", "t", parent, children, state, config, dry_run=False)
+        assert calls["labels"] == [f"{config['label_prefix']}-split-original"]
+        assert calls["tid"] == "9"
+        assert calls["fields"] == {"resolution": {"name": close["resolution"]}}
+        assert calls["adf"]["type"] == "doc"
+        assert f"Transitioned {parent} to {close['transition']} ({close['resolution']})" in (
+            capsys.readouterr().out
+        )
+
+    def test_phase3_warns_with_the_binding_status_when_unreachable(self, desc, monkeypatch, capsys):
+        config = SPLIT_CONFIG[desc.name]
+        close = desc.get("identity.jira.state_map.close_superseded")
+        parent, children, state = self._closable(desc)
+        monkeypatch.setattr(split_submit, "add_labels", lambda *a: None)
+        monkeypatch.setattr(
+            split_submit,
+            "get_transitions",
+            lambda *a: [{"id": "1", "name": "Start", "to": {"name": "In Progress"}}],
+        )
+        monkeypatch.setattr(
+            split_submit, "do_transition", lambda *a, **k: pytest.fail("must not transition")
+        )
+        phase3_close("https://j", "u", "t", parent, children, state, config, dry_run=False)
+        err = capsys.readouterr().err
+        assert f"No '{close['transition']}' transition found" in err
+        assert "Skipping parent closure." in err
+
+
+class TestTypeChoices:
+    def test_type_choices_are_the_registry_choices(self):
+        r = subprocess.run(
+            [sys.executable, SCRIPT, "--help"], capture_output=True, text=True, env=_clean_env()
+        )
+        assert r.returncode == 0
+        assert "{" + ",".join(split_submit._TYPES.choices()) + "}" in r.stdout
+
+    def test_unknown_type_is_a_usage_error(self):
+        r = subprocess.run(
+            [sys.executable, SCRIPT, "X-1", "--type", "nope"],
+            capture_output=True,
+            text=True,
+            env=_clean_env(),
+        )
+        assert r.returncode == 64
+        assert "invalid choice: 'nope'" in r.stderr
+
+
+INITIATIVE_PARENT = """\
+---
+initiative_id: RHOAIENG-2000
+title: Parent Initiative
+priority: Critical
+status: Archived
+parent_key: RHAISTRAT-77
+---
+
+## Objective
+
+Original parent initiative content.
+"""
+
+INITIATIVE_CHILD = """\
+---
+initiative_id: INIT-{num:03d}
+title: Child Initiative {num}
+priority: Normal
+status: Ready
+parent_key: RHOAIENG-2000
+---
+
+## Objective
+
+Child initiative {num} objective.
+"""
+
+
+class TestInitiativeDryRun:
+    def test_plans_the_initiative_binding_end_to_end(self, tmp_path):
+        """--type initiative resolves every per-type value from the initiative descriptor:
+        project, label prefix, alignment labels, link type, closure — and no index rebuild."""
+        art = str(tmp_path)
+        _write(f"{art}/initiatives/RHOAIENG-2000.md", INITIATIVE_PARENT)
+        for i in (1, 2):
+            _write(f"{art}/initiatives/INIT-{i:03d}.md", INITIATIVE_CHILD.format(num=i))
+        desc = split_submit._TYPES.get("initiative")
+        review = _review_fields(
+            desc, "INIT-001", auto_revised=True, needs_attention=True, alignment="weak"
+        )
+        review["needs_attention_reason"] = "Weak alignment"
+        _write(f"{art}/initiative-reviews/INIT-001-review.md", _fm(review))
+
+        r = subprocess.run(
+            [sys.executable, SCRIPT, "RHOAIENG-2000", "--dry-run", "--type", "initiative"]
+            + ["--artifacts-dir", art],
+            capture_output=True,
+            text=True,
+            env=_clean_env(),
+        )
+        assert r.returncode == 0, r.stderr
+        out = r.stdout
+        assert "Split submission: RHOAIENG-2000 -> 2 children" in out
+        assert "Phase 1: Persisting child Initiative content to parent comments..." in out
+        assert "Would create RHOAIENG ticket for child 1/2: Child Initiative 1" in out
+        assert (
+            "Labels: initiative-auto-created, initiative-split-result, "
+            "initiative-split-child-rhoaieng-2000-init-001-"
+        ) in out
+        assert (
+            "initiative-auto-revised, initiative-needs-attention, "
+            "initiative-autofix-rubric-pass, initiative-feasibility-pass, "
+            "initiative-alignment-weak"
+        ) in out
+        assert "Would link to RHOAIENG-2000 via 'Work item split'" in out
+        assert "Would post needs-attention comment" in out
+        assert "Would label RHOAIENG-2000 with initiative-split-original" in out
+        assert "Would transition RHOAIENG-2000 to Closed (resolution: Obsolete)" in out
+        assert out.rstrip().endswith("Done.")
+        assert not os.path.exists(f"{art}/rfes.md")
+
+
+class TestSplitFactsGuards:
+    """identity.jira.split_link_type and state_map.close_superseded are optional in the schema
+    (a type that never splits omits them), so their absence is refused at the moment a parent
+    of that type is submitted for a split — before any scan or Jira call — and a second type
+    on a shipped type's (project, issue_type) pair cannot silently replace its facts."""
+
+    def test_shipped_types_miss_nothing(self, desc):
+        assert split_submit._missing_split_facts(SPLIT_CONFIG[desc.name]) == []
+
+    def test_missing_facts_are_named_one_by_one(self, monkeypatch):
+        pair = ("MEMO", "Memo")
+        config = {"project": pair[0], "issue_type": pair[1]}
+        tracker = dict(split_submit._TRACKER)
+        monkeypatch.setattr(split_submit, "_TRACKER", tracker)
+
+        tracker[pair] = {"split_link_type": None, "close_superseded": None}
+        assert split_submit._missing_split_facts(config) == [
+            "identity.jira.split_link_type",
+            "identity.jira.state_map.close_superseded.transition",
+            "identity.jira.state_map.close_superseded.resolution",
+        ]
+        tracker[pair] = {"split_link_type": "Work item split", "close_superseded": {}}
+        assert split_submit._missing_split_facts(config) == [
+            "identity.jira.state_map.close_superseded.transition",
+            "identity.jira.state_map.close_superseded.resolution",
+        ]
+        tracker[pair] = {
+            "split_link_type": "Work item split",
+            "close_superseded": {"transition": "Closed"},
+        }
+        assert split_submit._missing_split_facts(config) == [
+            "identity.jira.state_map.close_superseded.resolution",
+        ]
+
+    def _run_memo(self, root, tmp_path):
+        return subprocess.run(
+            [sys.executable, SCRIPT, "MEMO-1", "--dry-run", "--type", "memo"]
+            + ["--artifacts-dir", str(tmp_path / "artifacts")],
+            capture_output=True,
+            text=True,
+            env=_clean_env(RFE_CREATOR_EXTRA_TYPES=root),
+        )
+
+    def test_a_type_without_split_facts_is_refused_before_scanning(self, drop_in_root, tmp_path):
+        root = drop_in_root.memo(
+            drop=("identity.jira.split_link_type", "identity.jira.state_map.close_superseded")
+        )
+        r = self._run_memo(root, tmp_path)
+        assert r.returncode == split_submit.EXIT_SYSTEMIC, r.stderr
+        assert (
+            "Error: type 'memo' declares no identity.jira.split_link_type / "
+            "identity.jira.state_map.close_superseded.transition / "
+            "identity.jira.state_map.close_superseded.resolution; it cannot be split."
+        ) in r.stderr
+        assert "No memo files found" not in r.stderr
+        assert r.stdout == ""
+
+    def test_a_type_with_split_facts_passes_the_guard(self, drop_in_root, tmp_path):
+        r = self._run_memo(drop_in_root.memo(), tmp_path)
+        assert r.returncode == split_submit.EXIT_PER_PARENT, r.stderr
+        assert "No memo files found" in r.stderr
+        assert "cannot be split" not in r.stderr
+
+    def test_two_types_on_one_binding_pair_fail_the_import(self, drop_in_root):
+        root = drop_in_root.add("rfe2")  # a plain rfe copy: the same (RHAIRFE, Feature Request)
+        r = subprocess.run(
+            [sys.executable, SCRIPT, "--help"],
+            capture_output=True,
+            text=True,
+            env=_clean_env(RFE_CREATOR_EXTRA_TYPES=root),
+        )
+        assert r.returncode != 0
+        assert "RegistryError" in r.stderr
+        assert (
+            "split_submit: types 'rfe' and 'rfe2' share the (project, issue_type) binding "
+            "('RHAIRFE', 'Feature Request')"
+        ) in r.stderr

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -5,10 +5,12 @@ import os
 import shutil
 import subprocess
 import sys
+from types import SimpleNamespace
 
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import type_registry  # noqa: E402
 
 SCRIPT = os.path.join(os.path.dirname(__file__), "..", "scripts", "submit.py")
 
@@ -19,14 +21,30 @@ def _write(path, content):
         f.write(content)
 
 
+def _clean_env(**extra):
+    """The developer's registry seams and the headless/CI markers stay out of subprocess runs
+    (an RFE_CREATOR_EXTRA_TYPES root would change the --type choices; a runner's ``CI`` would
+    gate it)."""
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.startswith("RFE_CREATOR_") and k not in type_registry.HEADLESS_MARKER_VARS
+    }
+    env.update(extra)
+    return env
+
+
+FAKE_CREDS = {
+    "JIRA_SERVER": "https://fake.atlassian.net",
+    "JIRA_USER": "fake@example.com",
+    "JIRA_TOKEN": "fake-token",
+}
+NO_CREDS = {"JIRA_SERVER": "", "JIRA_USER": "", "JIRA_TOKEN": ""}
+
+
 def _run_submit(artifacts_dir, extra_flags=None):
     """Run submit.py --dry-run and return stdout."""
-    env = {
-        **os.environ,
-        "JIRA_SERVER": "https://fake.atlassian.net",
-        "JIRA_USER": "fake@example.com",
-        "JIRA_TOKEN": "fake-token",
-    }
+    env = _clean_env(**FAKE_CREDS)
     cmd = ["python3", SCRIPT, "--dry-run", "--artifacts-dir", artifacts_dir]
     if extra_flags:
         cmd.extend(extra_flags)
@@ -702,12 +720,7 @@ class TestGenerateReportFlag:
 
     def test_generate_report_without_timestamp_fails(self):
         """--generate-report without --report-timestamp → error exit."""
-        env = {
-            **os.environ,
-            "JIRA_SERVER": "",
-            "JIRA_USER": "",
-            "JIRA_TOKEN": "",
-        }
+        env = _clean_env(**NO_CREDS)
         result = subprocess.run(
             [sys.executable, SCRIPT, "--dry-run", "--generate-report"],
             capture_output=True,
@@ -725,12 +738,7 @@ class TestGenerateReportFlag:
             REVIEW_FM.format(rfe_id="RFE-001", auto_revised="false"),
         )
 
-        env = {
-            **os.environ,
-            "JIRA_SERVER": "https://fake.atlassian.net",
-            "JIRA_USER": "fake@example.com",
-            "JIRA_TOKEN": "fake-token",
-        }
+        env = _clean_env(**FAKE_CREDS)
         result = subprocess.run(
             [
                 sys.executable,
@@ -974,12 +982,7 @@ class TestSplitFailureIsRecorded:
         # type root beside it or every registry-adopted import (generate_run_report) dies.
         shutil.copytree(os.path.join(os.path.dirname(SCRIPT), "..", "types"), tmp_path / "types")
 
-        env = {
-            **os.environ,
-            "JIRA_SERVER": "https://fake.atlassian.net",
-            "JIRA_USER": "fake@example.com",
-            "JIRA_TOKEN": "fake-token",
-        }
+        env = _clean_env(**FAKE_CREDS)
         result = subprocess.run(
             [
                 "python3",
@@ -1049,3 +1052,213 @@ class TestRecordSplitFailureResilience:
 
         assert "rfe-creator-split-quarantine" in added
         assert "rfe-creator-needs-attention" in added
+
+
+class TestTypeConfigsProjection:
+    """TYPE_CONFIGS projects the type descriptors (types/<type>/type.yaml) at import.
+
+    The rfe entry must equal, key for key and in key order, the literal table submit.py carried
+    before it read the registry: every label, comment and Jira payload this script composes
+    derives from these values, so the table is an artifact contract and this golden keeps a
+    descriptor edit that reaches Jira a visible test change. (The initiative twin lives in
+    tests/test_initiative_submit.py.)
+    """
+
+    RFE = {
+        "project": "RHAIRFE",
+        "issue_type": "Feature Request",
+        "type_label": "RFE",
+        "id_field": "rfe_id",
+        "local_prefix": "RFE-",
+        "jira_prefix": "RHAIRFE-",
+        "tasks_dir": "rfe-tasks",
+        "reviews_dir": "rfe-reviews",
+        "originals_dir": "rfe-originals",
+        "task_schema": "rfe-task",
+        "review_schema": "rfe-review",
+        "snapshot_prefix": "",
+        "split_type_arg": None,
+        "label_prefix": "rfe-creator",
+        "rubric_pass_label": "rfe-creator-autofix-rubric-pass",
+        "feasibility_labels": {
+            "feasible": "rfe-creator-feasibility-pass",
+            "infeasible": "rfe-creator-feasibility-fail",
+            "indeterminate": "rfe-creator-feasibility-unknown",
+        },
+        "alignment_labels": None,
+        "removed_context_preamble": (
+            "*[RFE Creator]* The following technical implementation "
+            "details were removed from the RFE description during review. "
+            "This content is better suited for a RHAISTRAT and is "
+            "preserved here for reference:"
+        ),
+        "comment_prefix": "[RFE Creator]",
+        "has_index": True,
+    }
+
+    def test_rfe_projection_is_the_literal_table(self):
+        import submit as submit_mod
+
+        cfg = submit_mod.TYPE_CONFIGS["rfe"]
+        assert cfg == self.RFE
+        assert list(cfg) == list(self.RFE)
+        assert list(cfg["feasibility_labels"]) == list(self.RFE["feasibility_labels"])
+        assert {k: type(v) for k, v in cfg.items()} == {k: type(v) for k, v in self.RFE.items()}
+
+    def test_every_registered_type_has_a_config_in_registry_order(self):
+        import submit as submit_mod
+
+        assert list(submit_mod.TYPE_CONFIGS) == submit_mod._TYPES.names()
+        assert list(submit_mod.TYPE_CONFIGS) == ["rfe", "initiative"]
+        for cfg in submit_mod.TYPE_CONFIGS.values():
+            assert list(cfg) == list(self.RFE)
+
+    def test_module_alias_is_the_rfe_feasibility_map(self):
+        import submit as submit_mod
+
+        assert submit_mod.FEASIBILITY_LABELS is submit_mod.TYPE_CONFIGS["rfe"]["feasibility_labels"]
+
+    def test_projected_maps_do_not_alias_descriptor_data(self):
+        """A caller editing a projected label map must not corrupt the registry."""
+        import submit as submit_mod
+
+        desc = submit_mod._TYPES.get("rfe")
+        feas = submit_mod.TYPE_CONFIGS["rfe"]["feasibility_labels"]
+        assert feas == desc.get("conventions.labels.feasibility")
+        assert feas is not desc.get("conventions.labels.feasibility")
+
+    def test_rfe_grandfathered_sentinels(self):
+        """'' means "snapshot_fetch's default prefix" and None means "spawn split_submit.py
+        without --type" — the rfe conventions the pre-registry table encoded, never the
+        descriptor's own snapshot.prefix."""
+        import submit as submit_mod
+
+        desc = submit_mod._TYPES.get("rfe")
+        assert desc.get("snapshot.prefix") == "issue-snapshot-"
+        assert submit_mod.TYPE_CONFIGS["rfe"]["snapshot_prefix"] == ""
+        assert submit_mod.TYPE_CONFIGS["rfe"]["split_type_arg"] is None
+
+    def test_type_choices_are_the_registry_choices(self):
+        """--help still offers exactly {rfe,initiative}; an unregistered type is refused."""
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--help"], capture_output=True, text=True, env=_clean_env()
+        )
+        assert result.returncode == 0, result.stderr
+        assert "--type {rfe,initiative}" in result.stdout
+
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--type", "epic", "--dry-run"],
+            capture_output=True,
+            text=True,
+            env=_clean_env(),
+        )
+        assert result.returncode == 2
+        assert "invalid choice: 'epic'" in result.stderr
+
+
+class TestApproveStateFromTheBinding:
+    """identity.jira.state_map.approved is optional in the schema: a registered type without it
+    still submits, and only --auto-approve is refused — as a usage error, before any scan or
+    Jira call. Both shipped types declare it (tests/test_type_registry_pins.py pins the value the
+    emulator workflow seeds)."""
+
+    def _run_memo(self, root, tmp_path, *flags):
+        return subprocess.run(
+            [sys.executable, SCRIPT, "--type", "memo", "--dry-run", *flags]
+            + ["--artifacts-dir", str(tmp_path / "artifacts")],
+            capture_output=True,
+            text=True,
+            env=_clean_env(RFE_CREATOR_EXTRA_TYPES=root, **FAKE_CREDS),
+        )
+
+    def test_a_type_without_the_approved_state_submits(self, drop_in_root, tmp_path):
+        root = drop_in_root.memo(drop=("identity.jira.state_map.approved",))
+        result = self._run_memo(root, tmp_path)
+        assert result.returncode == 1, result.stderr
+        assert "No Memo task files found." in result.stderr  # startup passed, the scan ran
+
+    def test_auto_approve_is_refused_for_a_type_without_the_approved_state(
+        self, drop_in_root, tmp_path
+    ):
+        root = drop_in_root.memo(drop=("identity.jira.state_map.approved",))
+        result = self._run_memo(root, tmp_path, "--auto-approve")
+        assert result.returncode == 2, result.stderr
+        assert (
+            "error: --auto-approve: type 'memo' declares no identity.jira.state_map.approved"
+        ) in result.stderr
+        assert "No Memo task files found" not in result.stderr
+        assert result.stdout == ""
+
+    def test_auto_approve_uses_the_type_s_own_state(self, drop_in_root, tmp_path):
+        root = drop_in_root.memo()
+        result = self._run_memo(root, tmp_path, "--auto-approve")
+        assert result.returncode == 1, result.stderr
+        assert "No Memo task files found." in result.stderr
+
+
+class TestReportCommandArgv:
+    """_generate_reports spawns generate_run_report.py and generate_review_pdf.py.
+
+    Both scripts default to rfe, so the rfe invocation carries no --type (grandfathered
+    argv, byte-identical to the pre-registry command) and every other type is named.
+    """
+
+    def _capture(self, monkeypatch, type_name, tmp_path):
+        import submit as submit_mod
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+        monkeypatch.setattr(submit_mod.subprocess, "run", fake_run)
+        args = SimpleNamespace(
+            type=type_name, artifacts_dir=str(tmp_path), report_timestamp="20260404-170041"
+        )
+        submit_mod._generate_reports(args)
+        return calls
+
+    def test_rfe_report_commands_carry_no_type_flag(self, monkeypatch, tmp_path):
+        yaml_cmd, html_cmd = self._capture(monkeypatch, "rfe", tmp_path)
+        assert yaml_cmd[1].endswith("generate_run_report.py")
+        assert yaml_cmd[2:] == [
+            "--start-time",
+            "20260404-170041",
+            "--artifacts-dir",
+            str(tmp_path),
+            "--report-stage",
+            "final",
+        ]
+        assert html_cmd[1].endswith("generate_review_pdf.py")
+        assert html_cmd[2:] == [
+            "--revised-only",
+            "--artifacts-dir",
+            str(tmp_path),
+            "--output",
+            os.path.join(str(tmp_path), "auto-fix-runs", "20260404-170041-report.html"),
+        ]
+
+    def test_other_types_are_named_explicitly(self, monkeypatch, tmp_path):
+        yaml_cmd, html_cmd = self._capture(monkeypatch, "initiative", tmp_path)
+        assert yaml_cmd[2:] == [
+            "--start-time",
+            "20260404-170041",
+            "--artifacts-dir",
+            str(tmp_path),
+            "--report-stage",
+            "final",
+            "--type",
+            "initiative",
+        ]
+        assert html_cmd[2:] == [
+            "--revised-only",
+            "--artifacts-dir",
+            str(tmp_path),
+            "--output",
+            os.path.join(
+                str(tmp_path), "auto-fix-runs", "initiative-run-20260404-170041-report.html"
+            ),
+            "--type",
+            "initiative",
+        ]

--- a/tests/test_type_registry_pins.py
+++ b/tests/test_type_registry_pins.py
@@ -19,7 +19,11 @@ Grandfathered projections (explicit — never "compare literally"):
   * rfe pipeline.poll_prefix / pipeline.state_prefix / snapshot.report_prefix are '' while the
     initiative values are 'initiative-' / 'initiative-' / 'initiative-run-' (design §3.2);
   * submit.TYPE_CONFIGS['rfe']['snapshot_prefix'] is '' — a sentinel for snapshot_fetch's default
-    'issue-snapshot-' (Q16); snapshot.prefix itself is the non-empty string;
+    (the rfe snapshot.prefix, bound at import since PR-2c; Q16); snapshot.prefix itself is the
+    non-empty string. Since PR-2d _type_config derives it as '' if rfe else snapshot.prefix, and
+    split_type_arg / the report commands' --type as "omitted for rfe, the type name otherwise"
+    (an argv convention with no descriptor field) — both pinned as residues so lifting either
+    grandfather is a visible change;
   * validate_batch_input.PARENT_KEY_PATTERN omits INIT- (Q14: known divergence until PR-3);
   * the four rfe rubric-path sites in skill bodies are STALE (design §10 PR-5) and are pinned as
     such so the PR-5 fix is a visible pin change;
@@ -162,6 +166,39 @@ DEFERRED = [
 # ── matrix rows whose registry now derives from the descriptor at import (pins deleted) ─────
 # (rows, registry, "<PR>: <projection>; <what, if anything, is still literal and pinned>")
 MIGRATED = [
+    (
+        (*range(1, 19), 22, 25, 26),
+        "submit.TYPE_CONFIGS / FEASIBILITY_LABELS / --type choices / scan-rename dispatch / "
+        "approve target",
+        "PR-2d: _type_config(desc) over names() — identity.jira.{project,issue_type}, "
+        "conventions.type_label, id_field / local_prefix / write_prefix, dirs(bare), "
+        "f'{type}-task' / f'{type}-review', conventions.{label_prefix,labels.rubric_pass,"
+        "labels.feasibility,labels.alignment,removed_context_preamble,comment_prefix}, "
+        "index.enabled (same keys, key order and value types); FEASIBILITY_LABELS stays the rfe "
+        "entry; --type is registry.choices(); the id_field dispatchers are "
+        "artifact_utils.scan_tasks / rename_to_tracker_key(desc); the approve target, the "
+        "already-there short-circuit, the status lines and the comment read "
+        "identity.jira.state_map.approved once; grandfathered and still pinned as residues: the "
+        "rfe snapshot_prefix '' sentinel (9) and the split_type_arg / report --type argv "
+        "convention (10, 26); still pinned: the labels composed from label_prefix (19, 20), the "
+        "policy predicate (21), the dry-run sentinel (23), the report companion path (24) and "
+        "the R7 literals (12, 15, 16 in TestPublishedContracts)",
+    ),
+    (
+        (*range(27, 37), 42, 43, 46),
+        "split_submit.SPLIT_CONFIG / _TRACKER (link type, close-superseded) / --type choices",
+        "PR-2d: _split_config(desc) over names() — identity.jira.{project,issue_type}, "
+        "conventions.{comment_prefix,label_prefix}, display.{entity,entity_plural}, id_field, "
+        "dirs(bare), f'{type}-review', index.enabled, conventions.labels.alignment; scan_fn / "
+        "rename_fn / parse_child_fn = functools.partial(artifact_utils.<generic>, desc=desc) and "
+        "find_review_fn = artifact_utils.find_review_file (detect()-routed; pinned to land in "
+        "dirs.reviews for both id grammars, 34 residue); the six 'Work item split' sites and the "
+        "Closed / Obsolete closure read identity.jira.split_link_type and "
+        "identity.jira.state_map.close_superseded through the private _TRACKER projection "
+        "(source form pinned); --type is registry.choices(); still pinned: the feasibility "
+        "composition (37), the marker template (38), the composed labels and inheritance filter "
+        "(39-41), the comment grammar (44) and the dry-run sentinel (45)",
+    ),
     (
         (47, 48, 49, 50, 53),
         "snapshot_fetch.SNAPSHOT_CONFIG / default prefix= kwargs / --type choices",
@@ -418,7 +455,7 @@ def fm(fields, body="Body\n"):
 
 
 class TestRegistryShape:
-    # rows: 25, 46, 124, 142, 159, 160, 161 + the source form of 162 (47-50, 53-56, 60, 62, 65,
+    # rows: 124, 142, 159, 160, 161 + the source form of 162 (25, 46, 47-50, 53-56, 60, 62, 65,
     # 66, 70, 87, 102, 106, 147, 148, 153-156, 162 MIGRATED)
 
     def test_shipped_types_in_argparse_order(self):
@@ -429,8 +466,6 @@ class TestRegistryShape:
         [
             # The type-keyed dicts still spelled out by hand; a dict derived from the registry
             # (comprehension over names()) has this property by construction and is not listed.
-            ("submit.TYPE_CONFIGS", submit.TYPE_CONFIGS),
-            ("split_submit.SPLIT_CONFIG", split_submit.SPLIT_CONFIG),
             ("pipeline_state.PIPELINE_TYPES", pipeline_state.PIPELINE_TYPES),
             ("compare_review_outputs._TYPE_CONFIG", compare_review_outputs._TYPE_CONFIG),
             ("check_autofix_complete._TYPE_CONFIG", check_autofix_complete._TYPE_CONFIG),
@@ -451,8 +486,6 @@ class TestRegistryShape:
     @pytest.mark.parametrize(
         "rel, flag",
         [
-            ("scripts/submit.py", "--type"),  # :365-370
-            ("scripts/split_submit.py", "--type"),  # :853-858
             ("scripts/pipeline_state.py", "--type"),  # :848 cmd_init
             ("scripts/compare_review_outputs.py", "--type"),  # :145
             ("scripts/cleanup_partial_split.py", "--type"),  # :27
@@ -460,7 +493,7 @@ class TestRegistryShape:
         ],
     )
     def test_argparse_type_choices_are_registry_choices(self, rel, flag):
-        # rows: 25, 46, 124, 159, 160, 161 — the literal lists still carried (53, 60 MIGRATED)
+        # rows: 124, 159, 160, 161 — the literal lists still carried (25, 46, 53, 60 MIGRATED)
         # (check_revised.py / check_right_sized.py hand-parse --type without choices)
         got = choices(rel, flag)
         assert got, f"{rel}: no add_argument({flag!r}, choices=...) found"
@@ -485,11 +518,13 @@ class TestRegistryShape:
             ("scripts/snapshot_fetch.py", "--type"),
             ("scripts/bootstrap_snapshot.py", "--type"),
             ("scripts/fetch_issue.py", "--type"),  # new in PR-2c (row 65): no literal list ever
+            ("scripts/submit.py", "--type"),  # PR-2d (row 25; :365-370 at c1df503)
+            ("scripts/split_submit.py", "--type"),  # PR-2d (row 46; :853-858 at c1df503)
         ],
     )
     def test_migrated_argparse_choices_read_the_registry(self, rel, flag):
-        # MIGRATED rows 53, 60, 62, 65, 66, 70, 87, 102, 106, 147, 148, 153-156 — the literal
-        # list is gone; the source form is pinned (as
+        # MIGRATED rows 25, 46, 53, 60, 62, 65, 66, 70, 87, 102, 106, 147, 148, 153-156 — the
+        # literal list is gone; the source form is pinned (as
         # test_frontmatter_schema_choices_are_the_schema_keys pins "list(SCHEMAS.keys())") so a
         # re-introduced literal list is a visible change.
         assert choices(rel, flag) == ["_TYPES.choices()"], rel
@@ -508,40 +543,45 @@ class TestRegistryShape:
 
 
 class TestSubmitTypeConfigs:
-    # rows: 1-26
-
-    def test_binding_and_identity(self, ctx):
-        c = submit.TYPE_CONFIGS[ctx.t]
-        pin("identity.jira.project", "submit.py:63,:94", ctx.jira["project"], c["project"])
-        pin("identity.jira.issue_type", "submit.py:64,:95", ctx.jira["issue_type"], c["issue_type"])
-        pin("conventions.type_label", "submit.py:65,:96", ctx.conv["type_label"], c["type_label"])
-        pin("identity.id_field", "submit.py:66,:97", ctx.id_field, c["id_field"])
-        pin("identity.local_prefix", "submit.py:67,:98", ctx.lp, c["local_prefix"])
-        pin("identity.jira.key_prefixes[0]", "submit.py:68,:99", ctx.wp, c["jira_prefix"])
-
-    def test_dirs_bare_form_and_schema_names(self, ctx):
-        c = submit.TYPE_CONFIGS[ctx.t]
-        pin("dirs.tasks (bare)", "submit.py:69,:100", ctx.bare["tasks"], c["tasks_dir"])
-        pin("dirs.reviews (bare)", "submit.py:70,:101", ctx.bare["reviews"], c["reviews_dir"])
-        pin("dirs.originals (bare)", "submit.py:71,:102", ctx.bare["originals"], c["originals_dir"])
-        pin("f'{type}-task'", "submit.py:72,:103", ctx.task_schema, c["task_schema"])
-        pin("f'{type}-review'", "submit.py:73,:104", ctx.review_schema, c["review_schema"])
+    # rows: 9, 10 (MIGRATED value, grandfathered shape), 19, 20, 21, 23, 24 residues, 26 (argv
+    # residue) — 1-18, 22, 25, 26 MIGRATED: TYPE_CONFIGS is a descriptor projection over names()
+    # since PR-2d (submit.py:61-128 at c1df503); what stays pinned is the two grandfathers, the
+    # labels still composed from label_prefix, the policy predicate, the dry-run sentinel, the
+    # report companion path and the source form of the migrated sites
 
     def test_snapshot_prefix_is_a_grandfathered_sentinel_for_rfe(self, ctx):
-        # Q16: '' means "use snapshot_fetch's default" (guards submit.py:672-673,:1170-1171);
-        # never compare snapshot.prefix literally to this key.
+        # rows: 9 (MIGRATED value, grandfathered shape) — submit.py:74,:105 carried '' / the
+        # initiative prefix; since PR-2d _type_config derives '' if rfe else snapshot.prefix. Q16:
+        # '' means "use snapshot_fetch's default" — the rfe snapshot.prefix, bound at import since
+        # PR-2c — and the guards (:672-673,:1170-1171) forward only a truthy value, so the
+        # EFFECTIVE prefix equals snapshot.prefix for every type. Never compare snapshot.prefix
+        # literally to this key; the shape is pinned so lifting the sentinel is a visible change.
         c = submit.TYPE_CONFIGS[ctx.t]
-        expected = "" if ctx.t == "rfe" else ctx.snap["prefix"]
         pin(
             "snapshot.prefix ('' sentinel for rfe)",
             "submit.py:74,:105",
-            expected,
+            "" if ctx.t == "rfe" else ctx.snap["prefix"],
             c["snapshot_prefix"],
         )
         assert ctx.snap["prefix"], "snapshot.prefix itself is never empty (design §8.2 L531)"
+        default = inspect.signature(snapshot_fetch.update_snapshot_hashes).parameters["prefix"]
+        pin(
+            "snapshot.prefix (effective: forwarded, or the sentinel's default)",
+            "submit.py:672-673,:1170-1171",
+            ctx.snap["prefix"],
+            c["snapshot_prefix"] or default.default,
+        )
+        source = read("scripts/submit.py")
+        assert '"" if desc.name == "rfe" else desc.get("snapshot.prefix")' in source
+        assert source.count('if cfg["snapshot_prefix"]:') == 2
 
-    def test_split_type_arg_is_the_argv_convention(self, ctx):
-        # UNMAPPED argv convention (consumed submit.py:497-498): pinned as a literal.
+    def test_split_type_arg_and_report_type_flag_are_the_argv_convention(self, ctx):
+        # rows: 10 (MIGRATED value, grandfathered shape), 26 residue — the argv convention of the
+        # subprocesses submit.py spawns: no --type for rfe (its argv is byte-identical), the type
+        # name otherwise. submit.py:75,:106 carried None / "initiative" (consumed :497-498) and
+        # :192-193,:210-211 appended '--type initiative' iff initiative; since PR-2d _type_config
+        # derives None if rfe else the type name and _generate_reports tests args.type != "rfe".
+        # UNMAPPED (no descriptor field) — pinned by value and source form.
         c = submit.TYPE_CONFIGS[ctx.t]
         pin(
             "(argv) None if rfe else type",
@@ -549,76 +589,13 @@ class TestSubmitTypeConfigs:
             None if ctx.t == "rfe" else ctx.t,
             c["split_type_arg"],
         )
-
-    def test_labels(self, ctx):
-        c = submit.TYPE_CONFIGS[ctx.t]
-        pin(
-            "conventions.label_prefix",
-            "submit.py:76,:107",
-            ctx.conv["label_prefix"],
-            c["label_prefix"],
-        )
-        pin(
-            "conventions.labels.rubric_pass",
-            "submit.py:77,:108",
-            ctx.labels["rubric_pass"],
-            c["rubric_pass_label"],
-        )
-        pin(
-            "conventions.labels.feasibility",
-            "submit.py:78-82,:109-113",
-            ctx.labels["feasibility"],
-            c["feasibility_labels"],
-        )
-        pin(
-            "conventions.labels.feasibility (order)",
-            "submit.py:78-82,:109-113",
-            list(ctx.labels["feasibility"]),
-            list(c["feasibility_labels"]),
-        )
-        pin(
-            "conventions.labels.alignment",
-            "submit.py:83,:114-118",
-            ctx.labels.get("alignment"),
-            c["alignment_labels"],
-        )
-
-    def test_published_contract_strings(self, ctx):
-        c = submit.TYPE_CONFIGS[ctx.t]
-        pin(
-            "conventions.removed_context_preamble",
-            "submit.py:84-89,:119-124",
-            ctx.conv["removed_context_preamble"],
-            c["removed_context_preamble"],
-        )
-        pin(
-            "conventions.comment_prefix",
-            "submit.py:90,:125",
-            ctx.conv["comment_prefix"],
-            c["comment_prefix"],
-        )
-
-    def test_has_index(self, ctx):
-        pin(
-            "index.enabled",
-            "submit.py:91,:126",
-            ctx.d["index"]["enabled"],
-            submit.TYPE_CONFIGS[ctx.t]["has_index"],
-        )
-
-    def test_module_alias_is_the_rfe_feasibility_map(self):
-        # rows: 18 — rfe-only backward-compat alias (feasibility_label_changes default :142-143)
-        rfe = _ctx("rfe")
-        pin(
-            "labels.feasibility (rfe)",
-            "submit.py:131",
-            rfe.labels["feasibility"],
-            submit.FEASIBILITY_LABELS,
-        )
-        add, stale = submit.feasibility_label_changes(
-            "feasible", is_reject=False, original_labels=[]
-        )
-        assert (add, stale) == (rfe.labels["feasibility"]["feasible"], [])
+        source = read("scripts/submit.py")
+        assert 'None if desc.name == "rfe" else desc.name' in source
+        assert 'cmd.extend(["--type", cfg["split_type_arg"]])' in source  # :497-498
+        reports = inspect.getsource(submit._generate_reports)
+        assert reports.count('if args.type != "rfe":') == 2
+        assert reports.count('extend(["--type", args.type])') == 2
+        assert 'extend(["--type", "initiative"])' not in source
 
     def test_feasibility_label_changes_uses_the_type_map(self, ctx):
         feas = ctx.labels["feasibility"]
@@ -665,17 +642,34 @@ class TestSubmitTypeConfigs:
             assert f'cfg["{cfg_key}"]' in body, f"_build_labels no longer reads cfg[{cfg_key!r}]"
 
     def test_auto_approve_policy_and_transition_target(self, ctx):
-        # rows: 21, 22 — submit.py:805-814 (type-invariant policy), :970-991 (transition + comment)
+        # rows: 21 (residue), 22 (MIGRATED) — submit.py:805-814 is the type-invariant policy
+        # (rubric pass and feasibility == 'feasible'; design §10 'approve policy implemented once');
+        # :987/:981 carried the literal "Approved" and since PR-2d main() reads
+        # identity.jira.state_map.approved once (approved_status) for the transition target, the
+        # already-there short-circuit, the status lines and the approve comment. The source form
+        # is pinned so a re-introduced literal is a visible change, and the emulator workflows
+        # (tests/conftest.py:104-121, the global Approve transition) must keep offering the
+        # descriptor's state or the integration suites would approve into a different status
+        # than production.
         source = read("scripts/submit.py")
         assert 'review_data.get("feasibility") == "feasible"' in source
         assert "feasible" == list(ctx.labels["feasibility"])[0]
         approved = ctx.jira["state_map"]["approved"]
-        assert f'transition_issue(server, user, token, jira_key, "{approved}")' in source, (
-            "submit.py:987"
-        )
-        assert f'entry.get("jira_status") == "{approved}"' in source, "submit.py:981"
+        assert 'approved_status = desc.get("identity.jira.state_map.approved", None)' in source
+        # Optional in the schema: only --auto-approve requires it, refused before any Jira call.
+        assert "if args.auto_approve and not approved_status:" in source
+        assert "transition_issue(server, user, token, jira_key, approved_status)" in source
+        assert 'entry.get("jira_status") == approved_status' in source
         assert "f\"*{cfg['comment_prefix']}* This {type_label} has been automatically \"" in source
-        assert f'"transitioned to {approved} status based on passing rubric scoring and "' in source
+        assert (
+            'f"transitioned to {approved_status} status based on passing rubric scoring and "'
+            in source
+        )
+        assert 'transition_issue(server, user, token, jira_key, "Approved")' not in source
+        assert f'_global_approve = (None, "Approve", "{approved}")' in read("tests/conftest.py"), (
+            "identity.jira.state_map.approved: the emulator's global Approve transition "
+            "(tests/conftest.py:105) no longer targets the descriptor's state"
+        )
 
     def test_dry_run_sentinel_derivation(self, ctx):
         # rows: 23, 45 — submit.py:1079 uses jira_prefix, split_submit.py:689/:1036 use project;
@@ -695,25 +689,6 @@ class TestSubmitTypeConfigs:
         expected = os.path.join("a", "auto-fix-runs", f"{ctx.snap['report_prefix']}RUN-report.html")
         pin("snapshot.report_prefix", "submit.py:318-326", expected, got)
 
-    def test_dispatch_on_id_field(self, ctx, monkeypatch):
-        # rows: 26 — submit.py:154-164 forked-pair dispatcher keyed on id_field (collapses in PR-2)
-        calls = []
-        monkeypatch.setattr(submit, "scan_task_files", lambda a: calls.append("rfe") or [])
-        monkeypatch.setattr(
-            submit, "scan_initiative_task_files", lambda a: calls.append("initiative") or []
-        )
-        monkeypatch.setattr(submit, "rename_to_jira_key", lambda a, i, k: calls.append("rfe"))
-        monkeypatch.setattr(
-            submit, "rename_initiative_to_jira_key", lambda a, i, k: calls.append("initiative")
-        )
-        cfg = submit.TYPE_CONFIGS[ctx.t]
-        submit._scan_tasks("x", cfg)
-        submit._rename_to_jira("x", "A-1", "B-1", cfg)
-        expected = "initiative" if ctx.id_field == "initiative_id" else "rfe"
-        pin("identity.id_field discriminator", "submit.py:154-164", [expected, expected], calls)
-        # :192-193/:210-211 append '--type initiative' to the report commands iff initiative
-        assert read("scripts/submit.py").count('extend(["--type", "initiative"])') == 2
-
     def test_no_task_files_message_is_byte_stable_for_rfe(self):
         # design §10 tail: "No RFE task files found" stays byte-stable (type_label projection)
         assert 'f"Error: No {type_label} task files found."' in read("scripts/submit.py")
@@ -726,84 +701,36 @@ class TestSubmitTypeConfigs:
 
 
 class TestSplitSubmitConfig:
-    # rows: 27-46
+    # rows: 34 (residue), 37, 38, 39, 40, 41, 44, 45 — 27-36, 42, 43, 46 MIGRATED: SPLIT_CONFIG is
+    # a descriptor projection over names() since PR-2d (split_submit.py:109-151 at c1df503) and
+    # the link type / close-superseded state come from identity.jira through _TRACKER; what stays
+    # pinned is the composition (feasibility set, marker template, labels, inheritance filter),
+    # the comment grammar, the dry-run sentinel and the source form of the migrated sites
 
-    def test_binding_conventions_display(self, ctx):
+    def test_generics_bound_to_the_descriptor_and_find_review_in_dirs_reviews(self, ctx, tmp_path):
+        # rows: 34 (MIGRATED value, residue) — split_submit.py:121-124,:139-144 selected the
+        # per-type pair by id_field; since PR-2d scan_fn / rename_fn / parse_child_fn are
+        # functools.partial(artifact_utils.<generic>, desc=desc) and find_review_fn is
+        # artifact_utils.find_review_file for every type, which routes by registry.detect(child_id)
+        # (the deleted _direct_review_path built the path from the config's reviews_dir). What
+        # stays pinned is the equality that makes that routing a no-op: for both id grammars of
+        # the type it renders the path under THIS type's dirs.reviews — the PR-3 binding overlay
+        # must keep it true (or bind the lookup to the descriptor).
         s = split_submit.SPLIT_CONFIG[ctx.t]
-        pin("identity.jira.project", "split_submit.py:111,:129", ctx.jira["project"], s["project"])
-        pin(
-            "identity.jira.issue_type",
-            "split_submit.py:112,:130",
-            ctx.jira["issue_type"],
-            s["issue_type"],
-        )
-        pin(
-            "conventions.comment_prefix",
-            "split_submit.py:113,:131",
-            ctx.conv["comment_prefix"],
-            s["comment_marker"],
-        )
-        pin(
-            "conventions.label_prefix",
-            "split_submit.py:114,:132",
-            ctx.conv["label_prefix"],
-            s["label_prefix"],
-        )
-        pin(
-            "display.entity",
-            "split_submit.py:115,:133",
-            ctx.d["display"]["entity"],
-            s["entity_name"],
-        )
-        pin(
-            "display.entity_plural",
-            "split_submit.py:116,:134",
-            ctx.d["display"]["entity_plural"],
-            s["entity_name_plural"],
-        )
-        pin("identity.id_field", "split_submit.py:117,:135", ctx.id_field, s["id_field"])
-        pin(
-            "dirs.reviews (bare)", "split_submit.py:118,:136", ctx.bare["reviews"], s["reviews_dir"]
-        )
-        pin("f'{type}-review'", "split_submit.py:119,:137", ctx.review_schema, s["review_schema"])
-        pin(
-            "dirs.originals (bare)",
-            "split_submit.py:120,:138",
-            ctx.bare["originals"],
-            s["originals_dir"],
-        )
-        pin(
-            "index.enabled",
-            "split_submit.py:125,:145",
-            ctx.d["index"]["enabled"],
-            s["do_rebuild_index"],
-        )
-        pin(
-            "conventions.labels.alignment",
-            "split_submit.py:126,:146-150",
-            ctx.labels.get("alignment"),
-            s["alignment_labels"],
-        )
-
-    def test_forked_callables_selected_by_id_field(self, ctx, tmp_path):
-        # rows: 34 — split_submit.py:121-124,:139-144; find_review_fn pinned by rendered path
-        s = split_submit.SPLIT_CONFIG[ctx.t]
-        if ctx.id_field == "rfe_id":
-            expected = (
-                artifact_utils.scan_task_files,
-                artifact_utils.rename_to_jira_key,
-                artifact_utils.parse_child_artifact,
-            )
-        else:
-            expected = (
-                artifact_utils.scan_initiative_task_files,
-                artifact_utils.rename_initiative_to_jira_key,
-                artifact_utils.parse_child_initiative,
-            )
-        assert (s["scan_fn"], s["rename_fn"], s["parse_child_fn"]) == expected
+        for key, generic in (
+            ("scan_fn", artifact_utils.scan_tasks),
+            ("rename_fn", artifact_utils.rename_to_tracker_key),
+            ("parse_child_fn", artifact_utils.parse_child),
+        ):
+            assert s[key].func is generic, key
+            assert s[key].keywords["desc"].name == ctx.t, key
+        assert s["find_review_fn"] is artifact_utils.find_review_file
         for ident in ctx.sample_ids:
             review = write(
                 tmp_path / ctx.bare["reviews"] / f"{ident}-review.md", fm({ctx.id_field: ident})
+            )
+            assert str(review) == os.path.join(
+                str(tmp_path), s["reviews_dir"], f"{ident}-review.md"
             )
             pin(
                 "dirs.reviews",
@@ -813,7 +740,8 @@ class TestSplitSubmitConfig:
             )
 
     def test_feasibility_labels_second_definition(self, ctx):
-        # rows: 13, 37 — split_submit.py:161-166 composes what submit.py:78-82 spells out
+        # rows: 37 (13 MIGRATED) — split_submit.py:161-166 composes what submit.py:78-82 spelled
+        # out and TYPE_CONFIGS now projects from conventions.labels.feasibility
         pin(
             "conventions.labels.feasibility",
             "split_submit.py:161-166",
@@ -891,31 +819,34 @@ class TestSplitSubmitConfig:
                 ctx.labels[key],
             )
 
-    def test_split_link_type_literal_sites(self, ctx):
-        # rows: 42 — six literal sites :210,:410,:497,:610,:685,:716; emulator seed conftest.py:96
+    def test_split_link_type_and_close_superseded_read_identity_jira(self, ctx):
+        # rows: 42, 43 (MIGRATED) — split_submit.py:210,:410,:497,:610,:685,:716 carried the
+        # literal 'Work item split' and :816-839 Closed / Obsolete; since PR-2d both come from
+        # identity.jira.split_link_type and identity.jira.state_map.close_superseded through the
+        # private _TRACKER projection (keyed by the (project, issue_type) pair every SPLIT_CONFIG
+        # entry carries; read with a None default because the schema leaves both optional and a
+        # registered type that never splits must not break the import). The source form is
+        # pinned so a re-introduced literal is a visible change, the case-insensitive target match
+        # is kept, and the emulator seed (tests/conftest.py:96) must keep offering the
+        # descriptor's link type or the integration suites would exercise another transaction.
         link = ctx.jira["split_link_type"]
-        assert link == "Work item split"
-        pin(
-            "identity.jira.split_link_type (6 sites)",
-            "split_submit.py:210-716",
-            6,
-            read("scripts/split_submit.py").count(link),
-        )
-        assert f'"name": "{link}"' in read("tests/conftest.py")
-
-    def test_close_superseded_state_map(self, ctx):
-        # rows: 43 — split_submit.py:816-839 (:820 target matched case-insensitively, :837
-        # resolution)
         close = ctx.jira["state_map"]["close_superseded"]
+        assert link and close["transition"] and close["resolution"], "both shipped types split"
         source = read("scripts/split_submit.py")
-        assert f'.lower() == "{close["transition"].lower()}"' in source, "split_submit.py:820"
-        assert f'fields={{"resolution": {{"name": "{close["resolution"]}"}}}}' in source, (
-            "split_submit.py:837"
-        )
+        for literal in (link, close["transition"], close["resolution"]):
+            assert f'"{literal}"' not in source, literal
+        assert '"split_link_type": desc.get("identity.jira.split_link_type", None),' in source
         assert (
-            f"Would transition {{parent_key}} to {close['transition']} "
-            f"(resolution: {close['resolution']})" in source
+            '"close_superseded": desc.get("identity.jira.state_map.close_superseded", None),'
+            in source
         )
+        # _inspect_child, discover_state, phase2_create_link / phase3_close
+        assert source.count('_tracker(config)["split_link_type"]') == 3
+        assert source.count('_tracker(config)["close_superseded"]') == 1
+        assert 'if t["to"].get("name", "").lower() == target_status.lower():' in source
+        assert 'fields={"resolution": {"name": resolution}},' in source
+        assert "(resolution: {resolution})" in source
+        assert f'"name": "{link}"' in read("tests/conftest.py")
 
     def test_durable_store_comment_grammar_round_trips(self, ctx):
         # rows: 44 — split_submit.py:353-389 (reader regexes), :550,:614-617,:721-731,:769-776

--- a/types/README.md
+++ b/types/README.md
@@ -10,7 +10,7 @@ reference). Design: `design-proposals/work-item-types-unified.md` §3.2 (contrac
 and are invoked by their cwd-relative path (`python3 scripts/type_registry.py …`, design §3.5.1).
 The provider guide is `docs/type-provider-guide.md`.
 
-**Status (PR-2c): 24 scripts read the registry** (table below). An adopted script does
+**Status (PR-2d): 26 scripts read the registry** (table below). An adopted script does
 `import type_registry` and `_TYPES = type_registry.load()` once at import and builds its per-type
 table over the registry (`_TYPES.names()` or iteration — both in `names()` order), so a drop-in
 type appears in it without a code change. Adopted scripts use DESCRIPTOR values only (`Descriptor.get`, `dirs()`, `labels`,
@@ -36,7 +36,29 @@ companion gated on `companions.comments`). Those two tables are built at import 
 registered type — and `submit.py` imports `snapshot_fetch` — so a drop-in must carry
 `conventions.labels.{ignore,split_quarantine}` and `snapshot.{prefix,report_prefix}` (gate 1
 already requires the two `snapshot` keys but not the two labels; copying `types/rfe/` keeps them
-all) or the import fails with a `KeyError` naming the type and the field. Every value a pending script still carries is pinned by `tests/test_type_registry_pins.py`
+all) or the import fails with a `KeyError` naming the type and the field. Since PR-2d the Jira write
+path is a projection too: `submit.TYPE_CONFIGS` and `split_submit.SPLIT_CONFIG` build over `names()`
+from `identity.jira.{project,issue_type,key_prefixes}`, `identity.{id_field,local_prefix}`,
+`dirs.{tasks,reviews,originals}`, `display.{entity,entity_plural}`,
+`conventions.{type_label,label_prefix,comment_prefix,removed_context_preamble}`,
+`conventions.labels.{rubric_pass,feasibility}` (`alignment` optional), `index.enabled` and
+`snapshot.prefix` (all schema-required except the two label keys — a drop-in missing either fails
+the import of `submit.py` with the same `KeyError`); the task scan / rename go through the
+`artifact_utils` generics keyed on the descriptor, `--auto-approve` transitions to
+`identity.jira.state_map.approved` (optional in the schema, read with a `None` default at startup:
+a type without it submits, and only `--auto-approve` is refused — a usage error naming the type
+and the field, before any scan or Jira call), and a split links with
+`identity.jira.split_link_type` and closes the parent with
+`identity.jira.state_map.close_superseded` (both optional too, read with a `None` default at
+import: a type that never splits may omit them, and `split_submit.py` refuses to split a parent
+of such a type before any scan or Jira call — exit 5, the systemic code, so `submit.py`'s split
+loop aborts instead of flagging every parent; it recovers the two facts by the
+`(project, issue_type)` pair, so two registered types sharing a pair fail its import with a
+`RegistryError` naming both). Two rfe
+grandfathers stay pinned as residues — submit's `''` `snapshot_prefix` sentinel and the argv
+convention that passes no `--type` for rfe to `split_submit.py` and the report scripts — and the
+`auto-created` / `auto-revised` / `needs-attention` / `split-quarantine` labels are still composed
+from `conventions.label_prefix`. Every value a pending script still carries is pinned by `tests/test_type_registry_pins.py`
 to its descriptor projection — source of truth *by test* until it adopts (§10); that file's
 `MIGRATED` list names the matrix rows already covered *by import*, and each adoption deletes its
 pin.
@@ -71,6 +93,8 @@ itself is fine — `resolve()` follows the link).
 | `reassess_save.py` | `_TYPE_CONFIG`, `--type` choices | PR-2a |
 | `snapshot_fetch.py` | `SNAPSHOT_CONFIG` (`conventions.labels.{ignore,split_quarantine}`, `snapshot.prefix`), default `prefix=` of `find_previous_snapshot` / `load_snapshot_from_dir` / `update_snapshot_hashes` (rfe `snapshot.prefix`, bound at import), `--type` choices | PR-2c; the hard-filter JQL wrapper and the `f"{prefix}{ts}.yaml"` file name are composition, still pinned by source form |
 | `split_collect.py` | `_TYPE_CONFIG`, `_set_revise` defaults, `--type` choices | PR-2a |
+| `split_submit.py` | `SPLIT_CONFIG` (descriptor projection over `names()`: `identity.jira.{project,issue_type}`, `conventions.{comment_prefix,label_prefix}`, `display.{entity,entity_plural}`, `id_field`, `dirs`, `index.enabled`, alignment labels; `scan_fn` / `rename_fn` / `parse_child_fn` bound to the `artifact_utils` generics, `find_review_fn` = `find_review_file`), the split link type and the close-superseded transition / resolution from `identity.jira.{split_link_type,state_map.close_superseded}`, `--type` choices | PR-2d; the feasibility set, the split-child marker and every phase label are still composed from `conventions.label_prefix`; the durable-store comment grammar and the `<PROJECT>-DRY` sentinel are composition, pinned by source form |
+| `submit.py` | `TYPE_CONFIGS` (descriptor projection over `names()`), `--type` choices, task scan / rename via `artifact_utils.scan_tasks` / `rename_to_tracker_key(desc)`, approve target from `identity.jira.state_map.approved` | PR-2d; grandfathered: the rfe `snapshot_prefix` `''` sentinel and the `split_type_arg` / report `--type` argv convention (no `--type` for rfe); the `auto-created` / `auto-revised` / `needs-attention` / `split-quarantine` labels are still composed from `conventions.label_prefix` |
 | `validate_batch_input.py` | `ALLOWED_PRIORITIES`, known fields, `--type` choices | PR-2a; `PARENT_KEY_PATTERN` literal until PR-3 (Q14) |
 | `verify_phase.py` | phase tables, `_TYPE_CONFIG`, error-stub score tail, `--type` choices | PR-2a |
 | `check_autofix_complete.py` | `_TYPE_CONFIG` | pending |
@@ -79,8 +103,6 @@ itself is fine — `resolve()` follows the link).
 | `compare_review_outputs.py` | `_TYPE_CONFIG` | pending |
 | `jira_utils.py` | `strip_metadata` prefix regex | pending |
 | `pipeline_state.py` | `PIPELINE_TYPES` (prompt/skill entries move in PR-5) | pending |
-| `split_submit.py` | `SPLIT_CONFIG` | pending (last, with `submit.py`) |
-| `submit.py` | `TYPE_CONFIGS` | pending (last; emulator suites in CI) |
 
 ## Adding a type
 

--- a/types/initiative/type.yaml
+++ b/types/initiative/type.yaml
@@ -1,6 +1,6 @@
 # types/initiative/type.yaml — the initiative work-item type descriptor.
 # Contract: types/_schema/type.schema.json; design-proposals/work-item-types-unified.md §3.2 and the worked
-# example §8.2. Status (PR-2c): 24 scripts read this descriptor at import (types/README.md "Adoption
+# example §8.2. Status (PR-2d): 26 scripts read this descriptor at import (types/README.md "Adoption
 # status"); the values a pending script still carries are pinned equal to it by test, so the descriptor
 # is source of truth BY IMPORT for adopted scripts and BY TEST for the rest (design §10). Every value is
 # the live literal on main (c1df503) with the consuming file:line AT THAT COMMIT in a trailing comment

--- a/types/rfe/type.yaml
+++ b/types/rfe/type.yaml
@@ -1,6 +1,6 @@
 # types/rfe/type.yaml — the rfe work-item type descriptor.
 # Contract: types/_schema/type.schema.json; design-proposals/work-item-types-unified.md §3.2 (§8.2 is the
-# initiative twin). Status (PR-2c): 24 scripts read this descriptor at import (types/README.md "Adoption
+# initiative twin). Status (PR-2d): 26 scripts read this descriptor at import (types/README.md "Adoption
 # status"); the values a pending script still carries are pinned equal to it by test, so the descriptor
 # is source of truth BY IMPORT for adopted scripts and BY TEST for the rest (design §10). Every value is
 # the live literal on main (c1df503) with the consuming file:line AT THAT COMMIT in a trailing comment


### PR DESCRIPTION
## Summary

PR-2d of the work-item-types design (§10 item 2: "submit.py/split_submit.py last, gated on the emulator integration suites running in CI"), **stacked on #178** (on #177, on #176). The two production writers derive their type configs from the registry. **Behavior is byte-identical**: same dry-run plans, run reports, labels, transitions, link types and comments. Four commits.

1. **`submit.TYPE_CONFIGS`** projected per type from the descriptor, same twenty-one keys and order. Grandfathers stay explicit: rfe's empty snapshot prefix and the `split_type_arg` argv convention. The approve target reads `identity.jira.state_map.approved` (value `Approved` for both types); `--auto-approve` refuses a type that declares none. Task scanning and renaming use the artifact_utils generics keyed on the descriptor.
2. **`split_submit.SPLIT_CONFIG`** likewise; the callables close over the descriptor. The split link type and the close-superseded status/resolution come from the binding, keyed by the descriptor's `(project, issue_type)` pair, with loud failures for a colliding pair or missing split facts instead of a mid-phase KeyError.
3. **CI** now runs the emulator integration suites (140 tests, about 90 seconds) after the unit selection in the lint workflow, with a new `make test-integration` target for the same selection locally; this is the gate the design named for this step.
4. **Pins and baseline**: tautological pins retired, residues kept explicit, prefix baseline 14 → 9 occurrences (9 → 8 files; submit and split_submit at zero).

## Equivalence evidence

- Golden dry runs against the pristine PR-2c base on real artifact trees for both types, with and without `--generate-report` at fixed timestamps, plus `split_submit --dry-run` on parent-with-children fixtures, plus `--help` for both: identical stdout, exit codes and trees (28 scenarios by the builders, reproduced by a reviewer, spot-checked by me).
- `RFE_CREATOR_BINDING_RFE_PROJECT=KONFLUX` in the environment changes nothing: overrides are honoured only from PR-3's resolve step.
- Unit suite 1737 passed; **emulator integration suites 140 passed** (submit, initiative submit, split submit); ruff clean; `validate_types` OK.

## Not in this PR, by design

The approve policy applied to split children, the per-type bootstrap probe, and any change to which items are selected, approved, labelled or linked. After this PR the remaining literal type facts live in `pipeline_state.py` (PR-5 with the file moves), `jira_utils.strip_metadata` (a deliberate regex change), `check_autofix_complete`, `cleanup_partial_split`, `check_content_preservation` and `compare_review_outputs` (small, cosmetic strings).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a separate command for running integration tests.
  - Expanded submit and split workflows to support registered work-item types and their configured tracker behavior.
  - Added validation for missing or conflicting type configuration before processing begins.

- **Bug Fixes**
  - Auto-approval now uses each work-item type’s configured approval state.

- **Documentation**
  - Updated type-provider documentation to reflect expanded registry support and tracker submission behavior.

- **Tests**
  - Integration tests now run automatically in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->